### PR TITLE
docs: Document how to install the development tools

### DIFF
--- a/e2e/_suites/ingest-manager/README.md
+++ b/e2e/_suites/ingest-manager/README.md
@@ -47,7 +47,13 @@ The first step in determining the exact failure is to try and reproduce the test
 
     >TBD: There is an initiative to automate this process to build the Docker image for a PR (or the local workspace) before running the tests, so the image is ready.
 
-4. Run the tests.
+4. Install dependencies.
+
+   - Install Go with Gimme: `.ci/scripts/install-go.sh 1.13.4`
+   - Configure Go Path: `export GOROOT=${HOME}/.gimme/versions/go1.13.4.darwin.amd64`
+   - Install godog: `make -C e2e install-godog`
+
+5. Run the tests.
 
    ```shell
    OP_LOG_LEVEL=DEBUG godog

--- a/e2e/_suites/ingest-manager/README.md
+++ b/e2e/_suites/ingest-manager/README.md
@@ -71,6 +71,12 @@ Check if the scenario has an annotation/tag supporting the test runner to filter
    OP_LOG_LEVEL=DEBUG godog -t '@annotation'
    ```
 
+Example:
+
+   ```shell
+   OP_LOG_LEVEL=DEBUG godog -t '@stand_alone_mode'
+   ```
+
 ### Setup failures
 
 Sometimes the tests coulf fail to configure or start a product such as Metricbeat, Elasticsearch, etc. To determine why 

--- a/e2e/_suites/ingest-manager/README.md
+++ b/e2e/_suites/ingest-manager/README.md
@@ -38,7 +38,7 @@ The first step in determining the exact failure is to try and reproduce the test
 
    ```shell
    # There should be a Docker image for the runtime dependencies (elasticsearch, kibana, package registry)
-   export OP_STACK_VERSION=7.7.0
+   export OP_STACK_VERSION=8.0.0-SNAPSHOT
    ```
 
 3. Define the proper Docker images to be used in tests.

--- a/e2e/_suites/ingest-manager/README.md
+++ b/e2e/_suites/ingest-manager/README.md
@@ -50,7 +50,9 @@ The first step in determining the exact failure is to try and reproduce the test
 4. Install dependencies.
 
    - Install Go with Gimme: `.ci/scripts/install-go.sh 1.13.4`
-   - Configure Go Path: `export GOROOT=${HOME}/.gimme/versions/go1.13.4.darwin.amd64`
+   - Configure Go Path:
+      - Mac: `export GOROOT=${HOME}/.gimme/versions/go1.13.4.darwin.amd64`
+      - Linux: `export GOROOT=${HOME}/.gimme/versions/go1.13.4.linux.amd64`
    - Install godog: `make -C e2e install-godog`
 
 5. Run the tests.

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -15,7 +15,7 @@ import (
 
 // stackVersion is the version of the stack to use
 // It can be overriden by OP_STACK_VERSION env var
-var stackVersion = "7.7.0"
+var stackVersion = "8.0.0-SNAPSHOT"
 
 // profileEnv is the environment to be applied to any execution
 // affecting the runtime dependencies (or profile)


### PR DESCRIPTION
## What is this PR doing?
It adds to the ingest-manager docs the instructions on how to setup the local computer for running the tests

## Why is it important?
Knowledge sharing!

## Related issues
- Closes #138

## Follow-up
Document install steps for Windows