### PR TITLE
fix typo in token delete debug statement

### DIFF
--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -403,7 +403,7 @@ func (fts *FleetTestSuite) removeToken() error {
 			"body":    body,
 			"error":   err,
 			"url":     revokeTokenURL,
-		}).Error("Could delete token")
+		}).Error("Could not delete token")
 		return err
 	}
 


### PR DESCRIPTION
If I'm reading this err code right, then this fixes a small typo / omission in the relating debug line.

I was actually debugging this are and found the line... and it confused me, but only for a second as I was sure it must be inverted!  :)  Easy fix.

here is what the log line looks like:
<img width="1213" alt="Screen Shot 2020-08-20 at 11 24 34 PM" src="https://user-images.githubusercontent.com/12970373/90849029-53b2ef80-e33c-11ea-9e69-8656d27493d8.png">
