### PR TITLE
[7.9.x] notify green builds for ingest-manager

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
     choice(name: 'runTestsSuite', choices: ['all', 'helm', 'ingest-manager', 'metricbeat'], description: 'Choose which test suite to run (default: all)')
     booleanParam(name: "forceSkipGitChecks", defaultValue: false, description: "If it's needed to check for Git changes to filter by modified sources")
     booleanParam(name: "forceSkipPresubmit", defaultValue: false, description: "If it's needed to execute the pre-submit tests: unit and precommit.")
+    booleanParam(name: "notifyOnGreenBuilds", defaultValue: false, description: "If it's needed to notify with green builds.")
     string(name: 'SLACK_CHANNEL', defaultValue: 'observablt-robots', description: 'The Slack channel where errors will be posted')
     string(name: 'ELASTIC_AGENT_DOWNLOAD_URL', defaultValue: '', description: 'If present, it will override the download URL for the Elastic agent artifact. (I.e. https://snapshots.elastic.co/7.9.0-81c43e7b/downloads/beats/elastic-agent/elastic-agent-7.9.0-linux-x86_64.tar.gz')
     string(name: 'ELASTIC_AGENT_VERSION', defaultValue: '7.9.0', description: 'SemVer version of the stand-alone elastic-agent to be used for Ingest Manager tests. You can use here the tag of your PR to test your changes')
@@ -200,6 +201,13 @@ pipeline {
   post {
     cleanup {
       notifyBuildResult(analyzeFlakey: true, flakyReportIdx: "reporter-e2e-tests-end-2-end-tests-pipeline-7.9.x", prComment: true)
+    }
+    success {
+      whenTrue(!isPR() && params.notifyOnGreenBuilds) {
+        slackSend(channel: "#${env.SLACK_CHANNEL}", color: 'good',
+                  message: "[${params.runTestsSuite}] Build Passed: ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.RUN_DISPLAY_URL}|Open>).",
+                  tokenCredentialId: 'jenkins-slack-integration-token')
+      }
     }
     unsuccessful {
       whenFalse(isPR()) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
     string(name: 'ELASTIC_AGENT_DOWNLOAD_URL', defaultValue: '', description: 'If present, it will override the download URL for the Elastic agent artifact. (I.e. https://snapshots.elastic.co/7.9.0-81c43e7b/downloads/beats/elastic-agent/elastic-agent-7.9.0-linux-x86_64.tar.gz')
     string(name: 'ELASTIC_AGENT_VERSION', defaultValue: '7.9.0', description: 'SemVer version of the stand-alone elastic-agent to be used for Ingest Manager tests. You can use here the tag of your PR to test your changes')
     booleanParam(name: "ELASTIC_AGENT_USE_CI_SNAPSHOTS", defaultValue: false, description: "If it's needed to use the binary snapshots produced by Beats CI instead of the official releases")
-    choice(name: 'LOG_LEVEL', choices: ['INFO', 'DEBUG'], description: 'Log level to be used')
+    choice(name: 'LOG_LEVEL', choices: ['DEBUG', 'INFO'], description: 'Log level to be used')
     choice(name: 'RETRY_TIMEOUT', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
     string(name: 'INGEST_MANAGER_STACK_VERSION', defaultValue: '7.9.0', description: 'SemVer version of the stack to be used for Ingest Manager tests.')
     string(name: 'METRICBEAT_STACK_VERSION', defaultValue: '7.9.0', description: 'SemVer version of the stack to be used for Metricbeat tests.')

--- a/.ci/e2eTestingIngestManagerDaily.groovy
+++ b/.ci/e2eTestingIngestManagerDaily.groovy
@@ -44,6 +44,7 @@ pipeline {
           parameters: [
             booleanParam(name: 'forceSkipGitChecks', value: true),
             booleanParam(name: 'forceSkipPresubmit', value: true),
+            booleanParam(name: 'notifyOnGreenBuilds', value: true),
             string(name: 'runTestsSuite', value: 'ingest-manager'),
             string(name: 'SLACK_CHANNEL', value: "ingest-management"),
           ],

--- a/cli/services/manager.go
+++ b/cli/services/manager.go
@@ -78,12 +78,16 @@ func (sm *DockerServiceManager) RemoveServicesFromCompose(profile string, compos
 		err := executeCompose(sm, true, newComposeNames, command, persistedEnv)
 		if err != nil {
 			log.WithFields(log.Fields{
-				"command":  command,
-				"services": composeNames,
-				"profile":  profile,
-			}).Error("Could not remove services")
+				"command": command,
+				"service": composeName,
+				"profile": profile,
+			}).Error("Could not remove service from compose")
 			return err
 		}
+		log.WithFields(log.Fields{
+			"profile": profile,
+			"service": composeName,
+		}).Debug("Service removed from compose")
 	}
 
 	return nil

--- a/e2e/_suites/ingest-manager/README.md
+++ b/e2e/_suites/ingest-manager/README.md
@@ -74,7 +74,7 @@ This is an example of the optional configuration:
    If you want to run the tests in Developer mode, which means reusing bakend services between test runs, please set this environment variable first:
 
    ```shell
-   # It won't tear down the backend services (ES, Kibana, Package Registry) after a test suite. 
+   # It won't tear down the backend services (ES, Kibana, Package Registry) or agent services after a test suite. 
    export DEVELOPER_MODE=true
    ```
 

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -154,19 +154,11 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 
 		if imts.StandAlone.Cleanup {
 			serviceName := "elastic-agent"
-
-			services := []string{serviceName}
-
-			err := serviceManager.RemoveServicesFromCompose("ingest-manager", services, profileEnv)
-			if err != nil {
-				log.WithFields(log.Fields{
-					"service": serviceName,
-				}).Error("Could not stop the service.")
+			if !developerMode {
+				_ = serviceManager.RemoveServicesFromCompose("ingest-manager", []string{serviceName}, profileEnv)
+			} else {
+				log.WithField("service", serviceName).Info("Because we are running in development mode, the service won't be stopped")
 			}
-
-			log.WithFields(log.Fields{
-				"service": serviceName,
-			}).Debug("Service removed from compose.")
 
 			if _, err := os.Stat(imts.StandAlone.AgentConfigFilePath); err == nil {
 				os.Remove(imts.StandAlone.AgentConfigFilePath)
@@ -178,21 +170,13 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 
 		if imts.Fleet.Cleanup {
 			serviceName := imts.Fleet.Image
-
-			services := []string{serviceName}
-
-			err := serviceManager.RemoveServicesFromCompose("ingest-manager", services, profileEnv)
-			if err != nil {
-				log.WithFields(log.Fields{
-					"service": serviceName,
-				}).Error("Could not stop the service.")
+			if !developerMode {
+				_ = serviceManager.RemoveServicesFromCompose("ingest-manager", []string{serviceName}, profileEnv)
+			} else {
+				log.WithField("service", serviceName).Info("Because we are running in development mode, the service won't be stopped")
 			}
 
-			log.WithFields(log.Fields{
-				"service": serviceName,
-			}).Debug("Service removed from compose.")
-
-			err = imts.Fleet.removeToken()
+			err := imts.Fleet.removeToken()
 			if err != nil {
 				log.WithFields(log.Fields{
 					"err":     err,

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -117,11 +117,6 @@ func (sats *StandAloneTestSuite) theDockerContainerIsStopped(serviceName string)
 
 	err := serviceManager.RemoveServicesFromCompose("ingest-manager", []string{serviceName}, profileEnv)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"error":   err,
-			"service": serviceName,
-		}).Error("Could not stop the service.")
-
 		return err
 	}
 	sats.AgentStoppedDate = time.Now().UTC()

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -131,15 +131,6 @@ func (mts *MetricbeatTestSuite) CleanUp() error {
 	}
 
 	err := serviceManager.RemoveServicesFromCompose("metricbeat", services, env)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"service": mts.ServiceName,
-		}).Error("Could not stop the service.")
-	}
-
-	log.WithFields(log.Fields{
-		"service": mts.ServiceName,
-	}).Debug("Service removed from compose.")
 
 	if mts.cleanUpTmpFiles {
 		if _, err := os.Stat(mts.configurationFile); err == nil {


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - chore: use debug in CI by default (6341a9a7)
 - chore: support notifying on green builds using a param (dac43608)
 - chore: notify green builds for ingest management scheduled builds (e9bbb2c3)
 - chore: optimise removing services (#241)