### PR TITLE
chore(ci): add a pipeline for the daily trigger of the ingest manager tests

### DIFF
--- a/.ci/e2eTestingIngestManagerDaily.groovy
+++ b/.ci/e2eTestingIngestManagerDaily.groovy
@@ -59,7 +59,7 @@ pipeline {
             string(name: 'STACK_VERSION', value: "${params.STACK_VERSION.trim()}"),
             string(name: 'GO_VERSION', value: "${params.GO_VERSION.trim()}")
           ],
-          propagate: true,
+          propagate: false,
           wait: false
         )
       }

--- a/.ci/e2eTestingIngestManagerDaily.groovy
+++ b/.ci/e2eTestingIngestManagerDaily.groovy
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'linux && immutable' }
+  environment {
+    REPO = 'e2e-testing'
+    BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    GOPATH = "${env.WORKSPACE}"
+    HOME = "${env.WORKSPACE}"
+    JOB_GCS_BUCKET = credentials('gcs-bucket')
+    JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
+    NOTIFY_TO = credentials('notify-to')
+    PATH = "${env.GOPATH}/bin:${env.PATH}"
+    PIPELINE_LOG_LEVEL='INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  triggers {
+    cron '@daily'
+  }
+  parameters {
+    choice(name: 'LOG_LEVEL', choices: ['INFO', 'DEBUG'], description: 'Log level to be used')
+    choice(name: 'RETRY_TIMEOUT', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
+    string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'SemVer version of the stack to be used.')
+    string(name: 'GO_VERSION', defaultValue: '1.13.4', description: "Go version to use.")
+  }
+  stages {
+    stage('Run Tests') {
+      steps {
+        build(job: 'stack/e2e-testing-mbp',
+          parameters: [
+            string(name: 'runTestsSuite', value: 'ingest-manager'),
+            string(name: 'LOG_LEVEL', value: "${params.LOG_LEVEL.trim()}"),
+            string(name: 'RETRY_TIMEOUTRETRY_TIMEOUT', value: "${params.RETRY_TIMEOUT.trim()}"),
+            string(name: 'STACK_VERSION', value: "${params.STACK_VERSION.trim()}"),
+            string(name: 'GO_VERSION', value: "${params.GO_VERSION.trim()}")
+          ],
+          propagate: true,
+          wait: true
+        )
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}

--- a/.ci/e2eTestingIngestManagerDaily.groovy
+++ b/.ci/e2eTestingIngestManagerDaily.groovy
@@ -25,7 +25,6 @@ pipeline {
     GOPATH = "${env.WORKSPACE}"
     HOME = "${env.WORKSPACE}"
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     NOTIFY_TO = credentials('notify-to')
     PATH = "${env.GOPATH}/bin:${env.PATH}"
     PIPELINE_LOG_LEVEL='INFO'
@@ -52,11 +51,11 @@ pipeline {
   stages {
     stage('Run Tests') {
       steps {
-        build(job: 'stack/e2e-testing-mbp',
+        build(job: 'stack/e2e-testing-mbp/master',
           parameters: [
             string(name: 'runTestsSuite', value: 'ingest-manager'),
             string(name: 'LOG_LEVEL', value: "${params.LOG_LEVEL.trim()}"),
-            string(name: 'RETRY_TIMEOUTRETRY_TIMEOUT', value: "${params.RETRY_TIMEOUT.trim()}"),
+            string(name: 'RETRY_TIMEOUT', value: "${params.RETRY_TIMEOUT.trim()}"),
             string(name: 'STACK_VERSION', value: "${params.STACK_VERSION.trim()}"),
             string(name: 'GO_VERSION', value: "${params.GO_VERSION.trim()}")
           ],

--- a/.ci/e2eTestingIngestManagerDaily.groovy
+++ b/.ci/e2eTestingIngestManagerDaily.groovy
@@ -40,7 +40,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    cron '@daily'
+    cron('H H(4-5) * * 1-5')
   }
   parameters {
     choice(name: 'LOG_LEVEL', choices: ['INFO', 'DEBUG'], description: 'Log level to be used')

--- a/.ci/e2eTestingIngestManagerDaily.groovy
+++ b/.ci/e2eTestingIngestManagerDaily.groovy
@@ -60,7 +60,7 @@ pipeline {
             string(name: 'GO_VERSION', value: "${params.GO_VERSION.trim()}")
           ],
           propagate: true,
-          wait: true
+          wait: false
         )
       }
     }

--- a/.ci/e2eTestingIngestManagerDaily.groovy
+++ b/.ci/e2eTestingIngestManagerDaily.groovy
@@ -18,7 +18,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent none
   environment {
     REPO = 'e2e-testing'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,19 @@
+---
+
+##### GLOBAL METADATA
+
+- meta:
+    cluster: apm-ci
+
+##### JOB DEFAULTS
+
+- job:
+    logrotate:
+      numToKeep: 20
+    node: linux
+    concurrent: true
+    publishers:
+      - email:
+          recipients: infra-root+build@elastic.co
+    periodic-folder-trigger: 1w
+    prune-dead-branches: true

--- a/.ci/jobs/e2e-testing-beats.yml
+++ b/.ci/jobs/e2e-testing-beats.yml
@@ -1,0 +1,20 @@
+---
+- job:
+    name: beats/e2e-testing-beats
+    display-name: End-2-End Tests Pipeline for Beats
+    description: Jenkins pipeline for running the functional tests for Beats project
+    view: APM-CI
+    project-type: pipeline
+    pipeline-scm:
+      script-path: .ci/functionalTests.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/e2e-testing.git
+            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/e2e-testing.git
+            branches:
+              - master

--- a/.ci/jobs/e2e-testing-ingest-manager-daily.yml
+++ b/.ci/jobs/e2e-testing-ingest-manager-daily.yml
@@ -1,0 +1,27 @@
+---
+- job:
+    name: stack/e2e-testing-ingest-manager-daily
+    display-name: End-2-End tests for Ingest Manager Pipeline
+    description: Run E2E Ingest Manager test suite daily
+    view: APM-CI
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: master
+          description: the Git branch specifier to build
+    pipeline-scm:
+      script-path: .ci/e2eTestingIngestManagerDaily.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/e2e-testing.git
+            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/e2e-testing.git
+            branches:
+              - $branch_specifier
+    triggers:
+      - timed: 'H H(4-5) * * 1-5'

--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -1,0 +1,43 @@
+---
+- job:
+    name: stack/e2e-testing-mbp
+    display-name: End-2-End Tests Pipeline
+    description: Jenkins pipeline for the e2e-testing project
+    view: APM-CI
+    project-type: multibranch
+    script-path: .ci/Jenkinsfile
+    scm:
+      - github:
+          branch-discovery: no-pr
+          discover-pr-forks-strategy: merge-current
+          discover-pr-forks-trust: permission
+          discover-pr-origin: merge-current
+          discover-tags: true
+          notification-context: 'apm-ci'
+          repo: e2e-testing
+          repo-owner: elastic
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          build-strategies:
+            - tags:
+                ignore-tags-older-than: -1
+                ignore-tags-newer-than: -1
+            - regular-branches: true
+            - change-request:
+                ignore-target-only-changes: false
+          clean:
+            after: true
+            before: true
+          prune: true
+          shallow-clone: true
+          depth: 3
+          do-not-fetch-tags: true
+          submodule:
+            disable: false
+            recursive: true
+            parent-credentials: true
+            timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: 'True'


### PR DESCRIPTION
## What does this PR do?
It adds a regular Jenkins pipeline that triggers the already existing job for the e2e tests, customising the execution with predefined input parameters, setting the ingest-manager test suite to be run.

It's also possible to manually run this job with different configurations:
- Go version
- Stack version
- Retry timeout
- Log level

If not set, it will use the triggered build's defaults for configuration

Besides that, all JJBB definitions have been added here, as we opened a request to infra to discover JJBB jobs in this repo.

## Why is it important?
We want to schedule the execution of the ingest-manager tests in a daily manner.

JJBB definitions in the same repo ==> self-content repo ==> 👍 

## Related issues
- Closes #142