### PR TITLE
chore(ci): use credentials for the new Beats CI GH app

### DIFF
--- a/.ci/jobs/e2e-testing-helm-daily.yml
+++ b/.ci/jobs/e2e-testing-helm-daily.yml
@@ -19,7 +19,7 @@
             wipe-workspace: 'True'
             name: origin
             shallow-clone: true
-            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            credentials-id: github-app-beats-ci
             reference-repo: /var/lib/jenkins/.git-references/e2e-testing.git
             branches:
               - $branch_specifier

--- a/.ci/jobs/e2e-testing-ingest-manager-daily.yml
+++ b/.ci/jobs/e2e-testing-ingest-manager-daily.yml
@@ -19,7 +19,7 @@
             wipe-workspace: 'True'
             name: origin
             shallow-clone: true
-            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            credentials-id: github-app-beats-ci
             reference-repo: /var/lib/jenkins/.git-references/e2e-testing.git
             branches:
               - $branch_specifier

--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -16,7 +16,7 @@
           notification-context: 'beats-ci'
           repo: e2e-testing
           repo-owner: elastic
-          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          credentials-id: github-app-beats-ci
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:


### PR DESCRIPTION
## What does this PR do?
It replaces old credentials with the new ones, which are for a dedicated Beats CI account.

## Why is it important?
Github quotas

## Related issues
- Relates https://github.com/elastic/beats/pull/19852