### PR TITLE
chore: support setting stack version per test suite on Jenkins

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -199,7 +199,7 @@ def generateStep(Map params = [:]){
 def generateFunctionalTestStep(Map params = [:]){
   def suite = params.get('suite')
   def sneakCaseSuite = suite.toUpperCase().replaceAll("-", "_")
-  def stackVersion = env["STACK_VERSION_${sneakCaseSuite}"]
+  def stackVersion = env["STACK_VERSION_${sneakCaseSuite}"]?.trim()
   def feature = params.get('feature')
   return {
     node('ubuntu-18.04 && immutable && docker') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -29,7 +29,8 @@ pipeline {
     string(name: 'ELASTIC_AGENT_DOWNLOAD_URL', defaultValue: '', description: 'If present, it will override the download URL for the Elastic agent artifact. (I.e. https://snapshots.elastic.co/8.0.0-59098054/downloads/beats/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz')
     choice(name: 'LOG_LEVEL', choices: ['INFO', 'DEBUG'], description: 'Log level to be used')
     choice(name: 'RETRY_TIMEOUT', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
-    string(name: 'STACK_VERSION', defaultValue: '7.8.0', description: 'SemVer version of the stack to be used.')
+    string(name: 'STACK_VERSION_INGEST_MANAGER', defaultValue: '8.0.0-SNAPSHOT', description: 'SemVer version of the stack to be used for Ingest Manager tests.')
+    string(name: 'STACK_VERSION_METRICBEAT', defaultValue: '7.8.0', description: 'SemVer version of the stack to be used for Metricbeat tests.')
     string(name: 'METRICBEAT_VERSION', defaultValue: '7.8.0', description: 'SemVer version of the metricbeat to be used.')
     string(name: 'HELM_CHART_VERSION', defaultValue: '7.6.1', description: 'SemVer version of Helm chart to be used.')
     string(name: 'HELM_VERSION', defaultValue: '2.16.3', description: 'SemVer version of Helm to be used.')
@@ -46,7 +47,8 @@ pipeline {
         GO111MODULE = 'on'
         ELASTIC_AGENT_DOWNLOAD_URL = "${params.ELASTIC_AGENT_DOWNLOAD_URL.trim()}"
         METRICBEAT_VERSION = "${params.METRICBEAT_VERSION.trim()}"
-        STACK_VERSION = "${params.STACK_VERSION.trim()}"
+        STACK_VERSION_INGEST_MANAGER = "${params.STACK_VERSION_INGEST_MANAGER.trim()}"
+        STACK_VERSION_METRICBEAT = "${params.STACK_VERSION_METRICBEAT.trim()}"
         FORCE_SKIP_GIT_CHECKS = "${params.forceSkipGitChecks}"
         HELM_CHART_VERSION = "${params.HELM_CHART_VERSION.trim()}"
         HELM_VERSION = "${params.HELM_VERSION.trim()}"
@@ -196,6 +198,8 @@ def generateStep(Map params = [:]){
 
 def generateFunctionalTestStep(Map params = [:]){
   def suite = params.get('suite')
+  def sneakCaseSuite = suite.toUpperCase().replaceAll("-", "_")
+  def stackVersion = env["STACK_VERSION_${sneakCaseSuite}"]
   def feature = params.get('feature')
   return {
     node('ubuntu-18.04 && immutable && docker') {
@@ -209,7 +213,7 @@ def generateFunctionalTestStep(Map params = [:]){
             }
           }
           dir("${BASE_DIR}"){
-            sh script: """.ci/scripts/functional-test.sh "${suite}" "${feature}" "${STACK_VERSION}" "${METRICBEAT_VERSION}" """, label: "Run functional tests for ${suite}:${feature}"
+            sh script: """.ci/scripts/functional-test.sh "${suite}" "${feature}" "${stackVersion}" "${METRICBEAT_VERSION}" """, label: "Run functional tests for ${suite}:${feature}"
           }
         }
       } catch(e) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -199,7 +199,7 @@ def generateStep(Map params = [:]){
 def generateFunctionalTestStep(Map params = [:]){
   def suite = params.get('suite')
   def sneakCaseSuite = suite.toUpperCase().replaceAll("-", "_")
-  def stackVersion = env["STACK_VERSION_${sneakCaseSuite}"]?.trim()
+  def stackVersion = env."STACK_VERSION_${sneakCaseSuite}"
   def feature = params.get('feature')
   return {
     node('ubuntu-18.04 && immutable && docker') {

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -39,6 +39,7 @@ func init() {
 	config.Init()
 
 	queryRetryTimeout = e2e.GetIntegerFromEnv("OP_RETRY_TIMEOUT", queryRetryTimeout)
+	stackVersion = e2e.GetEnv("OP_STACK_VERSION", stackVersion)
 }
 
 func IngestManagerFeatureContext(s *godog.Suite) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a Jenkins param and environment variable per test suite using this variable, so that the execution of the e2e tests is able to use the current test suite to read the proper environment variable.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We want to decouple the versions used for metricbeat and ingest-manager, as the second one uses 8.0.0-SNAPSHOT by default.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #199


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->