### PR TITLE
chore: move jobs to the Beats-CI

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -3,7 +3,7 @@
 ##### GLOBAL METADATA
 
 - meta:
-    cluster: apm-ci
+    cluster: beats-ci
 
 ##### JOB DEFAULTS
 

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -15,5 +15,4 @@
     publishers:
       - email:
           recipients: infra-root+build@elastic.co
-    periodic-folder-trigger: 1w
     prune-dead-branches: true

--- a/.ci/jobs/e2e-folder.yml
+++ b/.ci/jobs/e2e-folder.yml
@@ -1,0 +1,5 @@
+---
+- job:
+    name: e2e-tests
+    description: E2E Tests
+    project-type: folder

--- a/.ci/jobs/e2e-testing-beats.yml
+++ b/.ci/jobs/e2e-testing-beats.yml
@@ -3,7 +3,7 @@
     name: beats/e2e-testing-beats
     display-name: End-2-End Tests Pipeline for Beats
     description: Jenkins pipeline for running the functional tests for Beats project
-    view: APM-CI
+    view: E2E
     project-type: pipeline
     pipeline-scm:
       script-path: .ci/functionalTests.groovy

--- a/.ci/jobs/e2e-testing-helm-daily.yml
+++ b/.ci/jobs/e2e-testing-helm-daily.yml
@@ -3,7 +3,7 @@
     name: stack/e2e-testing-helm-daily
     display-name: End-2-End tests for Observability Helm charts Pipeline
     description: Run E2E Helm Charts test suite daily
-    view: APM-CI
+    view: E2E
     project-type: pipeline
     parameters:
       - string:

--- a/.ci/jobs/e2e-testing-ingest-manager-daily.yml
+++ b/.ci/jobs/e2e-testing-ingest-manager-daily.yml
@@ -3,7 +3,7 @@
     name: stack/e2e-testing-ingest-manager-daily
     display-name: End-2-End tests for Ingest Manager Pipeline
     description: Run E2E Ingest Manager test suite daily
-    view: APM-CI
+    view: E2E
     project-type: pipeline
     parameters:
       - string:

--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -25,7 +25,7 @@
                 ignore-tags-newer-than: -1
             - regular-branches: true
             - change-request:
-                ignore-target-only-changes: false
+                ignore-target-only-changes: true
           clean:
             after: true
             before: true

--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -3,7 +3,7 @@
     name: stack/e2e-testing-mbp
     display-name: End-2-End Tests Pipeline
     description: Jenkins pipeline for the e2e-testing project
-    view: APM-CI
+    view: E2E
     project-type: multibranch
     script-path: .ci/Jenkinsfile
     scm:


### PR DESCRIPTION
## What does this PR do?
It creates a folder in the beats-ci to have all e2e jobs in a single view

## Why is it important?
The core business for this project is to support the Beats team in triggering the e2e tests directly from the Beats CI, and that was not possible, or difficult to achieve hosting the tests in the APM CI

## Related issues
- Closes #155 