### PR TITLE
fix: fail the stage but not the build with pre-commit failures

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -100,8 +100,10 @@ pipeline {
                   unstash 'source'
                   withGoEnv(version: "${GO_VERSION}"){
                     dir(BASE_DIR){
-                      sh script: '.ci/scripts/install-dependencies.sh', label: 'Install dependencies'
-                      preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+                      catchError(message: 'There were some failures when running pre-commit checks', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+                        sh script: '.ci/scripts/install-dependencies.sh', label: 'Install dependencies'
+                        preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+                      } 
                     }
                   }
                 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It catches any error in the pre-commit stage, marking the stage as UNSTABLE but not failing the build.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Because of the project layout, with two different projects under the same repo, the pre-commit step catches lint errors with a lot of frequency, even though the local lint and compilation process passes. We want the build to have more reliability, and the lint flakiness could reduce it.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Executed pre-commit locally to verify Jenkinsfile's structure
- [x] Compared with an existing pipeline catching errors (shared-pipeline's notifyBuildResult.groovy)


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots
<img width="1412" alt="Screenshot 2020-08-27 at 12 58 33" src="https://user-images.githubusercontent.com/951580/91434415-13380200-e865-11ea-92bb-7841c1061456.png">

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->