### PR TITLE
feat(ci): only run test suites when modified

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -126,7 +126,13 @@ pipeline {
                     def suite = item.suite
                     def feature = item.feature
                     if (suiteParam == "all" || suiteParam == suite) {
-                      parallelTasks["${suite}_${feature}"] = generateFunctionalTestStep(suite: "${suite}", feature: "${feature}")
+                      def regexps = [ "^e2e/_suites/${suite}/.*", "^.ci/.*", "^cli/.*", "^e2e/.*\.go" ]
+                      if (isGitRegionMatch(patterns: regexps, shouldMatchAll: false)) {
+                        log(level: 'INFO', text: "Adding ${suite} test suite to the build execution")
+                        parallelTasks["${suite}_${feature}"] = generateFunctionalTestStep(suite: "${suite}", feature: "${feature}")
+                      } else {
+                        log(level: 'WARN', text: "The ${suite} test suite won't be executed because there are no modified files")
+                      }
                     }
                   }
                   parallel(parallelTasks)

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -128,10 +128,10 @@ pipeline {
                     if (suiteParam == "all" || suiteParam == suite) {
                       def regexps = [ "^e2e/_suites/${suite}/.*", "^.ci/.*", "^cli/.*", "^e2e/.*\\.go" ]
                       if (isGitRegionMatch(patterns: regexps, shouldMatchAll: false)) {
-                        log(level: 'INFO', text: "Adding ${suite} test suite to the build execution")
+                        log(level: 'INFO', text: "Adding ${suite}:${feature} test suite to the build execution")
                         parallelTasks["${suite}_${feature}"] = generateFunctionalTestStep(suite: "${suite}", feature: "${feature}")
                       } else {
-                        log(level: 'WARN', text: "The ${suite} test suite won't be executed because there are no modified files")
+                        log(level: 'WARN', text: "The ${suite}:${feature} test suite won't be executed because there are no modified files")
                       }
                     }
                   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
                     def suite = item.suite
                     def feature = item.feature
                     if (suiteParam == "all" || suiteParam == suite) {
-                      def regexps = [ "^e2e/_suites/${suite}/.*", "^.ci/.*", "^cli/.*", "^e2e/.*\.go" ]
+                      def regexps = [ "^e2e/_suites/${suite}/.*", "^.ci/.*", "^cli/.*", "^e2e/.*\\.go" ]
                       if (isGitRegionMatch(patterns: regexps, shouldMatchAll: false)) {
                         log(level: 'INFO', text: "Adding ${suite} test suite to the build execution")
                         parallelTasks["${suite}_${feature}"] = generateFunctionalTestStep(suite: "${suite}", feature: "${feature}")


### PR DESCRIPTION
## What is this PR doing?
It uses the `isGitRegionMatch` step to run those test suites that were modified by a PR

It will also check that the provisioning library is modified. This way,
a test suite will be added to the parallel execution in the following
conditions:

1) the "e2e/_suites/${suite}" has been modified
2) the ".ci" dir has been modified
3) the "cli" dir has been modified
4) any of the test helper files have been modified+