### PR TITLE
fix: typo in job name (#276) backport for 7.9.x

### DIFF
--- a/.ci/jobs/e2e-testing-integrations-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-integrations-daily-mbp.yml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: e2e-tests/e2e-testing-helm-daily-mbp
+    name: e2e-tests/e2e-testing-integrations-daily-mbp
     display-name: End-2-End tests for Metricbeat Integrations Pipeline
     description: Run E2E Metricbeat Integrations test suite daily, including maintenance branches
     view: E2E


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: typo in job name (#276)