### PR TITLE
fix: use systemctl to stop the agent process, otherwise pkill

### DIFF
--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -92,6 +92,11 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleet(image string) error {
 		return err
 	}
 
+	err = systemctlRun(profile, image, image, "start")
+	if err != nil {
+		return err
+	}
+
 	// get first agentID in online status, for future processing
 	fts.EnrolledAgentID, err = getAgentID(true, 0)
 

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -225,14 +225,20 @@ func (imts *IngestManagerTestSuite) processStateChangedOnTheHost(process string,
 		"process": process,
 	}).Debug("Stopping process on the service")
 
-	err := execCommandInService(profile, image, serviceName, []string{"pkill", "-9", process}, false)
+	stopCmds := []string{"pkill", "-9", process}
+	if process == "elastic-agent" {
+		stopCmds = []string{"systemctl", "stop", process}
+	}
+
+	err := execCommandInService(profile, image, serviceName, stopCmds, false)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"action":  state,
-			"error":   err,
-			"service": serviceName,
-			"process": process,
-		}).Error("Could not stop process with 'pkill -9' on the host")
+			"action":   state,
+			"stopCmds": stopCmds,
+			"error":    err,
+			"service":  serviceName,
+			"process":  process,
+		}).Error("Could not stop process on the host")
 
 		return err
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It uses systemctl to stop the elastic-agent service

Thanks to @michalpristas, we also noticed that the order of the execution matters. In the test framework we did (in this particular order):

1. a centos container is spun up
2. we copied the RPM installer and install it
3. we execute systemctl enable
4. we execute systemctl start
5. we create a fleet token
6. we enrol the agent with that token
7. we check the online status <- here it fails

We moved 4. after 6., so that the service is actually started AFTER the enrollment process. Can we check with @dedemorton if this is documented?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Let's stop services using the process manager, and fix a possible issue with how the service must be installed/configured.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/issues/20759

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->