### PR TITLE
chore: increase timeout for listing online agents (4e357c90) backport for 7.9.x

### DIFF
--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -122,7 +122,7 @@ func (fts *FleetTestSuite) setup() error {
 func (fts *FleetTestSuite) theAgentIsListedInFleetAsOnline() error {
 	log.Debug("Checking agent is listed in Fleet as online")
 
-	maxTimeout := time.Minute
+	maxTimeout := 2 * time.Minute
 	retryCount := 1
 
 	exp := e2e.GetExponentialBackOff(maxTimeout)
@@ -197,7 +197,7 @@ func (fts *FleetTestSuite) systemPackageDashboardsAreListedInFleet() error {
 	log.Debug("Checking system Package dashboards in Fleet")
 
 	dataStreamsCount := 0
-	maxTimeout := time.Minute
+	maxTimeout := 2 * time.Minute
 	retryCount := 1
 
 	exp := e2e.GetExponentialBackOff(maxTimeout)
@@ -282,7 +282,7 @@ func (fts *FleetTestSuite) theAgentIsUnenrolled() error {
 func (fts *FleetTestSuite) theAgentIsNotListedAsOnlineInFleet() error {
 	log.Debug("Checking if the agent is not listed as online in Fleet")
 
-	maxTimeout := time.Minute
+	maxTimeout := 2 * time.Minute
 	retryCount := 1
 
 	exp := e2e.GetExponentialBackOff(maxTimeout)


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - chore: increase timeout for listing online agents (4e357c90)