### PR TITLE
feat(ci): support selecting which suite to run

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {
+    choice(name: 'runTestsSuite', choices: ['all', 'helm', 'metricbeat'], description: 'Choose which test suite to run (default: all)')
     choice(name: 'LOG_LEVEL', choices: ['INFO', 'DEBUG'], description: 'Log level to be used')
     choice(name: 'QUERY_MAX_ATTEMPTS', choices: ['5', '10', '20'], description: 'Number of attempts to create the connection to Elasticsearch')
     choice(name: 'RETRY_TIMEOUT', choices: ['3', '5', '7', '11'], description: 'Number of seconds between retry')
@@ -117,12 +118,15 @@ pipeline {
               unstash 'source'
               dir("${BASE_DIR}") {
                 script {
+                  def suiteParam = params.runTestsSuite
                   def suites = readYaml(file: '.ci/.e2e-tests.yaml')
                   def parallelTasks = [:]
                   suites['SUITES'].each { item ->
                     def suite = item.suite
                     def feature = item.feature
-                    parallelTasks["${suite}_${feature}"] = generateFunctionalTestStep(suite: "${suite}", feature: "${feature}")
+                    if (suiteParam == "all" || suiteParam == suite) {
+                      parallelTasks["${suite}_${feature}"] = generateFunctionalTestStep(suite: "${suite}", feature: "${feature}")
+                    }
                   }
                   parallel(parallelTasks)
                 }


### PR DESCRIPTION
## What does this PR do?
It adds an input parameter to the CI pipeline, supporting running all or one of the existing test suites, setting 'all' as default.

## Why is it important?
It will allow running this pipeline with less parallel branches, being the case we want to run just one branch. This filter will be provided by a Jenkins input parameter.

## Related issues
- Relates #130