### PR TITLE
feat: run fleet scenarios for both Centos and Debian (#246) | fix: use Scenario Outline (#250) backport for 7.9.x

### DIFF
--- a/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
+++ b/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
@@ -3,7 +3,7 @@ Feature: Fleet Mode Agent
   Scenarios for the Agent in Fleet mode connecting to Ingest Manager application.
 
 @enroll
-Scenario: Deploying the <os> agent
+Scenario Outline: Deploying the <os> agent
   When a "<os>" agent is deployed to Fleet
   Then the agent is listed in Fleet as online
     And system package dashboards are listed in Fleet
@@ -13,7 +13,7 @@ Examples:
 | debian |
 
 @start-agent
-Scenario: Starting the <os> agent starts backend processes
+Scenario Outline: Starting the <os> agent starts backend processes
   When a "<os>" agent is deployed to Fleet
   Then the "filebeat" process is in the "started" state on the host
     And the "metricbeat" process is in the "started" state on the host
@@ -23,7 +23,7 @@ Examples:
 | debian |
 
 @stop-agent
-Scenario: Stopping the <os> agent stops backend processes
+Scenario Outline: Stopping the <os> agent stops backend processes
   Given a "<os>" agent is deployed to Fleet
   When the "elastic-agent" process is "stopped" on the host
   Then the "filebeat" process is in the "stopped" state on the host
@@ -46,7 +46,7 @@ Examples:
 | debian |
 
 @unenroll
-Scenario: Un-enrolling the <os> agent
+Scenario Outline: Un-enrolling the <os> agent
   Given a "<os>" agent is deployed to Fleet
   When the agent is un-enrolled
   Then the "elastic-agent" process is in the "started" state on the host
@@ -57,7 +57,7 @@ Examples:
 | debian |
 
 @reenroll
-Scenario: Re-enrolling the <os> agent
+Scenario Outline: Re-enrolling the <os> agent
   Given a "<os>" agent is deployed to Fleet
     And the agent is un-enrolled
     And the "elastic-agent" process is "stopped" on the host
@@ -70,7 +70,7 @@ Examples:
 | debian |
 
 @revoke-token
-Scenario: Revoking the enrollment token for the <os> agent
+Scenario Outline: Revoking the enrollment token for the <os> agent
   Given a "<os>" agent is deployed to Fleet
   When the enrollment token is revoked
   Then an attempt to enroll a new agent fails

--- a/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
+++ b/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
@@ -3,23 +3,35 @@ Feature: Fleet Mode Agent
   Scenarios for the Agent in Fleet mode connecting to Ingest Manager application.
 
 @enroll
-Scenario: Deploying an agent
-  When a "centos" agent is deployed to Fleet
+Scenario: Deploying the <os> agent
+  When a "<os>" agent is deployed to Fleet
   Then the agent is listed in Fleet as online
     And system package dashboards are listed in Fleet
+Examples:
+| os     |
+| centos |
+| debian |
 
 @start-agent
-Scenario: Starting the agent starts backend processes
-  When a "centos" agent is deployed to Fleet
+Scenario: Starting the <os> agent starts backend processes
+  When a "<os>" agent is deployed to Fleet
   Then the "filebeat" process is in the "started" state on the host
     And the "metricbeat" process is in the "started" state on the host
+Examples:
+| os     |
+| centos |
+| debian |
 
 @stop-agent
-Scenario: Stopping the agent stops backend processes
-  Given a "centos" agent is deployed to Fleet
+Scenario: Stopping the <os> agent stops backend processes
+  Given a "<os>" agent is deployed to Fleet
   When the "elastic-agent" process is "stopped" on the host
   Then the "filebeat" process is in the "stopped" state on the host
     And the "metricbeat" process is in the "stopped" state on the host
+Examples:
+| os     |
+| centos |
+| debian |
 
 @restart-host
 Scenario Outline: Restarting the <os> host with persistent agent restarts backend processes
@@ -34,23 +46,35 @@ Examples:
 | debian |
 
 @unenroll
-Scenario: Un-enrolling an agent
-  Given a "centos" agent is deployed to Fleet
+Scenario: Un-enrolling the <os> agent
+  Given a "<os>" agent is deployed to Fleet
   When the agent is un-enrolled
   Then the "elastic-agent" process is in the "started" state on the host
     But the agent is not listed as online in Fleet
+Examples:
+| os     |
+| centos |
+| debian |
 
 @reenroll
-Scenario: Re-enrolling an agent
-  Given a "centos" agent is deployed to Fleet
+Scenario: Re-enrolling the <os> agent
+  Given a "<os>" agent is deployed to Fleet
     And the agent is un-enrolled
     And the "elastic-agent" process is "stopped" on the host
   When the agent is re-enrolled on the host
     And the "elastic-agent" process is "started" on the host
   Then the agent is listed in Fleet as online
+Examples:
+| os     |
+| centos |
+| debian |
 
 @revoke-token
-Scenario: Revoking the enrollment token for an agent
-  Given a "centos" agent is deployed to Fleet
+Scenario: Revoking the enrollment token for the <os> agent
+  Given a "<os>" agent is deployed to Fleet
   When the enrollment token is revoked
   Then an attempt to enroll a new agent fails
+Examples:
+| os     |
+| centos |
+| debian |

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -26,6 +27,15 @@ import (
 // them running to speed up the development cycle.
 // It can be overriden by the DEVELOPER_MODE env var
 var developerMode = false
+
+// ElasticAgentProcessName the name of the process for the Elastic Agent
+const ElasticAgentProcessName = "elastic-agent"
+
+// ElasticAgentServiceName the name of the service for the Elastic Agent
+const ElasticAgentServiceName = "elastic-agent"
+
+// IngestManagerProfileName the name of the profile to run the runtime, backend services
+const IngestManagerProfileName = "ingest-manager"
 
 // stackVersion is the version of the stack to use
 // It can be overriden by STACK_VERSION env var
@@ -67,7 +77,6 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 	serviceManager := services.NewServiceManager()
 
 	s.Step(`^the "([^"]*)" process is in the "([^"]*)" state on the host$`, imts.processStateOnTheHost)
-	s.Step(`^the "([^"]*)" process is "([^"]*)" on the host$`, imts.processStateChangedOnTheHost)
 
 	imts.Fleet.contributeSteps(s)
 	imts.StandAlone.contributeSteps(s)
@@ -81,7 +90,7 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 			"kibanaConfigPath": path.Join(workDir, "configurations", "kibana.config.yml"),
 		}
 
-		profile := "ingest-manager"
+		profile := IngestManagerProfileName
 		err := serviceManager.RunCompose(true, []string{profile}, profileEnv)
 		if err != nil {
 			log.WithFields(log.Fields{
@@ -118,7 +127,7 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 	s.AfterSuite(func() {
 		if !developerMode {
 			log.Debug("Destroying ingest-manager runtime dependencies")
-			profile := "ingest-manager"
+			profile := IngestManagerProfileName
 
 			err := serviceManager.StopCompose(true, []string{profile})
 			if err != nil {
@@ -153,9 +162,9 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 		log.Debug("After Ingest Manager scenario")
 
 		if imts.StandAlone.Cleanup {
-			serviceName := "elastic-agent"
+			serviceName := ElasticAgentServiceName
 			if !developerMode {
-				_ = serviceManager.RemoveServicesFromCompose("ingest-manager", []string{serviceName}, profileEnv)
+				_ = serviceManager.RemoveServicesFromCompose(IngestManagerProfileName, []string{serviceName}, profileEnv)
 			} else {
 				log.WithField("service", serviceName).Info("Because we are running in development mode, the service won't be stopped")
 			}
@@ -171,7 +180,7 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 		if imts.Fleet.Cleanup {
 			serviceName := imts.Fleet.Image
 			if !developerMode {
-				_ = serviceManager.RemoveServicesFromCompose("ingest-manager", []string{serviceName}, profileEnv)
+				_ = serviceManager.RemoveServicesFromCompose(IngestManagerProfileName, []string{serviceName}, profileEnv)
 			} else {
 				log.WithField("service", serviceName).Info("Because we are running in development mode, the service won't be stopped")
 			}
@@ -184,6 +193,9 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 				}).Warn("The enrollment token could not be deleted")
 			}
 		}
+
+		imts.Fleet.Image = ""
+		imts.StandAlone.Hostname = ""
 	})
 }
 
@@ -193,63 +205,38 @@ type IngestManagerTestSuite struct {
 	StandAlone *StandAloneTestSuite
 }
 
-func (imts *IngestManagerTestSuite) processStateChangedOnTheHost(process string, state string) error {
-	profile := "ingest-manager"
-	image := "centos-systemd"
-	serviceName := "centos-systemd"
+func (imts *IngestManagerTestSuite) processStateOnTheHost(process string, state string) error {
+	profile := IngestManagerProfileName
+	serviceName := ElasticAgentServiceName
 
-	if state == "started" {
-		return startAgent(profile, image, serviceName)
-	} else if state != "stopped" {
-		return godog.ErrPending
+	containerName := fmt.Sprintf("%s_%s_%s_%d", profile, imts.Fleet.Image, serviceName, 1)
+	if imts.StandAlone.Hostname != "" {
+		containerName = fmt.Sprintf("%s_%s_%d", profile, serviceName, 1)
 	}
 
-	log.WithFields(log.Fields{
-		"service": serviceName,
-		"process": process,
-	}).Debug("Stopping process on the service")
-
-	stopCmds := []string{"pkill", "-9", process}
-	if process == "elastic-agent" {
-		stopCmds = []string{"systemctl", "stop", process}
-	}
-
-	err := execCommandInService(profile, image, serviceName, stopCmds, false)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"action":   state,
-			"stopCmds": stopCmds,
-			"error":    err,
-			"service":  serviceName,
-			"process":  process,
-		}).Error("Could not stop process on the host")
-
-		return err
-	}
-
-	// check process was stopped
-	return imts.processStateOnTheHost(process, "stopped")
+	return checkProcessStateOnTheHost(containerName, process, state)
 }
 
-func (imts *IngestManagerTestSuite) processStateOnTheHost(process string, state string) error {
-	// name of the container for the service:
-	// we are using the Docker client instead of docker-compose
-	// because it does not support returning the output of a
-	// command: it simply returns error level
-	serviceName := "ingest-manager_elastic-agent_1"
+// name of the container for the service:
+// we are using the Docker client instead of docker-compose
+// because it does not support returning the output of a
+// command: it simply returns error level
+func checkProcessStateOnTheHost(containerName string, process string, state string) error {
 	timeout := 4 * time.Minute
 
-	err := e2e.WaitForProcess(serviceName, process, state, timeout)
+	err := e2e.WaitForProcess(containerName, process, state, timeout)
 	if err != nil {
 		if state == "started" {
 			log.WithFields(log.Fields{
-				"error":   err,
-				"timeout": timeout,
+				"container ": containerName,
+				"error":      err,
+				"timeout":    timeout,
 			}).Error("The process was not found but should be present")
 		} else {
 			log.WithFields(log.Fields{
-				"error":   err,
-				"timeout": timeout,
+				"container": containerName,
+				"error":     err,
+				"timeout":   timeout,
 			}).Error("The process was found but shouldn't be present")
 		}
 

--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -30,6 +30,7 @@ type ElasticAgentInstaller struct {
 	InstallCmds       []string
 	name              string // the name for the binary
 	path              string // the local path where the agent for the binary is located
+	processName       string // name of the elastic-agent process
 	profile           string // parent docker-compose file
 	PostInstallFn     func() error
 	service           string // name of the service
@@ -69,7 +70,7 @@ func GetElasticAgentInstaller(image string) ElasticAgentInstaller {
 // newCentosInstaller returns an instance of the Centos installer
 func newCentosInstaller(image string, tag string) ElasticAgentInstaller {
 	service := image
-	profile := "ingest-manager"
+	profile := IngestManagerProfileName
 
 	// extract the agent in the box, as it's mounted as a volume
 	artifact := "elastic-agent"
@@ -91,12 +92,7 @@ func newCentosInstaller(image string, tag string) ElasticAgentInstaller {
 	}
 
 	fn := func() error {
-		return startAgent(profile, image, service)
-	}
-	if image == "centos-systemd" {
-		fn = func() error {
-			return systemctlRun(profile, image, service, "enable")
-		}
+		return systemctlRun(profile, image, service, "enable")
 	}
 
 	return ElasticAgentInstaller{
@@ -110,6 +106,7 @@ func newCentosInstaller(image string, tag string) ElasticAgentInstaller {
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     fn,
+		processName:       ElasticAgentProcessName,
 		profile:           profile,
 		service:           service,
 		tag:               tag,
@@ -121,7 +118,7 @@ func newDebianInstaller() ElasticAgentInstaller {
 	image := "debian-systemd"
 	service := image
 	tag := "stretch"
-	profile := "ingest-manager"
+	profile := IngestManagerProfileName
 
 	// extract the agent in the box, as it's mounted as a volume
 	artifact := "elastic-agent"
@@ -157,37 +154,15 @@ func newDebianInstaller() ElasticAgentInstaller {
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     fn,
+		processName:       ElasticAgentProcessName,
 		profile:           profile,
 		service:           service,
 		tag:               tag,
 	}
 }
 
-func startAgent(profile string, image string, service string) error {
-	cmd := []string{"elastic-agent", "run"}
-	err := execCommandInService(profile, image, service, cmd, true)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"command": cmd,
-			"error":   err,
-			"image":   image,
-			"service": service,
-		}).Error("Could not run the agent")
-
-		return err
-	}
-
-	log.WithFields(log.Fields{
-		"command": cmd,
-		"image":   image,
-		"service": service,
-	}).Debug("Agent run")
-
-	return nil
-}
-
 func systemctlRun(profile string, image string, service string, command string) error {
-	cmd := []string{"systemctl", command, "elastic-agent"}
+	cmd := []string{"systemctl", command, ElasticAgentProcessName}
 	err := execCommandInService(profile, image, service, cmd, false)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -49,8 +49,8 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed() error {
 
 	serviceManager := services.NewServiceManager()
 
-	profile := "ingest-manager"
-	serviceName := "elastic-agent"
+	profile := IngestManagerProfileName
+	serviceName := ElasticAgentServiceName
 	containerName := fmt.Sprintf("%s_%s_%d", profile, serviceName, 1)
 
 	configurationFileURL := "https://raw.githubusercontent.com/elastic/beats/" + standAloneVersion + "/x-pack/elastic-agent/elastic-agent.docker.yml"
@@ -115,7 +115,7 @@ func (sats *StandAloneTestSuite) thereIsNewDataInTheIndexFromAgent() error {
 func (sats *StandAloneTestSuite) theDockerContainerIsStopped(serviceName string) error {
 	serviceManager := services.NewServiceManager()
 
-	err := serviceManager.RemoveServicesFromCompose("ingest-manager", []string{serviceName}, profileEnv)
+	err := serviceManager.RemoveServicesFromCompose(IngestManagerProfileName, []string{serviceName}, profileEnv)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - feat: run fleet scenarios for both Centos and Debian (#246)
 - fix: use Scenario Outline (#250)