### PR TITLE
feat: add a step for restarting the elastic-agent in fleet-mode

### DIFF
--- a/cli/config/compose/services/centos-systemd/docker-compose.yml
+++ b/cli/config/compose/services/centos-systemd/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.3'
+services:
+  centos-systemd:
+    image: centos/systemd:${centos_systemdTag:-latest} 
+    container_name: ${centos_systemdContainerName}
+    entrypoint: "/usr/sbin/init"
+    privileged: true
+    volumes:
+      - ${centos_systemdAgentBinarySrcPath:-.}:${centos_systemdAgentBinaryTargetPath:-/tmp}
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro 

--- a/cli/config/compose/services/debian-systemd/docker-compose.yml
+++ b/cli/config/compose/services/debian-systemd/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.3'
+services:
+  debian-systemd:
+    image: alehaa/debian-systemd:${debian_systemdTag:-stretch}
+    container_name: ${debian_systemdContainerName} 
+    entrypoint: "/sbin/init"
+    privileged: true
+    volumes:
+      - ${debian_systemdAgentBinarySrcPath:-.}:${debian_systemdAgentBinaryTargetPath:-/tmp}
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/cli/config/compose/services/debian/docker-compose.yml
+++ b/cli/config/compose/services/debian/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2.3'
+services:
+  debian:
+    image: debian:${debianTag:-9}
+    container_name: ${debianContainerName} 
+    entrypoint: tail -f /dev/null
+    volumes:
+      - ${debianAgentBinarySrcPath:-.}:${debianAgentBinaryTargetPath:-/tmp}

--- a/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
+++ b/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
@@ -21,6 +21,14 @@ Scenario: Stopping the agent stops backend processes
   Then the "filebeat" process is in the "stopped" state on the host
     And the "metricbeat" process is in the "stopped" state on the host
 
+@restart-agent
+Scenario: Restarting the agent restarts backend processes
+  Given an agent is deployed to Fleet
+  When the host is restarted
+  Then the "elastic-agent" process is in the "started" state on the host
+    And the "filebeat" process is in the "started" state on the host
+    And the "metricbeat" process is in the "started" state on the host
+
 @unenroll
 Scenario: Un-enrolling an agent
   Given an agent is deployed to Fleet

--- a/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
+++ b/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
@@ -29,9 +29,8 @@ Scenario Outline: Restarting a <os> agent restarts backend processes
     And the "filebeat" process is in the "started" state on the host
     And the "metricbeat" process is in the "started" state on the host
 Examples:
-| os     |
-| centos |
-| debian |
+| os             |
+| centos-systemd |
 
 @unenroll
 Scenario: Un-enrolling an agent

--- a/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
+++ b/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
@@ -31,6 +31,7 @@ Scenario Outline: Restarting the <os> host with persistent agent restarts backen
 Examples:
 | os             |
 | centos-systemd |
+| debian-systemd |
 
 @unenroll
 Scenario: Un-enrolling an agent

--- a/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
+++ b/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
@@ -22,12 +22,16 @@ Scenario: Stopping the agent stops backend processes
     And the "metricbeat" process is in the "stopped" state on the host
 
 @restart-agent
-Scenario: Restarting the agent restarts backend processes
-  Given an agent is deployed to Fleet
+Scenario Outline: Restarting a <os> agent restarts backend processes
+  Given an agent running on "<os>" is deployed to Fleet
   When the host is restarted
   Then the "elastic-agent" process is in the "started" state on the host
     And the "filebeat" process is in the "started" state on the host
     And the "metricbeat" process is in the "started" state on the host
+Examples:
+| os     |
+| centos |
+| debian |
 
 @unenroll
 Scenario: Un-enrolling an agent

--- a/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
+++ b/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
@@ -21,8 +21,8 @@ Scenario: Stopping the agent stops backend processes
   Then the "filebeat" process is in the "stopped" state on the host
     And the "metricbeat" process is in the "stopped" state on the host
 
-@restart-agent
-Scenario Outline: Restarting a <os> agent restarts backend processes
+@restart-host
+Scenario Outline: Restarting the <os> host with persistent agent restarts backend processes
   Given an agent running on "<os>" is deployed to Fleet
   When the host is restarted
   Then the "elastic-agent" process is in the "started" state on the host

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -42,6 +42,7 @@ type FleetTestSuite struct {
 func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
 	s.Step(`^an agent is deployed to Fleet$`, fts.anAgentIsDeployedToFleet)
 	s.Step(`^the agent is listed in Fleet as online$`, fts.theAgentIsListedInFleetAsOnline)
+	s.Step(`^the host is restarted$`, fts.theHostIsRestarted)
 	s.Step(`^system package dashboards are listed in Fleet$`, fts.systemPackageDashboardsAreListedInFleet)
 	s.Step(`^the agent is un-enrolled$`, fts.theAgentIsUnenrolled)
 	s.Step(`^the agent is not listed as online in Fleet$`, fts.theAgentIsNotListedAsOnlineInFleet)
@@ -178,6 +179,31 @@ func (fts *FleetTestSuite) theAgentIsListedInFleetAsOnline() error {
 		return err
 	}
 
+	return nil
+}
+
+func (fts *FleetTestSuite) theHostIsRestarted() error {
+	serviceManager := services.NewServiceManager()
+
+	profile := "ingest-manager" // name of the runtime dependencies compose file
+	serviceName := fts.BoxType  // name of the service
+
+	composes := []string{
+		profile,     // profile name
+		serviceName, // service
+	}
+
+	err := serviceManager.RunCommand(profile, composes, []string{"restart", serviceName}, profileEnv)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"service": serviceName,
+		}).Error("Could not restart the service")
+		return err
+	}
+
+	log.WithFields(log.Fields{
+		"service": serviceName,
+	}).Debug("The service has been restarted")
 	return nil
 }
 

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -65,7 +65,6 @@ func (fts *FleetTestSuite) anAgentRunningOnOSIsDeployedToFleet(image string) err
 	installer := fts.Installers[fts.Image]
 
 	profile := installer.profile // name of the runtime dependencies compose file
-	boxType := installer.image   // name of the service type
 
 	serviceName := "elastic-agent"                      // name of the service
 	containerName := profile + "_" + serviceName + "_1" // name of the container
@@ -92,12 +91,6 @@ func (fts *FleetTestSuite) anAgentRunningOnOSIsDeployedToFleet(image string) err
 	fts.CurrentTokenID = tokenJSONObject.Path("id").Data().(string)
 
 	err = enrollAgent(installer, fts.CurrentToken)
-	if err != nil {
-		return err
-	}
-
-	// run the agent
-	err = startAgent(profile, boxType)
 	if err != nil {
 		return err
 	}

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -178,24 +178,24 @@ func (fts *FleetTestSuite) theHostIsRestarted() error {
 
 	installer := fts.Installers[fts.Image]
 
-	profile := installer.profile   // name of the runtime dependencies compose file
-	serviceName := installer.image // name of the service
+	profile := installer.profile // name of the runtime dependencies compose file
+	service := installer.image   // name of the service
 
 	composes := []string{
-		profile,     // profile name
-		serviceName, // service
+		profile, // profile name
+		service, // service
 	}
 
-	err := serviceManager.RunCommand(profile, composes, []string{"restart", serviceName}, profileEnv)
+	err := serviceManager.RunCommand(profile, composes, []string{"restart", service}, profileEnv)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"service": serviceName,
+			"service": service,
 		}).Error("Could not restart the service")
 		return err
 	}
 
 	log.WithFields(log.Fields{
-		"service": serviceName,
+		"service": service,
 	}).Debug("The service has been restarted")
 	return nil
 }
@@ -368,9 +368,9 @@ func (fts *FleetTestSuite) anAttemptToEnrollANewAgentFails() error {
 	installer := fts.Installers[fts.Image]
 
 	profile := installer.profile // name of the runtime dependencies compose file
-	boxType := installer.image   // name of the service
+	service := installer.image   // name of the service
 
-	containerName := profile + "_" + boxType + "_2" // name of the new container
+	containerName := profile + "_" + service + "_2" // name of the new container
 
 	err := deployAgentToFleet(installer, containerName)
 	if err != nil {
@@ -590,17 +590,17 @@ func deployAgentToFleet(installer ElasticAgentInstaller, containerName string) e
 }
 
 func enrollAgent(installer ElasticAgentInstaller, token string) error {
-	profile := installer.profile   // name of the runtime dependencies compose file
-	serviceName := installer.image // name of the service
-	serviceTag := installer.tag    // tag of the service
+	profile := installer.profile // name of the runtime dependencies compose file
+	service := installer.image   // name of the service
+	serviceTag := installer.tag  // tag of the service
 
 	cmd := []string{"elastic-agent", "enroll", "http://kibana:5601", token, "-f", "--insecure"}
-	err := execCommandInService(profile, serviceName, cmd, false)
+	err := execCommandInService(profile, service, cmd, false)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"command": cmd,
 			"error":   err,
-			"service": serviceName,
+			"service": service,
 			"tag":     serviceTag,
 			"token":   token,
 		}).Error("Could not enroll the agent with the token")

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -52,54 +52,7 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
 }
 
 func (fts *FleetTestSuite) anAgentIsDeployedToFleet() error {
-	log.Debug("Deploying an agent to Fleet, using default base")
-
-	fts.Image = "centos"
-
-	installer := fts.Installers[fts.Image]
-
-	profile := installer.profile                        // name of the runtime dependencies compose file
-	boxType := installer.image                          // name of the service type
-	serviceName := "elastic-agent"                      // name of the service
-	containerName := profile + "_" + serviceName + "_1" // name of the container
-	serviceTag := installer.tag                         // docker tag of the service
-
-	err := deployAgentToFleet(profile, boxType, serviceTag, containerName, installer)
-	if err != nil {
-		return err
-	}
-	fts.Cleanup = true
-
-	// get container hostname once
-	hostname, err := getContainerHostname(containerName)
-	if err != nil {
-		return err
-	}
-	fts.Hostname = hostname
-
-	// enroll the agent with a new token
-	tokenJSONObject, err := createFleetToken("Test token for "+hostname, fts.ConfigID)
-	if err != nil {
-		return err
-	}
-	fts.CurrentToken = tokenJSONObject.Path("api_key").Data().(string)
-	fts.CurrentTokenID = tokenJSONObject.Path("id").Data().(string)
-
-	err = enrollAgent(profile, boxType, serviceTag, fts.CurrentToken)
-	if err != nil {
-		return err
-	}
-
-	// run the agent
-	err = startAgent(profile, boxType)
-	if err != nil {
-		return err
-	}
-
-	// get first agentID in online status, for future processing
-	fts.EnrolledAgentID, err = getAgentID(true, 0)
-
-	return err
+	return fts.anAgentRunningOnOSIsDeployedToFleet("centos")
 }
 
 func (fts *FleetTestSuite) anAgentRunningOnOSIsDeployedToFleet(image string) error {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -71,10 +71,10 @@ func (fts *FleetTestSuite) anAgentRunningOnOSIsDeployedToFleet(image string) err
 	containerName := profile + "_" + serviceName + "_1" // name of the container
 
 	err := deployAgentToFleet(installer, containerName)
+	fts.Cleanup = true
 	if err != nil {
 		return err
 	}
-	fts.Cleanup = true
 
 	// get container hostname once
 	hostname, err := getContainerHostname(containerName)
@@ -581,7 +581,7 @@ func deployAgentToFleet(installer ElasticAgentInstaller, containerName string) e
 			"command": cmd,
 			"error":   err,
 			"service": service,
-		}).Error("Could not extract the agent in the box")
+		}).Error("Could not install the agent in the box")
 
 		return err
 	}

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -49,7 +49,7 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 			Installers: map[string]ElasticAgentInstaller{
 				"centos":         GetElasticAgentInstaller("centos"),
 				"centos-systemd": GetElasticAgentInstaller("centos-systemd"),
-				"debian":         GetElasticAgentInstaller("debian"),
+				"debian-systemd": GetElasticAgentInstaller("debian-systemd"),
 			},
 		},
 		StandAlone: &StandAloneTestSuite{},

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -95,13 +95,6 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 		imts.Fleet.setup()
 
 		imts.StandAlone.RuntimeDependenciesStartDate = time.Now().UTC()
-
-		err = imts.Fleet.downloadAgentBinary()
-		if err != nil {
-			log.WithFields(log.Fields{
-				"error": err,
-			}).Fatal("The Elastic Agent could not be downloaded")
-		}
 	})
 	s.BeforeScenario(func(*messages.Pickle) {
 		log.Debug("Before Ingest Manager scenario")

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -46,7 +46,7 @@ func init() {
 func IngestManagerFeatureContext(s *godog.Suite) {
 	imts := IngestManagerTestSuite{
 		Fleet: &FleetTestSuite{
-			Installer: NewCentosInstaller(),
+			Installer: GetElasticAgentInstaller("centos"),
 		},
 		StandAlone: &StandAloneTestSuite{},
 	}

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -45,7 +45,9 @@ func init() {
 
 func IngestManagerFeatureContext(s *godog.Suite) {
 	imts := IngestManagerTestSuite{
-		Fleet:      &FleetTestSuite{},
+		Fleet: &FleetTestSuite{
+			Installer: NewCentosInstaller(),
+		},
 		StandAlone: &StandAloneTestSuite{},
 	}
 	serviceManager := services.NewServiceManager()
@@ -118,16 +120,17 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 			}).Warn("Could not destroy the runtime dependencies for the profile.")
 		}
 
-		if _, err := os.Stat(imts.Fleet.AgentDownloadPath); err == nil {
-			err = os.Remove(imts.Fleet.AgentDownloadPath)
+		agentPath := imts.Fleet.getInstallerPath()
+		if _, err := os.Stat(agentPath); err == nil {
+			err = os.Remove(agentPath)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"err":  err,
-					"path": imts.Fleet.AgentDownloadPath,
+					"path": agentPath,
 				}).Warn("Elastic Agent binary could not be removed.")
 			} else {
 				log.WithFields(log.Fields{
-					"path": imts.Fleet.AgentDownloadPath,
+					"path": agentPath,
 				}).Debug("Elastic Agent binary was removed.")
 			}
 		}
@@ -160,7 +163,7 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 		}
 
 		if imts.Fleet.Cleanup {
-			serviceName := imts.Fleet.BoxType
+			serviceName := imts.Fleet.getInstallerImage()
 
 			services := []string{serviceName}
 

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -229,7 +229,7 @@ func (imts *IngestManagerTestSuite) processStateOnTheHost(process string, state 
 	// because it does not support returning the output of a
 	// command: it simply returns error level
 	serviceName := "ingest-manager_elastic-agent_1"
-	timeout := 3 * time.Minute
+	timeout := time.Minute
 
 	err := e2e.WaitForProcess(serviceName, process, state, timeout)
 	if err != nil {

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -235,7 +235,7 @@ func (imts *IngestManagerTestSuite) processStateOnTheHost(process string, state 
 	// because it does not support returning the output of a
 	// command: it simply returns error level
 	serviceName := "ingest-manager_elastic-agent_1"
-	timeout := time.Minute
+	timeout := 2 * time.Minute
 
 	err := e2e.WaitForProcess(serviceName, process, state, timeout)
 	if err != nil {

--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -1,19 +1,64 @@
 package main
 
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
 // ElasticAgentInstaller represents how to install an agent, depending of the box type
 type ElasticAgentInstaller struct {
 	image         string // docker image
-	installCmds   []string
+	InstallCmds   []string
 	name          string // the name for the binary
 	path          string // the path where the agent for the binary is installed
-	postInstallFn func() error
+	profile       string // parent docker-compose file
+	PostInstallFn func() error
 	tag           string // docker tag
 }
 
 // NewCentosInstaller returns an instance of the Centos installer
 func NewCentosInstaller() ElasticAgentInstaller {
+	image := "centos"
+	tag := "7"
+	profile := "ingest-manager"
+
+	// extract the agent in the box, as it's mounted as a volume
+	artifact := "elastic-agent"
+	version := "8.0.0-SNAPSHOT"
+	os := "linux"
+	arch := "x86_64"
+	extension := "tar.gz"
+
+	extractedDir := fmt.Sprintf("%s-%s-%s-%s", artifact, version, os, arch)
+	tarFile := fmt.Sprintf("%s.%s", extractedDir, extension)
+
+	fn := func() error {
+		// enable elastic-agent in PATH, because we know the location of the binary
+		cmd := []string{"ln", "-s", "/" + extractedDir + "/elastic-agent", "/usr/local/bin/elastic-agent"}
+		err := execCommandInService(profile, image, cmd, false)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"command": cmd,
+				"error":   err,
+				"service": image,
+			}).Error("Could not symlink the agent to PATH")
+
+			return err
+		}
+
+		log.WithFields(log.Fields{
+			"command": cmd,
+			"service": image,
+		}).Debug("The symlink for the agent was created")
+		return nil
+	}
+
 	return ElasticAgentInstaller{
-		image: "centos",
-		tag:   "7",
+		image:         image,
+		InstallCmds:   []string{"tar", "xzvf", tarFile},
+		PostInstallFn: fn,
+		profile:       profile,
+		tag:           tag,
 	}
 }

--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -1,0 +1,19 @@
+package main
+
+// ElasticAgentInstaller represents how to install an agent, depending of the box type
+type ElasticAgentInstaller struct {
+	image         string // docker image
+	installCmds   []string
+	name          string // the name for the binary
+	path          string // the path where the agent for the binary is installed
+	postInstallFn func() error
+	tag           string // docker tag
+}
+
+// NewCentosInstaller returns an instance of the Centos installer
+func NewCentosInstaller() ElasticAgentInstaller {
+	return ElasticAgentInstaller{
+		image: "centos",
+		tag:   "7",
+	}
+}

--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -17,8 +17,18 @@ type ElasticAgentInstaller struct {
 	tag           string // docker tag
 }
 
-// NewCentosInstaller returns an instance of the Centos installer
-func NewCentosInstaller() ElasticAgentInstaller {
+// GetElasticAgentInstaller returns an installer from a docker image
+func GetElasticAgentInstaller(image string) ElasticAgentInstaller {
+	if "centos" == image {
+		return newCentosInstaller()
+	}
+
+	log.WithField("image", image).Fatal("Sorry, we currently do not support this installer")
+	return ElasticAgentInstaller{}
+}
+
+// newCentosInstaller returns an instance of the Centos installer
+func newCentosInstaller() ElasticAgentInstaller {
 	image := "centos"
 	tag := "7"
 	profile := "ingest-manager"

--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -48,7 +48,7 @@ func GetElasticAgentInstaller(image string) ElasticAgentInstaller {
 		return newCentosInstaller("centos", "7")
 	} else if "centos-systemd" == image {
 		return newCentosInstaller("centos-systemd", "latest")
-	} else if "debian" == image {
+	} else if "debian-systemd" == image {
 		return newDebianInstaller()
 	}
 
@@ -108,8 +108,9 @@ func newCentosInstaller(image string, tag string) ElasticAgentInstaller {
 
 // newDebianInstaller returns an instance of the Debian installer
 func newDebianInstaller() ElasticAgentInstaller {
-	image := "debian"
-	tag := "9"
+	image := "debian-systemd"
+	service := image
+	tag := "stretch"
 	profile := "ingest-manager"
 
 	// extract the agent in the box, as it's mounted as a volume
@@ -132,7 +133,7 @@ func newDebianInstaller() ElasticAgentInstaller {
 	}
 
 	fn := func() error {
-		return systemctlInstall(profile, image, image)
+		return systemctlInstall(profile, image, service)
 	}
 
 	return ElasticAgentInstaller{
@@ -147,7 +148,7 @@ func newDebianInstaller() ElasticAgentInstaller {
 		path:              binaryPath,
 		PostInstallFn:     fn,
 		profile:           profile,
-		service:           image, // same service name as image
+		service:           service,
 		tag:               tag,
 	}
 }

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -374,7 +374,7 @@ func WaitForProcess(host string, process string, desiredState string, maxTimeout
 		}
 
 		if mustBePresent {
-			err = fmt.Errorf("Process is not running in the host yet")
+			err = fmt.Errorf("%s process is not running in the host yet", process)
 			log.WithFields(log.Fields{
 				"desiredState": desiredState,
 				"elapsedTime":  exp.GetElapsedTime(),
@@ -384,12 +384,10 @@ func WaitForProcess(host string, process string, desiredState string, maxTimeout
 				"retry":        retryCount,
 			}).Warn(err.Error())
 
-			retryCount++
-
 			return err
 		}
 
-		err = fmt.Errorf("Process is still running in the host")
+		err = fmt.Errorf("%s process is still running in the host", process)
 		log.WithFields(log.Fields{
 			"elapsedTime": exp.GetElapsedTime(),
 			"error":       err,
@@ -398,8 +396,6 @@ func WaitForProcess(host string, process string, desiredState string, maxTimeout
 			"state":       desiredState,
 			"retry":       retryCount,
 		}).Warn(err.Error())
-
-		retryCount++
 
 		return err
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -138,6 +138,12 @@ func GetElasticArtifactURL(artifact string, version string, OS string, arch stri
 	}
 
 	artifactPath := fmt.Sprintf("%s-%s-%s-%s.%s", artifact, version, OS, arch, extension)
+	if extension == "deb" || extension == "rpm" {
+		// elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm
+		// elastic-agent-8.0.0-SNAPSHOT-amd64.deb
+		artifactPath = fmt.Sprintf("%s-%s-%s.%s", artifact, version, arch, extension)
+	}
+
 	packagesObject := jsonParsed.Path("packages")
 	// we need to get keys with dots using Search instead of Path
 	downloadObject := packagesObject.Search(artifactPath)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -384,6 +384,8 @@ func WaitForProcess(host string, process string, desiredState string, maxTimeout
 				"retry":        retryCount,
 			}).Warn(err.Error())
 
+			retryCount++
+
 			return err
 		}
 
@@ -396,6 +398,8 @@ func WaitForProcess(host string, process string, desiredState string, maxTimeout
 			"state":       desiredState,
 			"retry":       retryCount,
 		}).Warn(err.Error())
+
+		retryCount++
 
 		return err
 	}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -353,8 +353,6 @@ func WaitForProcess(host string, process string, desiredState string, maxTimeout
 			return err
 		}
 
-		log.Debugf("pgrep -n -l %s: %s", process, output)
-
 		outputContainsProcess := strings.Contains(output, process)
 
 		// both true or both false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a new Cucumber scenario for restarting an agent, checking for backend proccesses (elastic-agent, filebeat and metricbeat) are back to life.

Because of the benefits of BDD, we are reusing all steps but one, the one to restart a container (we used the word `host` to mean whatever type of host, in our case a container). This new step is invoking `docker-compose restart` for the service representing the agent (a Centos container).

This restart scenario caused a big, major change: instead of using TAR as the installation process, we want to test packages (RPM and DEB), called persistent installers. For that reason we have abstracted the installer to a separate struct, which will manage the life cycle of the installation process. There will be an installer for Centos, Centos using `systemd`, and Debian using `systemd` (to understand more about the need of `systemd`, please read #215).

This installer will use systemd to enable&start the service if needed, or it will simply run the agent right after installing it.

Another minot changes we did was to use a different field to check the status of an agent, to verify whether it's online or not. We also increased the max timeout to check this status, as it takes around 30 seconds for the agent to be marked as online.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We want to check that persistent services (filebeat, metricbeat and the elastic-agent itself) are restarted after the host is restarted, and we expand coverage of the installation process to the official packages (RPM and DEB).

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's checklist
<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Installed RPM in the container and in a VM, to verify the installation of RPM under Centos works
- [x] Installed DEB in the container and in a VM, to verify the installation of RPM under Debian works
- [x] Run all the test suite to verify that no regressions where introduced

## How to test this PR locally
From the root directory of the ingest-manager test suite, run this command:

```shell
$ cd e2e/_suites/ingest-manager
$ OP_LOG_LEVEL=DEBUG godog -t "fleet_mode && restart-host"
```

To run the entire test suite:
```shell
$ cd e2e/_suites/ingest-manager
$ OP_LOG_LEVEL=DEBUG godog -t "fleet_mode"
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #214
- Closes #215 

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->

## Other concerns
I noticed that the backend processes are sometimes not properly stopped after sending `pkill -9 elastic-agent`:

- 2 out of 12 builds failed with that error: https://beats-ci.elastic.co/job/e2e-tests/job/e2e-testing-mbp/job/PR-216/11/testReport/(root)/Fleet%20Mode%20Agent/Initializing___End_To_End_Tests___ingest_manager_fleet_mode___Stopping_the_agent_stops_backend_processes/

Also, about the existence of system package dashboards on Fleet:
- 3 out of 12 builds failed with the `The agent is not online yet` error: https://beats-ci.elastic.co/job/e2e-tests/job/e2e-testing-mbp/job/PR-216/12/testReport/(root)/Fleet%20Mode%20Agent/Initializing___End_To_End_Tests___ingest_manager_fleet_mode___Deploying_an_agent/

IIRC, the flaky test analyser is enabled for this project, right? @elastic/observablt-robots 