### PR TITLE
fix: move back to using the beats-ci token

### DIFF
--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -16,7 +16,7 @@
           notification-context: 'beats-ci/e2e-testing'
           repo: e2e-testing
           repo-owner: elastic
-          credentials-id: github-app-beats-ci
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:


### PR DESCRIPTION
## What is this PR doing?
It uses the previous Beats-CI token, instead of the new github app one.

## Why is it important?
The webhooks for the github app token are not delivered so the CI is not notified about new PRs and changes. Besides that, scheduled builds triggering the MBP will fail with an error: https://beats-ci.elastic.co/blue/organizations/jenkins/e2e-tests%2Fe2e-testing-mbp/detail/master/57/pipeline:

```json
{"message":"Resource not accessible by integration","documentation_url":"https://developer.github.com/v3/repos/statuses/#create-a-status"}
```