### PR TITLE
docs: generate a website with the specs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -148,6 +148,7 @@ pipeline {
           steps {
             deleteDir()
             unstash 'source'
+            dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
             dir("${BASE_DIR}/e2e") {
               sh(label: 'Build docs', script: 'make build-docs')
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -191,10 +191,11 @@ pipeline {
             unstash 'source'
             dir("${BASE_DIR}/e2e") {
               sh(label: 'Build docs', script: 'make build-docs')
-          }
-          post {
-            always {
-              archiveArtifacts allowEmptyArchive: true, artifacts: "${BASE_DIR}/e2e/docs/**"
+            }
+            post {
+              always {
+                archiveArtifacts allowEmptyArchive: true, artifacts: "${BASE_DIR}/e2e/docs/**"
+              }
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -177,6 +177,27 @@ pipeline {
             }
           }
         }
+        stage('Build Docs') {
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            anyOf {
+              expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
+              expression { return env.SKIP_TESTS == "false" }
+            }
+          }
+          steps {
+            deleteDir()
+            unstash 'source'
+            dir("${BASE_DIR}/e2e") {
+              sh(label: 'Build docs', script: 'make build-docs')
+          }
+          post {
+            always {
+              archiveArtifacts allowEmptyArchive: true, artifacts: "${BASE_DIR}/e2e/docs/**"
+            }
+          }
+        }
         stage('Release') {
           options { skipDefaultCheckout() }
           when { tag "v*" }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -152,11 +152,11 @@ pipeline {
             dir("${BASE_DIR}/e2e") {
               sh(label: 'Build docs', script: 'make build-docs')
             }
-            post {
-              always {
-                dir("${BASE_DIR}") {
-                  archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/docs/**"
-                }
+          }
+          post {
+            always {
+              dir("${BASE_DIR}") {
+                archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/docs/**"
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -136,6 +136,28 @@ pipeline {
             }
           }
         }
+        stage('Build Docs') {
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            anyOf {
+              expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
+              expression { return env.SKIP_TESTS == "false" }
+            }
+          }
+          steps {
+            deleteDir()
+            unstash 'source'
+            dir("${BASE_DIR}/e2e") {
+              sh(label: 'Build docs', script: 'make build-docs')
+            }
+            post {
+              always {
+                archiveArtifacts allowEmptyArchive: true, artifacts: "${BASE_DIR}/e2e/docs/**"
+              }
+            }
+          }
+        }
         stage('End-To-End Tests') {
           options { skipDefaultCheckout() }
           environment {
@@ -173,28 +195,6 @@ pipeline {
                   }
                   parallel(parallelTasks)
                 }
-              }
-            }
-          }
-        }
-        stage('Build Docs') {
-          options { skipDefaultCheckout() }
-          when {
-            beforeAgent true
-            anyOf {
-              expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
-              expression { return env.SKIP_TESTS == "false" }
-            }
-          }
-          steps {
-            deleteDir()
-            unstash 'source'
-            dir("${BASE_DIR}/e2e") {
-              sh(label: 'Build docs', script: 'make build-docs')
-            }
-            post {
-              always {
-                archiveArtifacts allowEmptyArchive: true, artifacts: "${BASE_DIR}/e2e/docs/**"
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -153,7 +153,9 @@ pipeline {
             }
             post {
               always {
-                archiveArtifacts allowEmptyArchive: true, artifacts: "${BASE_DIR}/e2e/docs/**"
+                dir("${BASE_DIR}") {
+                  archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/docs/**"
+                }
               }
             }
           }

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,6 +1,7 @@
 godog.test
 report.xml
 
+docs
 outputs/*
 !outputs/.touch
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -20,7 +20,7 @@ GOARCH?='amd64'
 .PHONT: build-docs
 build-docs:
 	rm -fr docs
-	@docker run --rm -v $(PWD):/suites docker.elastic.co/observavbility-ci/picklesdoc:$(PICKLES_VERSION) -f /suites -o /suites/docs --sn "E2E Testing" --sv $(VERSION_VALUE)
+	@docker run --rm -v $(PWD):/suites docker.elastic.co/observability-ci/picklesdoc:$(PICKLES_VERSION) -f /suites -o /suites/docs --sn "E2E Testing" --sv $(VERSION_VALUE)
 	# because pickledocs is a Windows tool, there is a wrong slash.
 	mv docs/.\\/index.html docs/index.html
 	rm -fr docs/.\\

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -6,6 +6,7 @@ LOG_LEVEL?=INFO
 RETRY_TIMEOUT?=3
 STACK_VERSION?=
 METRICBEAT_VERSION?=
+PICKLES_VERSION?="2.20.1"
 VERSION_VALUE=`cat ../cli/VERSION.txt`
 
 ifneq ($(FEATURE),)
@@ -15,6 +16,14 @@ endif
 GO_IMAGE_TAG?='stretch'
 GOOS?='linux'
 GOARCH?='amd64'
+
+.PHONT: build-docs
+build-docs:
+	rm -fr docs
+	@docker run --rm -it -v $(PWD):/suites docker.elastic.co/observavbility-ci/picklesdoc:$(PICKLES_VERSION) -f /suites -o /suites/docs --sn "E2E Testing" --sv $(VERSION_VALUE)
+	# because pickledocs is a Windows tool, there is a wrong slash.
+	mv docs/.\\/index.html docs/index.html
+	rm -fr docs/.\\
 
 .PHONY: fetch-binary
 fetch-binary:

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -20,7 +20,7 @@ GOARCH?='amd64'
 .PHONT: build-docs
 build-docs:
 	rm -fr docs
-	@docker run --rm -v $(PWD):/suites docker.elastic.co/observability-ci/picklesdoc:$(PICKLES_VERSION) -f /suites -o /suites/docs --sn "E2E Testing" --sv $(VERSION_VALUE)
+	@docker run --rm --user $$(id -u):$$(id -g) -v $(PWD):/suites docker.elastic.co/observability-ci/picklesdoc:$(PICKLES_VERSION) -f /suites -o /suites/docs --sn "E2E Testing" --sv $(VERSION_VALUE)
 	# because pickledocs is a Windows tool, there is a wrong slash.
 	mv docs/.\\/index.html docs/index.html
 	rm -fr docs/.\\

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -20,7 +20,7 @@ GOARCH?='amd64'
 .PHONT: build-docs
 build-docs:
 	rm -fr docs
-	@docker run --rm -it -v $(PWD):/suites docker.elastic.co/observavbility-ci/picklesdoc:$(PICKLES_VERSION) -f /suites -o /suites/docs --sn "E2E Testing" --sv $(VERSION_VALUE)
+	@docker run --rm -v $(PWD):/suites docker.elastic.co/observavbility-ci/picklesdoc:$(PICKLES_VERSION) -f /suites -o /suites/docs --sn "E2E Testing" --sv $(VERSION_VALUE)
 	# because pickledocs is a Windows tool, there is a wrong slash.
 	mv docs/.\\/index.html docs/index.html
 	rm -fr docs/.\\

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -82,6 +82,15 @@ The anatomy of a feature file is:
 ### Configuration files
 It's possible that there will exist configuration YAML files in the test suire. We recommend locating them under the `configurations` folder in the suite directory. The name of the file will represent the feature to be tested (i.e. `apache.yml`). In this file we will add those configurations that are exclusive to the feature to be tests.
 
+## Generating documentation about the specifications
+If you want to generate a website for the feature files, please run this command:
+
+```shell
+$ make build-docs
+```
+
+It will generate the website under the `./docs` directory (which is ignored in Git). You'll be able to navigate through the feature files and scenarios in a website.
+
 ## Debugging the tests
 
 ### VSCode


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR generates a website with the HTML representation of the gherkin feature files, so that it's easier to consume them.

The generation is done using picklesdoc (http://docs.picklesdoc.com), a Windows application that parses Gherkin files and generates an HTML output. We have wrapped the Windows binary into a Docker image (using mono), and pushing this image to our registry:

- docker.elastic.co/observavbility-ci/picklesdoc:2.21.0 (Dockerfile here: https://github.com/Xeli/picklesdoc-docker/blob/master/Dockerfile)

Because this image uses a Windows binary, we wrapped the execution into a Make target, which massages the output to remove bad slashes in the generated paths (i.e. the root index.html file).

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We want to provide an easy way to consume the specification, shareable and understandable by anybody in the team, and HTML is easy to read.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Generated the docs locally

## How to test this PR locally

```shell
$ cd e2e
$ make build-docs
```

A website will be generate under the `docs` directory


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #260 


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

Sample website:

<img width="1338" alt="Screenshot 2020-09-03 at 17 38 49" src="https://user-images.githubusercontent.com/951580/92136506-646b6700-ee0c-11ea-97c6-ca49b220f606.png">

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

```
Generating documentation based on the following parameters 
---------------------------------------------------------- 
Feature Directory              : /suites 
Output Directory               : /suites/docs 
Project Name                   : E2E Testing 
Project Version                : 1.0.0 
Language                       : en 
Incorporate Test Results?      : No 
Include Experimental Features? : No 
Exclude Tag                    :  
Technical Tag                    :  
Writing HTML to /suites/docs 
Pickles completed successfully
```

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
The templates are embedded into the binary, need to research about customising the HTML templates.

We also need to put the Dockerfile for the picklesdoc image in a repo.
<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->