### PR TITLE
fix: suppress scm triggering for all branches (#265) backport for 7.9.x

### DIFF
--- a/.ci/jobs/e2e-testing-helm-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-helm-daily-mbp.yml
@@ -21,6 +21,9 @@
           credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          property-strategies:
+            all-branches:
+              - suppress-scm-triggering: true
           build-strategies:
             - regular-branches: true
             - change-request:


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: suppress scm triggering for all branches (#265)