### PR TITLE
fix: do not update state status when catching lint errors (#255) backport for 7.9.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
                   unstash 'source'
                   withGoEnv(version: "${GO_VERSION}"){
                     dir(BASE_DIR){
-                      catchError(message: 'There were some failures when running pre-commit checks', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+                      catchError(message: 'There were some failures when running pre-commit checks', buildResult: 'SUCCESS') {
                         sh script: '.ci/scripts/install-dependencies.sh', label: 'Install dependencies'
                         preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
                       } 


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: do not update state status when catching lint errors (#255)