### PR TITLE
fix: fail the stage but not the build with pre-commit failures (#247) backport for 7.9.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -100,8 +100,10 @@ pipeline {
                   unstash 'source'
                   withGoEnv(version: "${GO_VERSION}"){
                     dir(BASE_DIR){
-                      sh script: '.ci/scripts/install-dependencies.sh', label: 'Install dependencies'
-                      preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+                      catchError(message: 'There were some failures when running pre-commit checks', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+                        sh script: '.ci/scripts/install-dependencies.sh', label: 'Install dependencies'
+                        preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+                      } 
                     }
                   }
                 }


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: fail the stage but not the build with pre-commit failures (#247)