### PR TITLE
feat: enrich the unenroll scenario

### DIFF
--- a/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
+++ b/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
@@ -25,7 +25,8 @@ Scenario: Stopping the agent stops backend processes
 Scenario: Un-enrolling an agent
   Given an agent is deployed to Fleet
   When the agent is un-enrolled
-  Then the agent is not listed as online in Fleet
+  Then the "elastic-agent" process is in the "started" state on the host
+    But the agent is not listed as online in Fleet
 
 @reenroll
 Scenario: Re-enrolling an agent


### PR DESCRIPTION
## What is this PR doing?
It adds an existing step to the unenroll scenario, checking the elastic-agent process is there.

## Why is it important?
We want to ensure the elastic-agent process is still running in the host, as described in the original test script

## Related issues
- Relates #149