### PR TITLE
[7.9.x] fix: use systemctl to stop the agent process, otherwise pkill (f64c1cbe) | fix: start the agent service ater the enrollment (c6b8d858)

### DIFF
--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -92,6 +92,11 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleet(image string) error {
 		return err
 	}
 
+	err = systemctlRun(profile, image, image, "start")
+	if err != nil {
+		return err
+	}
+
 	// get first agentID in online status, for future processing
 	fts.EnrolledAgentID, err = getAgentID(true, 0)
 

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -225,14 +225,20 @@ func (imts *IngestManagerTestSuite) processStateChangedOnTheHost(process string,
 		"process": process,
 	}).Debug("Stopping process on the service")
 
-	err := execCommandInService(profile, image, serviceName, []string{"pkill", "-9", process}, false)
+	stopCmds := []string{"pkill", "-9", process}
+	if process == "elastic-agent" {
+		stopCmds = []string{"systemctl", "stop", process}
+	}
+
+	err := execCommandInService(profile, image, serviceName, stopCmds, false)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"action":  state,
-			"error":   err,
-			"service": serviceName,
-			"process": process,
-		}).Error("Could not stop process with 'pkill -9' on the host")
+			"action":   state,
+			"stopCmds": stopCmds,
+			"error":    err,
+			"service":  serviceName,
+			"process":  process,
+		}).Error("Could not stop process on the host")
 
 		return err
 	}


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: use systemctl to stop the agent process, otherwise pkill (f64c1cbe)
 - fix: start the agent service ater the enrollment (c6b8d858)