### PR TITLE
fix(ci): use proper labels

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
   }
   stages {
     stage('Initializing'){
-      agent { label 'ubuntu-1804 && immutable' }
+      agent { label 'ubuntu-18.04 && immutable && docker' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"
@@ -67,7 +67,7 @@ pipeline {
         stage('Tests') {
           parallel {
             stage('Sanity checks') {
-              agent { label 'ubuntu-1804 && immutable' }
+              agent { label 'ubuntu-18.04 && immutable && docker' }
               environment {
                 GOROOT = "${env.WORKSPACE}/.gimme/versions/go${env.GO_VERSION}.linux.amd64"
                 PATH = "${env.WORKSPACE}/${env.BASE_DIR}/bin:${env.PATH}:${env.GOROOT}/bin"
@@ -85,7 +85,7 @@ pipeline {
               }
             }
             stage('Unit Tests') {
-              agent { label 'ubuntu-1804 && immutable' }
+              agent { label 'ubuntu-18.04 && immutable && docker' }
               options { skipDefaultCheckout() }
               steps {
                 withGithubNotify(context: 'Tests', tab: 'tests') {
@@ -175,7 +175,7 @@ def generateStep(Map params = [:]){
   def oss = params.get('oss')
   def platform = params.get('platform')
   return {
-    node('ubuntu-1804 && immutable') {
+    node('ubuntu-18.04 && immutable && docker') {
       try {
         deleteDir()
         unstash 'build'
@@ -197,7 +197,7 @@ def generateFunctionalTestStep(Map params = [:]){
   def suite = params.get('suite')
   def feature = params.get('feature')
   return {
-    node('ubuntu-1804 && immutable') {
+    node('ubuntu-18.04 && immutable && docker') {
       try {
         deleteDir()
         unstash 'build'

--- a/.ci/functionalTests.groovy
+++ b/.ci/functionalTests.groovy
@@ -7,7 +7,7 @@ pipeline {
   * this node will be reused across the nested stages because it's needed to
   * reuse the Docker cache
   */
-  agent { label 'ubuntu-1804 && immutable' }
+  agent { label 'ubuntu-18.04 && immutable && docker' }
   environment {
     REPO = 'e2e-testing'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"


### PR DESCRIPTION
## What is this PR doing?
Replaces the `ubuntu-1804` label with `ubuntu-18.04` one.

## Why is it important?
The first label does not exist