### PR TITLE
docs: generate a website with the specs (#261) backport for 7.9.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -136,6 +136,31 @@ pipeline {
             }
           }
         }
+        stage('Build Docs') {
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            anyOf {
+              expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
+              expression { return env.SKIP_TESTS == "false" }
+            }
+          }
+          steps {
+            deleteDir()
+            unstash 'source'
+            dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
+            dir("${BASE_DIR}/e2e") {
+              sh(label: 'Build docs', script: 'make build-docs')
+            }
+          }
+          post {
+            always {
+              dir("${BASE_DIR}") {
+                archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/docs/**"
+              }
+            }
+          }
+        }
         stage('End-To-End Tests') {
           options { skipDefaultCheckout() }
           environment {

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,6 +1,7 @@
 godog.test
 report.xml
 
+docs
 outputs/*
 !outputs/.touch
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -6,6 +6,7 @@ LOG_LEVEL?=INFO
 RETRY_TIMEOUT?=3
 STACK_VERSION?=
 METRICBEAT_VERSION?=
+PICKLES_VERSION?="2.20.1"
 VERSION_VALUE=`cat ../cli/VERSION.txt`
 
 ifneq ($(FEATURE),)
@@ -15,6 +16,14 @@ endif
 GO_IMAGE_TAG?='stretch'
 GOOS?='linux'
 GOARCH?='amd64'
+
+.PHONT: build-docs
+build-docs:
+	rm -fr docs
+	@docker run --rm --user $$(id -u):$$(id -g) -v $(PWD):/suites docker.elastic.co/observability-ci/picklesdoc:$(PICKLES_VERSION) -f /suites -o /suites/docs --sn "E2E Testing" --sv $(VERSION_VALUE)
+	# because pickledocs is a Windows tool, there is a wrong slash.
+	mv docs/.\\/index.html docs/index.html
+	rm -fr docs/.\\
 
 .PHONY: fetch-binary
 fetch-binary:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -82,6 +82,15 @@ The anatomy of a feature file is:
 ### Configuration files
 It's possible that there will exist configuration YAML files in the test suire. We recommend locating them under the `configurations` folder in the suite directory. The name of the file will represent the feature to be tested (i.e. `apache.yml`). In this file we will add those configurations that are exclusive to the feature to be tests.
 
+## Generating documentation about the specifications
+If you want to generate a website for the feature files, please run this command:
+
+```shell
+$ make build-docs
+```
+
+It will generate the website under the `./docs` directory (which is ignored in Git). You'll be able to navigate through the feature files and scenarios in a website.
+
 ## Debugging the tests
 
 ### VSCode


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - docs: generate a website with the specs (#261)