### PR TITLE
chore: do not build the binary when running tests

### DIFF
--- a/.ci/scripts/functional-test.sh
+++ b/.ci/scripts/functional-test.sh
@@ -14,17 +14,12 @@ SUITE=${2:-''}
 FEATURE=${3:-''}
 STACK_VERSION=${4:-'7.7.0'}
 METRICBEAT_VERSION=${5:-'7.7.0'}
-TARGET_OS=${GOOS:-linux}
-TARGET_ARCH=${GOARCH:-amd64}
 
 # shellcheck disable=SC1091
 source .ci/scripts/install-go.sh "${GO_VERSION}"
 
-# Build OP Binary
-GOOS=${TARGET_OS} GOARCH=${TARGET_ARCH} make -C e2e fetch-binary
-
 # Sync integrations
-make -C e2e sync-integrations
+make -C cli sync-integrations
 
 rm -rf outputs || true
 mkdir -p outputs

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -22,6 +22,16 @@ build:
 install:
 	go get -v -t ./...
 
+.PHONY: sync-integrations
+sync-integrations:
+	docker run --rm \
+		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
+		-v ~/.op/git:/root/.op/git \
+		-w /go/src/github.com/elastic/e2e-testing/cli \
+		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
+		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \
+		go run main.go sync integrations --delete 
+
 .PHONY: test
 test:
 	go test -v -timeout=$(TEST_TIMEOUT) ./...

--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -15,7 +15,7 @@ func CheckInstalledSoftware(binaries []string) {
 	for _, binary := range binaries {
 		err := which(binary)
 		if err != nil {
-			log.Fatalf("The program cannot be run because %s are not installed. Required: %v", binary, binaries)
+			log.Warnf("The program cannot be run because %s are not installed. Required: %v", binary, binaries)
 		}
 	}
 }

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -13,14 +13,6 @@ FEATURE_FLAG=--tags
 endif
 
 GO_IMAGE_TAG?='stretch'
-GOOS?='linux'
-GOARCH?='amd64'
-
-.PHONY: fetch-binary
-fetch-binary:
-	@$(MAKE) -C ../cli build
-	cp ../cli/.github/releases/download/$(VERSION_VALUE)/$(GOOS)$(subst amd,,$(GOARCH))-op ./op
-	chmod +x ./op
 
 .PHONY: install
 install:
@@ -40,7 +32,3 @@ functional-test: install-godog
 	OP_METRICBEAT_VERSION=${METRICBEAT_VERSION} \
 	OP_STACK_VERSION=${STACK_VERSION} \
 	godog --format=${FORMAT} ${FEATURE_FLAG} ${FEATURE}
-
-.PHONY: sync-integrations
-sync-integrations:
-	OP_LOG_LEVEL=${LOG_LEVEL} ./op sync integrations --delete

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -98,11 +98,8 @@ $ export GO111MODULE=on                            # Go modules support
 $ make -C cli install                              # installs CLI dependencies
 $ export STACK_VERSION=7.7.0                       # exports stack version as runtime
 $ export METRICBEAT_VERSION=7.7.0                  # exports metricbeat version to be tested
-$ # export FEATURE=redis                           # exports which feature to run (default 'all')
-$ # export GOOS=darwin                             # exports your O.S. (default 'linux', valid: [darwin, linux, windows])
-$ # export GOARCH=amd64                            # exports your O.S. (default 'amd64', valid: [amd64, 386])
+$ # export FEATURE=redis                           # exports which feature to run (default 'all')                           # exports your O.S. (default 'amd64', valid: [amd64, 386])
 $ make -C e2e install                              # installs tests dependencies
-$ make -C e2e fetch-binary                         # generates the binary from the repository
 $ make -C e2e functional-test                      # runs the test suite for Redis and stack 
 ```
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -98,7 +98,7 @@ $ export GO111MODULE=on                            # Go modules support
 $ make -C cli install                              # installs CLI dependencies
 $ export STACK_VERSION=7.7.0                       # exports stack version as runtime
 $ export METRICBEAT_VERSION=7.7.0                  # exports metricbeat version to be tested
-$ # export FEATURE=redis                           # exports which feature to run (default 'all')                           # exports your O.S. (default 'amd64', valid: [amd64, 386])
+$ # export FEATURE=redis                           # exports which feature to run (default 'all')
 $ make -C e2e install                              # installs tests dependencies
 $ make -C e2e functional-test                      # runs the test suite for Redis and stack 
 ```


### PR DESCRIPTION
## What is this PR doing?
It directly uses Go instead of the compiled binary when running the tests, and for that we use a docker image to ensure the proper version of Go. Therefore, the Make command that downloaded the Beats repo (sync-integrations) has been moved from the "e2e" dir to the "cli".

This Make target will mount a volume to the Git download dir, under CLI's workspace (~/.op), so that the Docker image shares it to put there the files.

## Why is it important?
Running the synchronisation process from the binary is not needed, because we can invoke Go directly. We only used it to download Beats git repo, so we can reduce complexity because of removing that build time. As a consequence, the build time will be reduced.