### PR TITLE
chore(ci): support overriding the Elastic Agent binary to be used on CI

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
   parameters {
     choice(name: 'runTestsSuite', choices: ['all', 'helm', 'ingest-manager', 'metricbeat'], description: 'Choose which test suite to run (default: all)')
     booleanParam(name: "forceSkipGitChecks", defaultValue: false, description: "If it's needed to check for Git changes to filter by modified sources")
-    string(name: 'ELASTIC_AGENT_HASH', defaultValue: '', description: 'If present, it will override the released version of the Elastic agent artifact.')
+    string(name: 'ELASTIC_AGENT_DOWNLOAD_URL', defaultValue: '', description: 'If present, it will override the download URL for the Elastic agent artifact. (I.e. https://snapshots.elastic.co/8.0.0-59098054/downloads/beats/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz')
     choice(name: 'LOG_LEVEL', choices: ['INFO', 'DEBUG'], description: 'Log level to be used')
     choice(name: 'RETRY_TIMEOUT', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
     string(name: 'STACK_VERSION', defaultValue: '7.8.0', description: 'SemVer version of the stack to be used.')
@@ -48,7 +48,7 @@ pipeline {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin:${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts"
         GO111MODULE = 'on'
         GOPROXY = 'https://proxy.golang.org'
-        ELASTIC_AGENT_HASH = "${params.ELASTIC_AGENT_HASH.trim()}"
+        ELASTIC_AGENT_DOWNLOAD_URL = "${params.ELASTIC_AGENT_DOWNLOAD_URL.trim()}"
         METRICBEAT_VERSION = "${params.METRICBEAT_VERSION.trim()}"
         STACK_VERSION = "${params.STACK_VERSION.trim()}"
         FORCE_SKIP_GIT_CHECKS = "${params.forceSkipGitChecks}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
   parameters {
     choice(name: 'runTestsSuite', choices: ['all', 'helm', 'ingest-manager', 'metricbeat'], description: 'Choose which test suite to run (default: all)')
     booleanParam(name: "forceSkipGitChecks", defaultValue: false, description: "If it's needed to check for Git changes to filter by modified sources")
+    string(name: 'ELASTIC_AGENT_HASH', defaultValue: '', description: 'If present, it will override the released version of the Elastic agent artifact.')
     choice(name: 'LOG_LEVEL', choices: ['INFO', 'DEBUG'], description: 'Log level to be used')
     choice(name: 'RETRY_TIMEOUT', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
     string(name: 'STACK_VERSION', defaultValue: '7.8.0', description: 'SemVer version of the stack to be used.')
@@ -47,6 +48,7 @@ pipeline {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin:${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts"
         GO111MODULE = 'on'
         GOPROXY = 'https://proxy.golang.org'
+        ELASTIC_AGENT_HASH = "${params.ELASTIC_AGENT_HASH.trim()}"
         METRICBEAT_VERSION = "${params.METRICBEAT_VERSION.trim()}"
         STACK_VERSION = "${params.STACK_VERSION.trim()}"
         FORCE_SKIP_GIT_CHECKS = "${params.forceSkipGitChecks}"

--- a/e2e/_suites/ingest-manager/README.md
+++ b/e2e/_suites/ingest-manager/README.md
@@ -39,6 +39,9 @@ The first step in determining the exact failure is to try and reproduce the test
    ```shell
    # There should be a Docker image for the runtime dependencies (elasticsearch, kibana, package registry)
    export OP_STACK_VERSION=8.0.0-SNAPSHOT
+   # This environment variable will use a fixed version of the Elastic agent binary, obtained from
+   # https://artifacts-api.elastic.co/v1/search/8.0.0-SNAPSHOT/elastic-agent
+   export ELASTIC_AGENT_HASH="59098054"
    ```
 
 3. Define the proper Docker images to be used in tests.

--- a/e2e/_suites/ingest-manager/README.md
+++ b/e2e/_suites/ingest-manager/README.md
@@ -41,7 +41,7 @@ The first step in determining the exact failure is to try and reproduce the test
    export OP_STACK_VERSION=8.0.0-SNAPSHOT
    # This environment variable will use a fixed version of the Elastic agent binary, obtained from
    # https://artifacts-api.elastic.co/v1/search/8.0.0-SNAPSHOT/elastic-agent
-   export ELASTIC_AGENT_HASH="59098054"
+   export ELASTIC_AGENT_DOWNLOAD_URL="https://snapshots.elastic.co/8.0.0-59098054/downloads/beats/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz"
    ```
 
 3. Define the proper Docker images to be used in tests.

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -76,13 +76,12 @@ func GetExponentialBackOff(elapsedTime time.Duration) *backoff.ExponentialBackOf
 // Elastic's artifact repository, bbuilding the JSON path query based
 // on the desired OS, architecture and file extension
 // i.e. GetElasticArtifactURL("elastic-agent", "8.0.0-SNAPSHOT", "linux", "x86_64", "tar.gz")
-// If the environment variable ELASTIC_AGENT_HASH exists, then the artifact to be downloaded will
+// If the environment variable ELASTIC_AGENT_DOWNLOAD_URL exists, then the artifact to be downloaded will
 // be defined by that value
 func GetElasticArtifactURL(artifact string, version string, OS string, arch string, extension string) (string, error) {
-	hash := os.Getenv("ELASTIC_AGENT_HASH")
-	if hash != "" {
-		hashedVersion := strings.ReplaceAll(version, "-SNAPSHOT", "")
-		return fmt.Sprintf("https://snapshots.elastic.co/%s-%s/downloads/beats/%s/%s-%s-%s-%s.%s", hashedVersion, hash, artifact, artifact, version, OS, arch, extension), nil
+	downloadURL := os.Getenv("ELASTIC_AGENT_DOWNLOAD_URL")
+	if downloadURL != "" {
+		return downloadURL, nil
 	}
 
 	exp := GetExponentialBackOff(1 * time.Minute)
@@ -146,7 +145,7 @@ func GetElasticArtifactURL(artifact string, version string, OS string, arch stri
 	packagesObject := jsonParsed.Path("packages")
 	// we need to get keys with dots using Search instead of Path
 	downloadObject := packagesObject.Search(artifactPath)
-	downloadURL := downloadObject.Path("url").Data().(string)
+	downloadURL = downloadObject.Path("url").Data().(string)
 
 	return downloadURL, nil
 }

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -76,10 +76,10 @@ func GetExponentialBackOff(elapsedTime time.Duration) *backoff.ExponentialBackOf
 // Elastic's artifact repository, bbuilding the JSON path query based
 // on the desired OS, architecture and file extension
 // i.e. GetElasticArtifactURL("elastic-agent", "8.0.0-SNAPSHOT", "linux", "x86_64", "tar.gz")
-// If the environment variable ARTIFACT_HASH exists, then the artifact to be downloaded will
+// If the environment variable ELASTIC_AGENT_HASH exists, then the artifact to be downloaded will
 // be defined by that value
 func GetElasticArtifactURL(artifact string, version string, OS string, arch string, extension string) (string, error) {
-	hash := os.Getenv("ARTIFACT_HASH")
+	hash := os.Getenv("ELASTIC_AGENT_HASH")
 	if hash != "" {
 		hashedVersion := strings.ReplaceAll(version, "-SNAPSHOT", "")
 		return fmt.Sprintf("https://snapshots.elastic.co/%s-%s/downloads/beats/%s/%s-%s-%s-%s.%s", hashedVersion, hash, artifact, artifact, version, OS, arch, extension), nil


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a new parameter to the Jenkinsfile, which will set an environment variable to the pipeline. This new parameter will allow the user to configure which version of the Agent will be installed during a build. By default, this variable will be empty, which means the tests will use the agent for the current version (i.e. 8.0.0-SNAPSHOT)

In this PR we are refactoring the logic to get that variable, and instead of partially expecting a hash and build the download URL from it, we expect the entire download URL to be configurable.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
This flexibility in the definition of the download URL will help in executing the job with multiple values, also simplifying the calculation of the URL.

Besides that, triggering a job with a specific version of the agent will be simpler, as it would be just a matter of getting it from our artifact system.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
~~- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)~~


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally
Run tests with this new environment variable:
```shell
$ export ELASTIC_AGENT_DOWNLOAD_URL=https://snapshots.elastic.co/8.0.0-59098054/downloads/beats/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz
$ cd e2e/_suites/ingest-manager
$ godog -t fleet_mode
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #188 

## Use cases

Running the tests with different released versions of the agent will be possible.

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->