### PR TITLE
feat: download the agent once, mounting it as a volume

### DIFF
--- a/cli/config/compose/services/centos/docker-compose.yml
+++ b/cli/config/compose/services/centos/docker-compose.yml
@@ -4,3 +4,5 @@ services:
     image: centos:${centosTag:-7}
     container_name: ${centosContainerName} 
     entrypoint: tail -f /dev/null
+    volumes:
+      - ${centosAgentBinarySrcPath:-.}:${centosAgentBinaryTargetPath:-/tmp}

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -24,12 +24,14 @@ const ingestManagerDataStreamsURL = kibanaBaseURL + "/api/ingest_manager/data_st
 
 // FleetTestSuite represents the scenarios for Fleet-mode
 type FleetTestSuite struct {
-	EnrolledAgentID string // will be used to store current agent
-	BoxType         string // we currently support Linux
-	Cleanup         bool
-	ConfigID        string // will be used to manage tokens
-	CurrentToken    string // current enrollment token
-	CurrentTokenID  string // current enrollment tokenID
+	AgentDownloadName string // the name for the binary
+	AgentDownloadPath string // the path where the agent for the binary is installed
+	EnrolledAgentID   string // will be used to store current agent
+	BoxType           string // we currently support Linux
+	Cleanup           bool
+	ConfigID          string // will be used to manage tokens
+	CurrentToken      string // current enrollment token
+	CurrentTokenID    string // current enrollment tokenID
 }
 
 func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
@@ -52,7 +54,7 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleet() error {
 	containerName := profile + "_" + serviceName + "_1" // name of the container
 	serviceTag := "7"                                   // docker tag of the service
 
-	err := deployAgentToFleet(profile, fts.BoxType, serviceTag, containerName)
+	err := deployAgentToFleet(profile, fts.BoxType, serviceTag, containerName, fts.AgentDownloadPath, fts.AgentDownloadName)
 	if err != nil {
 		return err
 	}
@@ -80,6 +82,25 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleet() error {
 	// get first agentID in online status, for future processing
 	fts.EnrolledAgentID, err = getAgentID(true, 0)
 
+	return err
+}
+
+// downloadAgentBinary it downloads the binary and stores the location of the downloaded file
+// into the Fleet struct, to be used else where
+func (fts *FleetTestSuite) downloadAgentBinary() error {
+	artifact := "elastic-agent"
+	version := "8.0.0-SNAPSHOT"
+	os := "linux"
+	arch := "x86_64"
+	extension := "tar.gz"
+
+	downloadURL, err := e2e.GetElasticArtifactURL(artifact, version, os, arch, extension)
+	if err != nil {
+		return err
+	}
+
+	fts.AgentDownloadName = fmt.Sprintf("%s-%s-%s-%s.%s", artifact, version, os, arch, extension)
+	fts.AgentDownloadPath, err = e2e.DownloadFile(downloadURL)
 	return err
 }
 
@@ -341,7 +362,7 @@ func (fts *FleetTestSuite) anAttemptToEnrollANewAgentFails() error {
 
 	containerName := profile + "_" + fts.BoxType + "_2" // name of the new container
 
-	err := deployAgentToFleet(profile, fts.BoxType, serviceTag, containerName)
+	err := deployAgentToFleet(profile, fts.BoxType, serviceTag, containerName, fts.AgentDownloadPath, fts.AgentDownloadName)
 	if err != nil {
 		return err
 	}
@@ -518,11 +539,14 @@ func createFleetToken(name string, configID string) (*gabs.Container, error) {
 	return tokenItem, nil
 }
 
-func deployAgentToFleet(profile string, service string, serviceTag string, containerName string) error {
+func deployAgentToFleet(profile string, service string, serviceTag string, containerName string, agentBinaryPath string, agentBinaryName string) error {
 	// let's start with Centos 7
 	profileEnv[service+"Tag"] = serviceTag
 	// we are setting the container name because Centos service could be reused by any other test suite
 	profileEnv[service+"ContainerName"] = containerName
+	// define paths where the binary will be mounted
+	profileEnv[service+"AgentBinarySrcPath"] = agentBinaryPath
+	profileEnv[service+"AgentBinaryTargetPath"] = "/" + agentBinaryName
 
 	serviceManager := services.NewServiceManager()
 
@@ -535,34 +559,17 @@ func deployAgentToFleet(profile string, service string, serviceTag string, conta
 		return err
 	}
 
-	// install the agent in the box
+	// extract the agent in the box, as it's mounted as a volume
 	artifact := "elastic-agent"
 	version := "8.0.0-SNAPSHOT"
 	os := "linux"
 	arch := "x86_64"
 	extension := "tar.gz"
 
-	downloadURL, err := e2e.GetElasticArtifactURL(artifact, version, os, arch, extension)
-	if err != nil {
-		return err
-	}
-
-	cmd := []string{"curl", "-L", "-O", downloadURL}
-	err = execCommandInService(profile, service, cmd, false)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"command": cmd,
-			"error":   err,
-			"service": service,
-		}).Error("Could not download agent in box")
-
-		return err
-	}
-
 	extractedDir := fmt.Sprintf("%s-%s-%s-%s", artifact, version, os, arch)
 	tarFile := fmt.Sprintf("%s.%s", extractedDir, extension)
 
-	cmd = []string{"tar", "xzvf", tarFile}
+	cmd := []string{"tar", "xzvf", tarFile}
 	err = execCommandInService(profile, service, cmd, false)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -84,6 +84,13 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 		imts.Fleet.setup()
 
 		imts.StandAlone.RuntimeDependenciesStartDate = time.Now().UTC()
+
+		err = imts.Fleet.downloadAgentBinary()
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error": err,
+			}).Fatal("The Elastic Agent could not be downloaded")
+		}
 	})
 	s.BeforeScenario(func(*messages.Pickle) {
 		log.Debug("Before Ingest Manager scenario")
@@ -100,6 +107,20 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 				"error":   err,
 				"profile": profile,
 			}).Warn("Could not destroy the runtime dependencies for the profile.")
+		}
+
+		if _, err := os.Stat(imts.Fleet.AgentDownloadPath); err == nil {
+			err = os.Remove(imts.Fleet.AgentDownloadPath)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"err":  err,
+					"path": imts.Fleet.AgentDownloadPath,
+				}).Warn("Elastic Agent binary could not be removed.")
+			} else {
+				log.WithFields(log.Fields{
+					"path": imts.Fleet.AgentDownloadPath,
+				}).Debug("Elastic Agent binary was removed.")
+			}
 		}
 	})
 	s.AfterScenario(func(*messages.Pickle, error) {


### PR DESCRIPTION
## What is this PR doing?
It changes the compose file for the vanilla box defining a volume to mount the elastic-agent binary on it. We will use environment variables to configure the src and target of the volume.

That way, we will download the agent binary to a temporary dir before the test suite runs (only once), and will remove it from the file system after the tests suite runs.

## Why is this important?
It will reduce the number of HTTP connections to download the binary to 1, compared to one for each scenario installing an agent. It usually takes from 5 to 10 seconds, so the gain will be (in average) 7'5 times the number of scenarios (6 at this moment).

It will also bring reliability, because the download of the binary is done from the test runner, so it has the retry-with-backoff capabilities, instead of running it from inside the container.

## Related issues
- Closes #177