### PR TITLE
fix: use the status of the agent by hostname

### DIFF
--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -335,18 +335,8 @@ func (fts *FleetTestSuite) theEnrollmentTokenIsRevoked() error {
 		"tokenID": fts.CurrentTokenID,
 	}).Debug("Revoking enrollment token")
 
-	revokeTokenURL := fleetEnrollmentTokenURL + "/" + fts.CurrentTokenID
-	deleteReq := createDefaultHTTPRequest(revokeTokenURL)
-
-	body, err := curl.Delete(deleteReq)
+	err := fts.removeToken()
 	if err != nil {
-		log.WithFields(log.Fields{
-			"token":   fts.CurrentToken,
-			"tokenID": fts.CurrentTokenID,
-			"body":    body,
-			"error":   err,
-			"url":     revokeTokenURL,
-		}).Error("Could revoke token")
 		return err
 	}
 
@@ -387,6 +377,24 @@ func (fts *FleetTestSuite) anAttemptToEnrollANewAgentFails() error {
 		"err":   err,
 		"token": fts.CurrentToken,
 	}).Debug("As expected, it's not possible to enroll an agent with a revoked token")
+	return nil
+}
+
+func (fts *FleetTestSuite) removeToken() error {
+	revokeTokenURL := fleetEnrollmentTokenURL + "/" + fts.CurrentTokenID
+	deleteReq := createDefaultHTTPRequest(revokeTokenURL)
+
+	body, err := curl.Delete(deleteReq)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"tokenID": fts.CurrentTokenID,
+			"body":    body,
+			"error":   err,
+			"url":     revokeTokenURL,
+		}).Error("Could delete token")
+		return err
+	}
+
 	return nil
 }
 

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -36,6 +36,7 @@ type FleetTestSuite struct {
 	ConfigID          string // will be used to manage tokens
 	CurrentToken      string // current enrollment token
 	CurrentTokenID    string // current enrollment tokenID
+	Hostname          string // the hostname of the container
 }
 
 func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
@@ -64,8 +65,15 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleet() error {
 	}
 	fts.Cleanup = true
 
+	// get container hostname once
+	hostname, err := getContainerHostname(containerName)
+	if err != nil {
+		return err
+	}
+	fts.Hostname = hostname
+
 	// enroll the agent with a new token
-	tokenJSONObject, err := createFleetToken(containerName, fts.ConfigID)
+	tokenJSONObject, err := createFleetToken("Test token for "+hostname, fts.ConfigID)
 	if err != nil {
 		return err
 	}

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -65,7 +65,7 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleet() error {
 	fts.Cleanup = true
 
 	// enroll the agent with a new token
-	tokenJSONObject, err := createFleetToken("name", fts.ConfigID)
+	tokenJSONObject, err := createFleetToken(containerName, fts.ConfigID)
 	if err != nil {
 		return err
 	}

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -429,32 +429,6 @@ func checkFleetConfiguration() error {
 	return nil
 }
 
-// isAgentOnline extracts the status for an agent, identified by its hotname
-// It will wuery Fleet's agents endpoint
-func isAgentOnline(hostname string) (bool, error) {
-	jsonResponse, err := getOnlineAgents()
-	if err != nil {
-		return false, err
-	}
-
-	agents := jsonResponse.Path("list")
-
-	for _, agent := range agents.Children() {
-		agentStatus := agent.Path("active").Data().(bool)
-		agentHostname := agent.Path("local_metadata.host.hostname").Data().(string)
-		if agentHostname == hostname {
-			log.WithFields(log.Fields{
-				"active":   agentStatus,
-				"hostname": hostname,
-			}).Debug("Agent status retrieved")
-
-			return agentStatus, nil
-		}
-	}
-
-	return false, fmt.Errorf("The agent '" + hostname + "' was not found in Fleet")
-}
-
 // createFleetConfiguration sends a POST request to Fleet forcing the
 // recreation of the configuration
 func createFleetConfiguration() error {
@@ -750,4 +724,30 @@ func getOnlineAgents() (*gabs.Container, error) {
 	}
 
 	return jsonResponse, nil
+}
+
+// isAgentOnline extracts the status for an agent, identified by its hotname
+// It will wuery Fleet's agents endpoint
+func isAgentOnline(hostname string) (bool, error) {
+	jsonResponse, err := getOnlineAgents()
+	if err != nil {
+		return false, err
+	}
+
+	agents := jsonResponse.Path("list")
+
+	for _, agent := range agents.Children() {
+		agentStatus := agent.Path("active").Data().(bool)
+		agentHostname := agent.Path("local_metadata.host.hostname").Data().(string)
+		if agentHostname == hostname {
+			log.WithFields(log.Fields{
+				"active":   agentStatus,
+				"hostname": hostname,
+			}).Debug("Agent status retrieved")
+
+			return agentStatus, nil
+		}
+	}
+
+	return false, fmt.Errorf("The agent '" + hostname + "' was not found in Fleet")
 }

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -169,6 +169,14 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 			log.WithFields(log.Fields{
 				"service": serviceName,
 			}).Debug("Service removed from compose.")
+
+			err = imts.Fleet.removeToken()
+			if err != nil {
+				log.WithFields(log.Fields{
+					"err":     err,
+					"tokenID": imts.Fleet.CurrentTokenID,
+				}).Warn("The enrollment token could not be deleted")
+			}
 		}
 	})
 }

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -5,12 +5,10 @@
 package main
 
 import (
-	"context"
-	"strings"
+	"fmt"
 	"time"
 
 	"github.com/cucumber/godog"
-	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/cli/services"
 	"github.com/elastic/e2e-testing/e2e"
 	log "github.com/sirupsen/logrus"
@@ -40,6 +38,7 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed() error {
 
 	profile := "ingest-manager"
 	serviceName := "elastic-agent"
+	containerName := fmt.Sprintf("%s_%s_%d", profile, serviceName, 1)
 
 	configurationFileURL := "https://raw.githubusercontent.com/elastic/beats/master/x-pack/elastic-agent/elastic-agent.docker.yml"
 
@@ -58,7 +57,7 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed() error {
 	}
 
 	// get container hostname once
-	hostname, err := getContainerHostname(serviceName)
+	hostname, err := getContainerHostname(containerName)
 	if err != nil {
 		return err
 	}
@@ -129,41 +128,6 @@ func (sats *StandAloneTestSuite) thereIsNoNewDataInTheIndexAfterAgentShutsDown()
 	}
 
 	return e2e.AssertHitsAreNotPresent(result)
-}
-
-// we need the container name because we use the Docker Client instead of Docker Compose
-func getContainerHostname(serviceName string) (string, error) {
-	containerName := "ingest-manager_" + serviceName + "_1"
-
-	log.WithFields(log.Fields{
-		"service":       serviceName,
-		"containerName": containerName,
-	}).Debug("Retrieving container name from the Docker client")
-
-	hostname, err := docker.ExecCommandIntoContainer(context.Background(), containerName, "root", []string{"hostname"})
-	if err != nil {
-		log.WithFields(log.Fields{
-			"containerName": containerName,
-			"error":         err,
-			"service":       serviceName,
-		}).Error("Could not retrieve container name from the Docker client")
-		return "", err
-	}
-
-	if strings.HasPrefix(hostname, "\x01\x00\x00\x00\x00\x00\x00\r") {
-		hostname = strings.ReplaceAll(hostname, "\x01\x00\x00\x00\x00\x00\x00\r", "")
-		log.WithFields(log.Fields{
-			"hostname": hostname,
-		}).Debug("Container name has been sanitized")
-	}
-
-	log.WithFields(log.Fields{
-		"containerName": containerName,
-		"hostname":      hostname,
-		"service":       serviceName,
-	}).Info("Hostname retrieved from the Docker client")
-
-	return hostname, nil
 }
 
 func searchAgentData(hostname string, startDate time.Time, minimumHitsCount int, maxTimeout time.Duration) (e2e.SearchResult, error) {


### PR DESCRIPTION
## What is this PR doing?
It uses the hostname to get the status of the agent, because the hostname value is used as agentID. That way we are able to look up the status of the agent in the response of the API call, which returns a JSON with the list of agents including their active status.

We also revoke/remove the token that is created for the enrollment process (we create it on each scenario)

## Why is it important?
It moves from a testing approach that is based in the existence of only one agent, to an approach that is based in the status of a specific agent (identified by hostname). We need this change because the API should be able to unenroll/remove an agent whenever the container representing it is removed (docker-compose down), and this is not currently happening.

## Related issues
- Relates https://github.com/elastic/beats/issues/20006
- Relates https://github.com/elastic/kibana/pull/72386