### PR TITLE
chore: simplify deploy stand-alone specs

### DIFF
--- a/e2e/_suites/ingest-manager/features/ingest_manager.feature
+++ b/e2e/_suites/ingest-manager/features/ingest_manager.feature
@@ -1,6 +1,8 @@
 @stand_alone_mode
 Feature: Stand-alone Agent Mode
-  Scenarios for a standalone mode Elastic Agent in Ingest Manager
+  Scenarios for a standalone mode Elastic Agent in Ingest Manager, where an Elasticseach
+  and a Kibana instances are already provisioned, so that the Agent is able to communicate
+  with them
 
 @start-agent
 Scenario: Starting the agent starts backend processes
@@ -10,13 +12,11 @@ Scenario: Starting the agent starts backend processes
 
 @deploy-stand-alone
 Scenario: Deploying a stand-alone agent
-  Given Kibana and Elasticsearch are available
   When a stand-alone agent is deployed
   Then there is new data in the index from agent
 
 @stop-agent
 Scenario: Stopping the agent container stops data going into ES
-  Given Kibana and Elasticsearch are available
-    And a stand-alone agent is deployed
+  Given a stand-alone agent is deployed
   When the "agent" docker container is stopped
   Then there is no new data in the index after agent shuts down

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -15,7 +15,6 @@ type StandAloneTestSuite struct {
 
 func (sats *StandAloneTestSuite) contributeSteps(s *godog.Suite) {
 	s.Step(`^a stand-alone agent is deployed$`, sats.aStandaloneAgentIsDeployed)
-	s.Step(`^Kibana and Elasticsearch are available$`, sats.kibanaAndElasticsearchAreAvailable)
 	s.Step(`^there is new data in the index from agent$`, sats.thereIsNewDataInTheIndexFromAgent)
 	s.Step(`^the "([^"]*)" docker container is stopped$`, sats.theDockerContainerIsStopped)
 	s.Step(`^there is no new data in the index after agent shuts down$`, sats.thereIsNoNewDataInTheIndexAfterAgentShutsDown)
@@ -64,10 +63,6 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed() error {
 	}
 
 	return nil
-}
-
-func (sats *StandAloneTestSuite) kibanaAndElasticsearchAreAvailable() error {
-	return godog.ErrPending
 }
 
 func (sats *StandAloneTestSuite) thereIsNewDataInTheIndexFromAgent() error {


### PR DESCRIPTION
## What does this PR do?
It simplifies the specs for the Deploy stand-alone agent, removing the steps that are already part of the test framework.
To make it even clearer, we mention it in the description of the Feature, so any casual reader would understand it.

## Why is it important?
We make sure that Kibana and Elasticsearch are running, because are part of the BeforeSuite life cycle hook of the godog (cucumber) test runner. On the other hand, we could keep the step and perform a quick check that both instances are running. I'd see this valid, although redundant, as they represent the explicit runtime dependencies for the agent.

## Follow-ups
Once approved (and merged) we can continue with the implementation steps