### PR TITLE
add slack post for successful jobs too

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -201,6 +201,13 @@ pipeline {
     cleanup {
       notifyBuildResult(analyzeFlakey: true, flakyReportIdx: "reporter-e2e-tests-end-2-end-tests-pipeline-master", prComment: true)
     }
+    success {
+      whenFalse(isPR()) {
+        slackSend(channel: "#${env.SLACK_CHANNEL}", color: 'good',
+                  message: "[${params.runTestsSuite}] Build Passed: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.RUN_DISPLAY_URL}|Open>).",
+                  tokenCredentialId: 'jenkins-slack-integration-token')
+      }
+    }
     unsuccessful {
       whenFalse(isPR()) {
         slackSend(channel: "#${env.SLACK_CHANNEL}", color: 'danger',


### PR DESCRIPTION
This is a change the the reporting / notification to slack when a job passes.  If it fails, we already have notification, but I realize that passing tests should be celebrated and shown off (and keep folks in the habit of thinking of them, even if they pass all the time)

## What does this PR do?

Changes the Jenkins file with a 'success' section.

## Why is it important?
Because it allows for better visibility of test execution

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist
I can admit I don't know how to test this.  Team, can you help confirm?  I suppose it will create a branch in the relating Jenkins and we can poke it there?

