### PR TITLE
Revert to using the binary to generate integrations files

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,6 +41,7 @@ pipeline {
       agent { label 'ubuntu-18.04 && immutable && docker' }
       options { skipDefaultCheckout() }
       environment {
+        HOME = "${env.WORKSPACE}"
         GOPATH = "${env.WORKSPACE}"
         GO_VERSION = "${params.GO_VERSION.trim()}"
         PATH = "${env.PATH}:${env.WORKSPACE}/bin:${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -41,7 +41,6 @@ pipeline {
       agent { label 'ubuntu-18.04 && immutable && docker' }
       options { skipDefaultCheckout() }
       environment {
-        HOME = "${env.WORKSPACE}"
         GOPATH = "${env.WORKSPACE}"
         GO_VERSION = "${params.GO_VERSION.trim()}"
         PATH = "${env.PATH}:${env.WORKSPACE}/bin:${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts"

--- a/.ci/scripts/functional-test.sh
+++ b/.ci/scripts/functional-test.sh
@@ -14,12 +14,17 @@ SUITE=${2:-''}
 FEATURE=${3:-''}
 STACK_VERSION=${4:-'7.7.0'}
 METRICBEAT_VERSION=${5:-'7.7.0'}
+TARGET_OS=${GOOS:-linux}
+TARGET_ARCH=${GOARCH:-amd64}
 
 # shellcheck disable=SC1091
 source .ci/scripts/install-go.sh "${GO_VERSION}"
 
+# Build OP Binary
+GOOS=${TARGET_OS} GOARCH=${TARGET_ARCH} make -C e2e fetch-binary
+
 # Sync integrations
-make -C cli sync-integrations
+make -C e2e sync-integrations
 
 rm -rf outputs || true
 mkdir -p outputs

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -26,7 +26,7 @@ install:
 sync-integrations:
 	docker run --rm \
 		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
-		-v ~/.op:/root/.op \
+		-v $(HOME)/.op:/root/.op \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
 		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -26,7 +26,7 @@ install:
 sync-integrations:
 	docker run --rm \
 		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
-		-v ~/.op:/root/.op \
+		-v ~/.op/git:/root/.op/git \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
 		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -27,7 +27,6 @@ sync-integrations:
 	docker run --rm \
 		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
 		-v $(HOME)/.op:/root/.op \
-		-u "$(id -u):$(id -g)" \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
 		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -22,16 +22,6 @@ build:
 install:
 	go get -v -t ./...
 
-.PHONY: sync-integrations
-sync-integrations:
-	docker run --rm \
-		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
-		-v ~/.op/git:/root/.op/git \
-		-w /go/src/github.com/elastic/e2e-testing/cli \
-		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
-		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \
-		go run main.go sync integrations --delete 
-
 .PHONY: test
 test:
 	go test -v -timeout=$(TEST_TIMEOUT) ./...

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -26,7 +26,7 @@ install:
 sync-integrations:
 	docker run --rm \
 		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
-		-v ~/.op/git:/root/.op/git \
+		-v ~/.op:/root/.op \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
 		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,3 +1,6 @@
+CURRENT_UID := $(shell id -u)
+CURRENT_GID := $(shell id -g)
+
 # Get current directory of a Makefile: https://stackoverflow.com/a/23324703
 ROOT_DIR:=$(CURDIR)
 
@@ -27,7 +30,7 @@ sync-integrations:
 	docker run --rm \
 		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
 		-v $(HOME)/.op:/root/.op \
-		-u "$(id -u):$(id -g)" \
+		-u "$(CURRENT_UID):$(CURRENT_GID)" \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
 		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -27,6 +27,7 @@ sync-integrations:
 	docker run --rm \
 		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
 		-v $(HOME)/.op:/root/.op \
+		-u "$(id -u):$(id -g)" \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
 		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,6 +1,3 @@
-CURRENT_UID := $(shell id -u)
-CURRENT_GID := $(shell id -g)
-
 # Get current directory of a Makefile: https://stackoverflow.com/a/23324703
 ROOT_DIR:=$(CURDIR)
 
@@ -30,7 +27,7 @@ sync-integrations:
 	docker run --rm \
 		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
 		-v $(HOME)/.op:/root/.op \
-		-u "$(CURRENT_UID):$(CURRENT_GID)" \
+		-u "$(id -u):$(id -g)" \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
 		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -29,10 +29,11 @@ install:
 sync-integrations:
 	docker run --rm \
 		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
-		-v $(HOME)/.op:/root/.op \
+		-v $(HOME)/.op:/tmp/.op \
 		-u "$(CURRENT_UID):$(CURRENT_GID)" \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
-		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} -e GOCACHE=/tmp/.cache \
+		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
+		-e GOCACHE=/tmp/.cache -e HOME=/tmp \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \
 		go run main.go sync integrations --delete 
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -32,7 +32,7 @@ sync-integrations:
 		-v $(HOME)/.op:/root/.op \
 		-u "$(CURRENT_UID):$(CURRENT_GID)" \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
-		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
+		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} -e GOCACHE=/tmp/.cache \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \
 		go run main.go sync integrations --delete 
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -26,7 +26,7 @@ install:
 sync-integrations:
 	docker run --rm \
 		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
-		-v $(HOME)/.op:/root/.op \
+		-v ~/.op:/root/.op \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
 		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -32,7 +32,7 @@ sync-integrations:
 		-v $(HOME)/.op:/root/.op \
 		-u "$(CURRENT_UID):$(CURRENT_GID)" \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
-		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} -e GOCACHE=/tmp/.cache \
+		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \
 		go run main.go sync integrations --delete 
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -29,11 +29,10 @@ install:
 sync-integrations:
 	docker run --rm \
 		-v $(ROOT_DIR):/go/src/github.com/elastic/e2e-testing/cli \
-		-v $(HOME)/.op:/tmp/.op \
+		-v $(HOME)/.op:/root/.op \
 		-u "$(CURRENT_UID):$(CURRENT_GID)" \
 		-w /go/src/github.com/elastic/e2e-testing/cli \
-		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} \
-		-e GOCACHE=/tmp/.cache -e HOME=/tmp \
+		-e GO111MODULE=on -e OP_LOG_LEVEL=${LOG_LEVEL} -e GOCACHE=/tmp/.cache \
 		$(GO_IMAGE):$(GO_VERSION)-$(GO_IMAGE_TAG) \
 		go run main.go sync integrations --delete 
 

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -138,6 +138,10 @@ func copyIntegrationsComposeFiles(beats git.Project, target string) {
 			}).Warn("Meta dir was not copied")
 			continue
 		}
+		log.WithFields(log.Fields{
+			"meta":       metaDir,
+			"targetMeta": targetMetaDir,
+		}).Debug("Integration _meta directory copied")
 
 		err = sanitizeComposeFile(targetFile)
 		if err != nil {
@@ -147,7 +151,16 @@ func copyIntegrationsComposeFiles(beats git.Project, target string) {
 			}).Warn("Could not sanitize compose file")
 			continue
 		}
+		log.WithFields(log.Fields{
+			"file":       file,
+			"targetFile": targetFile,
+		}).Debug("Integration compose file copied")
 	}
+
+	log.WithFields(log.Fields{
+		"files":  len(files),
+		"target": target,
+	}).Info("Integrations files copied")
 }
 
 type service interface{}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -83,6 +83,7 @@ func GetComposeFile(isProfile bool, composeName string) (string, error) {
 
 	log.WithFields(log.Fields{
 		"composeFilePath": composeFilePath,
+		"error":           err,
 		"type":            serviceType,
 	}).Debug("Compose file not found at workdir. Extracting from binary resources")
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"path"
 	"path/filepath"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	shell "github.com/elastic/e2e-testing/cli/shell"
 
 	packr "github.com/gobuffalo/packr/v2"
+	homedir "github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 
 	"gopkg.in/yaml.v2"
@@ -143,9 +143,14 @@ func InitConfig() {
 		return
 	}
 
-	usr, _ := user.Current()
+	home, err := homedir.Dir()
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Fatal("Could not get current user's HOME dir")
+	}
 
-	w := filepath.Join(usr.HomeDir, ".op")
+	w := filepath.Join(home, ".op")
 
 	newConfig(w)
 }

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.5.0 // indirect
 	github.com/sirupsen/logrus v1.4.2

--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -15,7 +15,7 @@ func CheckInstalledSoftware(binaries []string) {
 	for _, binary := range binaries {
 		err := which(binary)
 		if err != nil {
-			log.Warnf("The program cannot be run because %s are not installed. Required: %v", binary, binaries)
+			log.Fatalf("The program cannot be run because %s are not installed. Required: %v", binary, binaries)
 		}
 	}
 }

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -13,6 +13,14 @@ FEATURE_FLAG=--tags
 endif
 
 GO_IMAGE_TAG?='stretch'
+GOOS?='linux'
+GOARCH?='amd64'
+
+.PHONY: fetch-binary
+fetch-binary:
+	@$(MAKE) -C ../cli build
+	cp ../cli/.github/releases/download/$(VERSION_VALUE)/$(GOOS)$(subst amd,,$(GOARCH))-op ./op
+	chmod +x ./op
 
 .PHONY: install
 install:
@@ -32,3 +40,7 @@ functional-test: install-godog
 	OP_METRICBEAT_VERSION=${METRICBEAT_VERSION} \
 	OP_STACK_VERSION=${STACK_VERSION} \
 	godog --format=${FORMAT} ${FEATURE_FLAG} ${FEATURE}
+
+.PHONY: sync-integrations
+sync-integrations:
+	OP_LOG_LEVEL=${LOG_LEVEL} ./op sync integrations --delete

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -98,7 +98,7 @@ $ export GO111MODULE=on                            # Go modules support
 $ make -C cli install                              # installs CLI dependencies
 $ export STACK_VERSION=7.7.0                       # exports stack version as runtime
 $ export METRICBEAT_VERSION=7.7.0                  # exports metricbeat version to be tested
-$ # export FEATURE=redis                           # exports which feature to run (default 'all')
+$ # export FEATURE=redis                           # exports which feature to run (default 'all')                           # exports your O.S. (default 'amd64', valid: [amd64, 386])
 $ make -C e2e install                              # installs tests dependencies
 $ make -C e2e functional-test                      # runs the test suite for Redis and stack 
 ```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -98,8 +98,11 @@ $ export GO111MODULE=on                            # Go modules support
 $ make -C cli install                              # installs CLI dependencies
 $ export STACK_VERSION=7.7.0                       # exports stack version as runtime
 $ export METRICBEAT_VERSION=7.7.0                  # exports metricbeat version to be tested
-$ # export FEATURE=redis                           # exports which feature to run (default 'all')                           # exports your O.S. (default 'amd64', valid: [amd64, 386])
+$ # export FEATURE=redis                           # exports which feature to run (default 'all')
+$ # export GOOS=darwin                             # exports your O.S. (default 'linux', valid: [darwin, linux, windows])
+$ # export GOARCH=amd64                            # exports your O.S. (default 'amd64', valid: [amd64, 386])
 $ make -C e2e install                              # installs tests dependencies
+$ make -C e2e fetch-binary                         # generates the binary from the repository
 $ make -C e2e functional-test                      # runs the test suite for Redis and stack 
 ```
 


### PR DESCRIPTION
## What is this PR doing?
~~It expands the volume used to download the Beats repo, so the entire workspace fir is used, making possible for the integrations compose files to be present in the host.~~

It reverts back all commits to the change that replaced using the binary.

## Why is it important?
~~The sync command was getting compose files out of the container. This was causing the CI, and local execution using the Make command, to not find the compose files for the integrations, causing consistent failures.~~

We realised that using Docker to run Go will cause that any file generated inside the Docker container will have same permissions as inside the container (root). We tried to use same user than in the host inside the container, but we found this error: https://github.com/golang/go/issues/26280.

Applying this code https://github.com/fabric8-services/toolchain-operator/pull/3 fixed that error, but then we found that, because the user was different than root, the Go tool was nott able to write its workspace to $HOME/.op (/root/.op).

We then changed the HOME env var of the container used to run Go to point to /tmp, but that did not work either, because /tmp belongs to root too. 

And that's why we decided to revert all commits affecting the Makefiles to go back to the point we used the binary (previously built) to generate the integrations files.
>Jenkins build discovering files as expected, although **Ingest manager tests are still broken**, because of Kibana not able to start : https://apm-ci.elastic.co/blue/organizations/jenkins/stack%2Fe2e-testing-mbp/detail/PR-168/9/pipeline/256/?start=0

We preferred to revert back to green before merging new changes, expecting better local testing would help with this.

## How to tests this?
Does not apply any more, as we reverted back to old behavior
#### Before applying this changes:
~~1) from project's root dir, execute `make -C cli sync-integrations`~~
~~**Expected behavior:** the ~/.op/compose/services dir contains all (11) integrations (apache, mysql, redis...)~~
~~**Actual behavior:** the ~/.op/compose/services dir contains only metricbeat, which is already bundled in the CLI~~

#### After applying this changes:
~~1) from project's root dir, execute `make -C cli sync-integrations`~~
~~**Expected behavior:** the ~/.op/compose/services dir contains all (11) integrations (apache, mysql, redis...)~~
~~**Actual behavior:** the ~/.op/compose/services dir contains all (11) integrations~~

## Related issues
- Fixes #167
- ~~Caused by~~ Reverting affecting commits back to 3a8837243ce6a7918c520f7117fe8c37cb64b49b