### PR TITLE
fix(ci): control git checks using a parameter

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
   }
   parameters {
     choice(name: 'runTestsSuite', choices: ['all', 'helm', 'ingest-manager', 'metricbeat'], description: 'Choose which test suite to run (default: all)')
-    booleanParam(name: "SKIP_GIT_CHECKS", defaultValue: "false", description: "If it's needed to check for Git changes to filter by modified sources")
+    booleanParam(name: "SKIP_GIT_CHECKS", defaultValue: false, description: "If it's needed to check for Git changes to filter by modified sources")
     choice(name: 'LOG_LEVEL', choices: ['INFO', 'DEBUG'], description: 'Log level to be used')
     choice(name: 'RETRY_TIMEOUT', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
     string(name: 'STACK_VERSION', defaultValue: '7.7.0', description: 'SemVer version of the stack to be used.')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
         GOPROXY = 'https://proxy.golang.org'
         METRICBEAT_VERSION = "${params.METRICBEAT_VERSION.trim()}"
         STACK_VERSION = "${params.STACK_VERSION.trim()}"
-        SKIP_GIT_CHECKS = "${params.SKIP_GIT_CHECKS.trim()}"
+        SKIP_GIT_CHECKS = "${params.SKIP_GIT_CHECKS}"
         HELM_CHART_VERSION = "${params.HELM_CHART_VERSION.trim()}"
         HELM_VERSION = "${params.HELM_VERSION.trim()}"
         KIND_VERSION = "${params.KIND_VERSION.trim()}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
   }
   parameters {
     choice(name: 'runTestsSuite', choices: ['all', 'helm', 'ingest-manager', 'metricbeat'], description: 'Choose which test suite to run (default: all)')
+    booleanParam(name: "SKIP_GIT_CHECKS", defaultValue: "false", description: "If it's needed to check for Git changes to filter by modified sources")
     choice(name: 'LOG_LEVEL', choices: ['INFO', 'DEBUG'], description: 'Log level to be used')
     choice(name: 'RETRY_TIMEOUT', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
     string(name: 'STACK_VERSION', defaultValue: '7.7.0', description: 'SemVer version of the stack to be used.')
@@ -48,6 +49,7 @@ pipeline {
         GOPROXY = 'https://proxy.golang.org'
         METRICBEAT_VERSION = "${params.METRICBEAT_VERSION.trim()}"
         STACK_VERSION = "${params.STACK_VERSION.trim()}"
+        SKIP_GIT_CHECKS = "${params.SKIP_GIT_CHECKS.trim()}"
         HELM_CHART_VERSION = "${params.HELM_CHART_VERSION.trim()}"
         HELM_VERSION = "${params.HELM_VERSION.trim()}"
         KIND_VERSION = "${params.KIND_VERSION.trim()}"
@@ -125,7 +127,7 @@ pipeline {
                     def feature = item.feature
                     if (suiteParam == "all" || suiteParam == suite) {
                       def regexps = [ "^e2e/_suites/${suite}/.*", "^.ci/.*", "^cli/.*", "^e2e/.*\\.go" ]
-                      if (isGitRegionMatch(patterns: regexps, shouldMatchAll: false)) {
+                      if ("${SKIP_GIT_CHECKS}" == "true" || isGitRegionMatch(patterns: regexps, shouldMatchAll: false)) {
                         log(level: 'INFO', text: "Adding ${suite}:${feature} test suite to the build execution")
                         parallelTasks["${suite}_${feature}"] = generateFunctionalTestStep(suite: "${suite}", feature: "${feature}")
                       } else {

--- a/.ci/e2eTestingIngestManagerDaily.groovy
+++ b/.ci/e2eTestingIngestManagerDaily.groovy
@@ -45,7 +45,7 @@ pipeline {
   parameters {
     choice(name: 'LOG_LEVEL', choices: ['INFO', 'DEBUG'], description: 'Log level to be used')
     choice(name: 'RETRY_TIMEOUT', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
-    booleanParam(name: "SKIP_GIT_CHECKS", defaultValue: "true", description: "If it's needed to check for Git changes to filter by modified sources")
+    booleanParam(name: "SKIP_GIT_CHECKS", defaultValue: true, description: "If it's needed to check for Git changes to filter by modified sources")
     string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'SemVer version of the stack to be used.')
     string(name: 'GO_VERSION', defaultValue: '1.13.4', description: "Go version to use.")
   }
@@ -57,7 +57,7 @@ pipeline {
             string(name: 'runTestsSuite', value: 'ingest-manager'),
             string(name: 'LOG_LEVEL', value: "${params.LOG_LEVEL.trim()}"),
             string(name: 'RETRY_TIMEOUT', value: "${params.RETRY_TIMEOUT.trim()}"),
-            string(name: 'SKIP_GIT_CHECKS', value: "${params.SKIP_GIT_CHECKS.trim()}")
+            string(name: 'SKIP_GIT_CHECKS', value: "${params.SKIP_GIT_CHECKS}")
             string(name: 'STACK_VERSION', value: "${params.STACK_VERSION.trim()}"),
             string(name: 'GO_VERSION', value: "${params.GO_VERSION.trim()}")
           ],

--- a/.ci/e2eTestingIngestManagerDaily.groovy
+++ b/.ci/e2eTestingIngestManagerDaily.groovy
@@ -45,6 +45,7 @@ pipeline {
   parameters {
     choice(name: 'LOG_LEVEL', choices: ['INFO', 'DEBUG'], description: 'Log level to be used')
     choice(name: 'RETRY_TIMEOUT', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
+    booleanParam(name: "SKIP_GIT_CHECKS", defaultValue: "true", description: "If it's needed to check for Git changes to filter by modified sources")
     string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'SemVer version of the stack to be used.')
     string(name: 'GO_VERSION', defaultValue: '1.13.4', description: "Go version to use.")
   }
@@ -56,6 +57,7 @@ pipeline {
             string(name: 'runTestsSuite', value: 'ingest-manager'),
             string(name: 'LOG_LEVEL', value: "${params.LOG_LEVEL.trim()}"),
             string(name: 'RETRY_TIMEOUT', value: "${params.RETRY_TIMEOUT.trim()}"),
+            string(name: 'SKIP_GIT_CHECKS', value: "${params.SKIP_GIT_CHECKS.trim()}")
             string(name: 'STACK_VERSION', value: "${params.STACK_VERSION.trim()}"),
             string(name: 'GO_VERSION', value: "${params.GO_VERSION.trim()}")
           ],

--- a/.ci/e2eTestingIngestManagerDaily.groovy
+++ b/.ci/e2eTestingIngestManagerDaily.groovy
@@ -57,7 +57,7 @@ pipeline {
             string(name: 'runTestsSuite', value: 'ingest-manager'),
             string(name: 'LOG_LEVEL', value: "${params.LOG_LEVEL.trim()}"),
             string(name: 'RETRY_TIMEOUT', value: "${params.RETRY_TIMEOUT.trim()}"),
-            string(name: 'SKIP_GIT_CHECKS', value: "${params.SKIP_GIT_CHECKS}")
+            string(name: 'SKIP_GIT_CHECKS', value: "${params.SKIP_GIT_CHECKS}"),
             string(name: 'STACK_VERSION', value: "${params.STACK_VERSION.trim()}"),
             string(name: 'GO_VERSION', value: "${params.GO_VERSION.trim()}")
           ],


### PR DESCRIPTION
## What does this PR do?
It adds a boolean param to control if the isGitRegionMatch takes effect. This param, which is defined in the downstream job, will be set as TRUE by the scheduled caller job, bein FALSE by default

We will trigger the job from the scheduled one setting the parameter to TRUE

## Why is it important?
Otherwise the isGitRegionMatch won't detect any change for triggered, scheduled builds.

## Related issues
- Fixes #144