### PR TITLE
fix: use proper GH credentials

### DIFF
--- a/.ci/jobs/e2e-testing-helm-daily.yml
+++ b/.ci/jobs/e2e-testing-helm-daily.yml
@@ -19,7 +19,7 @@
             wipe-workspace: 'True'
             name: origin
             shallow-clone: true
-            credentials-id: github-app-beats-ci
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
             reference-repo: /var/lib/jenkins/.git-references/e2e-testing.git
             branches:
               - $branch_specifier

--- a/.ci/jobs/e2e-testing-ingest-manager-daily.yml
+++ b/.ci/jobs/e2e-testing-ingest-manager-daily.yml
@@ -19,7 +19,7 @@
             wipe-workspace: 'True'
             name: origin
             shallow-clone: true
-            credentials-id: github-app-beats-ci
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
             reference-repo: /var/lib/jenkins/.git-references/e2e-testing.git
             branches:
               - $branch_specifier

--- a/.ci/jobs/e2e-testing-integrations-daily.yml
+++ b/.ci/jobs/e2e-testing-integrations-daily.yml
@@ -19,7 +19,7 @@
             wipe-workspace: 'True'
             name: origin
             shallow-clone: true
-            credentials-id: github-app-beats-ci
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
             reference-repo: /var/lib/jenkins/.git-references/e2e-testing.git
             branches:
               - $branch_specifier

--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
-          notification-context: 'beats-ci'
+          notification-context: 'beats-ci/e2e-testing'
           repo: e2e-testing
           repo-owner: elastic
           credentials-id: github-app-beats-ci


### PR DESCRIPTION
## What is this PR doing?
We introduced in 0ed1a29963465aa730cdd30c228c180180bd1b84 the new beats-ci GH user, but it should apply only to MBP. In this PR we are partially reverting that commit to keep the new credential only in the MBP.

Besides, we detected the notification context for the MBP should include information about the project itself, not only the instance.

## Why is this important?
We hit GH API quotas, and projects were not built. Related to the notification context, we want to provide more context in the github checks, avoiding being overriden by other checks.

## Related issues
- Relates https://github.com/elastic/e2e-testing/pull/166