### PR TITLE
typo - not urgent - but totally fun to fix

### DIFF
--- a/e2e/_suites/ingest-manager/README.md
+++ b/e2e/_suites/ingest-manager/README.md
@@ -102,7 +102,7 @@ Example:
 
 ### Setup failures
 
-Sometimes the tests coulf fail to configure or start a product such as Metricbeat, Elasticsearch, etc. To determine why 
+Sometimes the tests could fail to configure or start a product such as Metricbeat, Elasticsearch, etc. To determine why 
 this happened, look at your terminal log in DEBUG mode. If a `docker-compose.yml` file is not present please execute this command:
 
 ```shell


### PR DESCRIPTION
totally fixes the word 'coulf' to be 'could'.