### PR TITLE
[7.9.x] Backport endpoint integration

### DIFF
--- a/.ci/.e2e-tests.yaml
+++ b/.ci/.e2e-tests.yaml
@@ -7,6 +7,8 @@ SUITES:
   - suite: "helm"
     feature: "metricbeat"
   - suite: "ingest-manager"
+    feature: "agent_endpoint_integration"
+  - suite: "ingest-manager"
     feature: "stand_alone_mode"
   - suite: "ingest-manager"
     feature: "fleet_mode"

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -71,11 +71,11 @@ var syncIntegrationsCmd = &cobra.Command{
 
 			log.WithFields(log.Fields{
 				"path": repoDir,
-			}).Debug("Removing repository")
+			}).Trace("Removing repository")
 			os.RemoveAll(repoDir)
 			log.WithFields(log.Fields{
 				"path": repoDir,
-			}).Debug("Repository removed")
+			}).Trace("Repository removed")
 		}
 
 		git.Clone(BeatsRepo)
@@ -145,7 +145,7 @@ func copyIntegrationsComposeFiles(beats git.Project, target string) {
 		log.WithFields(log.Fields{
 			"meta":       metaDir,
 			"targetMeta": targetMetaDir,
-		}).Debug("Integration _meta directory copied")
+		}).Trace("Integration _meta directory copied")
 
 		err = sanitizeComposeFile(targetFile)
 		if err != nil {
@@ -158,7 +158,7 @@ func copyIntegrationsComposeFiles(beats git.Project, target string) {
 		log.WithFields(log.Fields{
 			"file":       file,
 			"targetFile": targetFile,
-		}).Debug("Integration compose file copied")
+		}).Trace("Integration compose file copied")
 	}
 
 	log.WithFields(log.Fields{
@@ -201,7 +201,7 @@ func sanitizeComposeFile(composeFilePath string) error {
 			log.WithFields(log.Fields{
 				"name":         k,
 				"compose-file": composeFilePath,
-			}).Debug("sanitize service in docker-compose file")
+			}).Trace("sanitize service in docker-compose file")
 
 			for key, value := range i {
 				strKey := fmt.Sprintf("%v", key)

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -80,7 +80,7 @@ func GetComposeFile(isProfile bool, composeName string) (string, error) {
 		log.WithFields(log.Fields{
 			"composeFilePath": composeFilePath,
 			"type":            serviceType,
-		}).Debug("Compose file found at workdir")
+		}).Trace("Compose file found at workdir")
 
 		return composeFilePath, nil
 	}
@@ -89,7 +89,7 @@ func GetComposeFile(isProfile bool, composeName string) (string, error) {
 		"composeFilePath": composeFilePath,
 		"error":           err,
 		"type":            serviceType,
-	}).Debug("Compose file not found at workdir. Extracting from binary resources")
+	}).Trace("Compose file not found at workdir. Extracting from binary resources")
 
 	composeBytes, err := opComposeBox.Find(path.Join(serviceType, composeName, composeFileName))
 	if err != nil {
@@ -118,7 +118,7 @@ func GetComposeFile(isProfile bool, composeName string) (string, error) {
 		"composeFilePath": composeFilePath,
 		"isProfile":       isProfile,
 		"type":            serviceType,
-	}).Debug("Compose file generated at workdir.")
+	}).Trace("Compose file generated at workdir.")
 
 	return composeFilePath, nil
 }
@@ -247,7 +247,7 @@ func checkConfigDirs(workspace string) {
 	log.WithFields(log.Fields{
 		"servicesPath": servicesPath,
 		"profilesPath": profilesPath,
-	}).Debug("'op' workdirs created.")
+	}).Trace("'op' workdirs created.")
 }
 
 func configureLogger() {
@@ -318,7 +318,7 @@ func packComposeFiles(op *OpConfig) *packr.Box {
 		log.WithFields(log.Fields{
 			"service": composeName,
 			"path":    boxedPath,
-		}).Debug("Boxed file")
+		}).Trace("Boxed file")
 
 		if composeType == "profiles" {
 			op.Profiles[composeName] = Profile{
@@ -363,7 +363,7 @@ func readFilesFromFileSystem(serviceType string) {
 				log.WithFields(log.Fields{
 					"service": name,
 					"path":    composeFilePath,
-				}).Debug("Workspace file")
+				}).Trace("Workspace file")
 
 				if serviceType == "services" {
 					// add a service or a profile

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -32,7 +32,7 @@ func ExecCommandIntoContainer(ctx context.Context, containerName string, user st
 		"command":   cmd,
 		"detach":    detach,
 		"tty":       tty,
-	}).Debug("Creating command to be executed in container")
+	}).Trace("Creating command to be executed in container")
 
 	response, err := dockerClient.ContainerExecCreate(
 		ctx, containerName, types.ExecConfig{
@@ -61,7 +61,7 @@ func ExecCommandIntoContainer(ctx context.Context, containerName string, user st
 		"command":   cmd,
 		"detach":    detach,
 		"tty":       tty,
-	}).Debug("Command to be executed in container created")
+	}).Trace("Command to be executed in container created")
 
 	resp, err := dockerClient.ContainerExecAttach(ctx, response.ID, types.ExecStartCheck{
 		Detach: detach,
@@ -98,7 +98,7 @@ func ExecCommandIntoContainer(ctx context.Context, containerName string, user st
 		"command":   cmd,
 		"detach":    detach,
 		"tty":       tty,
-	}).Debug("Command sucessfully executed in container")
+	}).Trace("Command sucessfully executed in container")
 
 	output = strings.ReplaceAll(output, "\n", "")
 
@@ -167,7 +167,7 @@ func RemoveDevNetwork() error {
 
 	log.WithFields(log.Fields{
 		"network": OPNetworkName,
-	}).Debug("Removing Dev Network...")
+	}).Trace("Removing Dev Network...")
 
 	if err := dockerClient.NetworkRemove(ctx, OPNetworkName); err != nil {
 		return err
@@ -175,7 +175,7 @@ func RemoveDevNetwork() error {
 
 	log.WithFields(log.Fields{
 		"network": OPNetworkName,
-	}).Debug("Dev Network has been removed")
+	}).Trace("Dev Network has been removed")
 
 	return nil
 }

--- a/cli/internal/state.go
+++ b/cli/internal/state.go
@@ -17,7 +17,7 @@ import (
 // stateRun represents a Run
 type stateRun struct {
 	ID       string            // ID of the run
-	Profile    stateService      // profile of the run (Optional)
+	Profile  stateService      // profile of the run (Optional)
 	Env      map[string]string // environment for the run
 	Services []stateService    // services in the run
 }
@@ -64,7 +64,7 @@ func Destroy(id string, workdir string) {
 
 	log.WithFields(log.Fields{
 		"stateFile": stateFile,
-	}).Debug("State destroyed")
+	}).Trace("State destroyed")
 }
 
 // Update updates the state of en execution, using ID as the file name for the run.
@@ -76,7 +76,7 @@ func Update(id string, workdir string, composeFilePaths []string, env map[string
 	log.WithFields(log.Fields{
 		"dir":       workdir,
 		"stateFile": stateFile,
-	}).Debug("Updating state")
+	}).Trace("Updating state")
 
 	run := stateRun{
 		ID:       id,
@@ -119,5 +119,5 @@ func Update(id string, workdir string, composeFilePaths []string, env map[string
 	log.WithFields(log.Fields{
 		"dir":       workdir,
 		"stateFile": stateFile,
-	}).Debug("State updated")
+	}).Trace("State updated")
 }

--- a/cli/services/helm.go
+++ b/cli/services/helm.go
@@ -185,7 +185,7 @@ func (h *helm2X) InstallChart(name string, chart string, version string, flags [
 		"flags":   flags,
 		"name":    name,
 		"version": version,
-	}).Debug("Installing chart")
+	}).Trace("Installing chart")
 
 	args := []string{
 		"install", chart, "--name", name, "--version", version,

--- a/cli/services/manager.go
+++ b/cli/services/manager.go
@@ -38,7 +38,7 @@ func (sm *DockerServiceManager) AddServicesToCompose(profile string, composeName
 	log.WithFields(log.Fields{
 		"profile":  profile,
 		"services": composeNames,
-	}).Debug("Adding services to compose")
+	}).Trace("Adding services to compose")
 
 	newComposeNames := []string{profile}
 	newComposeNames = append(newComposeNames, composeNames...)
@@ -61,7 +61,7 @@ func (sm *DockerServiceManager) RemoveServicesFromCompose(profile string, compos
 	log.WithFields(log.Fields{
 		"profile":  profile,
 		"services": composeNames,
-	}).Debug("Removing services to compose")
+	}).Trace("Removing services from compose")
 
 	newComposeNames := []string{profile}
 	newComposeNames = append(newComposeNames, composeNames...)
@@ -134,7 +134,7 @@ func (sm *DockerServiceManager) StopCompose(isProfile bool, composeNames []strin
 	log.WithFields(log.Fields{
 		"composeFilePath": composeFilePaths,
 		"profile":         composeNames[0],
-	}).Debug("Docker compose down.")
+	}).Trace("Docker compose down.")
 
 	return nil
 }

--- a/cli/shell/curl.go
+++ b/cli/shell/curl.go
@@ -79,7 +79,7 @@ func request(r HTTPRequest) (string, error) {
 		body = nil
 	}
 
-	log.WithFields(fields).Debug("Executing request")
+	log.WithFields(fields).Trace("Executing request")
 
 	req, err := http.NewRequest(r.method, escapedURL, body)
 	if err != nil {

--- a/cli/shell/curl.go
+++ b/cli/shell/curl.go
@@ -22,7 +22,7 @@ type HTTPRequest struct {
 	EncodeURL         bool
 	Headers           map[string]string
 	method            string
-	Payload           []byte
+	Payload           string // string representation of fthe payload, in JSON format
 	QueryString       string
 	URL               string
 }
@@ -66,17 +66,20 @@ func Post(r HTTPRequest) (string, error) {
 func request(r HTTPRequest) (string, error) {
 	escapedURL := r.GetURL()
 
-	log.WithFields(log.Fields{
+	fields := log.Fields{
 		"method":     r.method,
 		"escapedURL": escapedURL,
-	}).Debug("Executing request")
+	}
 
 	var body io.Reader
-	if r.Payload != nil {
-		body = bytes.NewReader(r.Payload)
+	if r.Payload != "" {
+		body = bytes.NewReader([]byte(r.Payload))
+		fields["payload"] = r.Payload
 	} else {
 		body = nil
 	}
+
+	log.WithFields(fields).Debug("Executing request")
 
 	req, err := http.NewRequest(r.method, escapedURL, body)
 	if err != nil {

--- a/cli/shell/curl.go
+++ b/cli/shell/curl.go
@@ -62,6 +62,13 @@ func Post(r HTTPRequest) (string, error) {
 	return request(r)
 }
 
+// Put executes a PUT request
+func Put(r HTTPRequest) (string, error) {
+	r.method = "PUT"
+
+	return request(r)
+}
+
 // Post executes a request
 func request(r HTTPRequest) (string, error) {
 	escapedURL := r.GetURL()

--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -17,7 +17,7 @@ import (
 
 // CheckInstalledSoftware checks that the required software is present
 func CheckInstalledSoftware(binaries []string) {
-	log.Debugf("Validating required tools: %v", binaries)
+	log.Tracef("Validating required tools: %v", binaries)
 
 	for _, binary := range binaries {
 		err := which(binary)
@@ -108,6 +108,6 @@ func which(binary string) error {
 	log.WithFields(log.Fields{
 		"binary": binary,
 		"path":   path,
-	}).Debug("Binary is present")
+	}).Trace("Binary is present")
 	return nil
 }

--- a/e2e/_suites/helm/helm_charts_test.go
+++ b/e2e/_suites/helm/helm_charts_test.go
@@ -141,7 +141,7 @@ func (ts *HelmChartTestSuite) aResourceWillExposePods(resourceType string) error
 	log.WithFields(log.Fields{
 		"name":     ts.Name,
 		"describe": describe,
-	}).Debug("Checking the configmap")
+	}).Trace("Checking the configmap")
 
 	return nil
 }
@@ -160,7 +160,7 @@ func (ts *HelmChartTestSuite) aResourceWillManagePods(resourceType string) error
 	log.WithFields(log.Fields{
 		"name":      ts.Name,
 		"resources": resources,
-	}).Debugf("Checking the %s pods", resourceType)
+	}).Tracef("Checking the %s pods", resourceType)
 
 	return nil
 }
@@ -179,7 +179,7 @@ func (ts *HelmChartTestSuite) checkResources(resourceType, selector string, min 
 	log.WithFields(log.Fields{
 		"name":  ts.Name,
 		"items": items,
-	}).Debugf("Checking for %d %s with selector %s", min, resourceType, selector)
+	}).Tracef("Checking for %d %s with selector %s", min, resourceType, selector)
 
 	return items, nil
 }
@@ -187,7 +187,7 @@ func (ts *HelmChartTestSuite) checkResources(resourceType, selector string, min 
 func (ts *HelmChartTestSuite) createCluster(k8sVersion string) error {
 	args := []string{"create", "cluster", "--name", ts.ClusterName, "--image", "kindest/node:v" + k8sVersion}
 
-	log.Debug("Creating cluster with kind")
+	log.Trace("Creating cluster with kind")
 	output, err := shell.Execute(".", "kind", args...)
 	if err != nil {
 		log.WithField("error", err).Error("Could not create the cluster")
@@ -222,7 +222,7 @@ func (ts *HelmChartTestSuite) deleteChart() {
 func (ts *HelmChartTestSuite) destroyCluster() error {
 	args := []string{"delete", "cluster", "--name", ts.ClusterName}
 
-	log.Debug("Deleting cluster")
+	log.Trace("Deleting cluster")
 	output, err := shell.Execute(".", "kind", args...)
 	if err != nil {
 		log.WithField("error", err).Error("Could not destroy the cluster")
@@ -526,7 +526,7 @@ func HelmChartFeatureContext(s *godog.Suite) {
 	s.Step(`^a "([^"]*)" which will expose the pods as network services internal to the k8s cluster$`, testSuite.aResourceWillExposePods)
 
 	s.BeforeSuite(func() {
-		log.Debug("Before Suite...")
+		log.Trace("Before Suite...")
 		toolsAreInstalled()
 
 		err := testSuite.createCluster(testSuite.KubernetesVersion)
@@ -543,11 +543,11 @@ func HelmChartFeatureContext(s *godog.Suite) {
 		}
 	})
 	s.BeforeScenario(func(*messages.Pickle) {
-		log.Info("Before Helm scenario...")
+		log.Trace("Before Helm scenario...")
 	})
 	s.AfterSuite(func() {
 		if !developerMode {
-			log.Debug("After Suite...")
+			log.Trace("After Suite...")
 			err := testSuite.destroyCluster()
 			if err != nil {
 				return
@@ -555,7 +555,7 @@ func HelmChartFeatureContext(s *godog.Suite) {
 		}
 	})
 	s.AfterScenario(func(*messages.Pickle, error) {
-		log.Debug("After Helm scenario...")
+		log.Trace("After Helm scenario...")
 		testSuite.deleteChart()
 	})
 }

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -12,7 +12,7 @@ Scenario: Adding the Endpoint Integration to an Agent makes the host to show in 
     
 @endpoint-policy-check
 Scenario: Deploying an Endpoint makes policies to appear in the Security App
-  Given an Endpoint is successfully deployed with a "centos" Agent
+  When an Endpoint is successfully deployed with a "centos" Agent
   Then the policy response will be shown in the Security App
 
 @set-policy-and-check-changes

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -5,6 +5,7 @@ Feature: Agent Endpoint Integration
 @deploy-endpoint-with-agent
 Scenario: Adding the Endpoint Integration to an Agent makes the host to show in Security App
   Given a "centos" agent is deployed to Fleet
+    And the agent is listed in Fleet as "online"
   When the "Endpoint" integration is "added" in the "default" configuration
   Then the "Endpoint" datasource is shown in the "default" configuration as added
     And the host name is shown in the Security App as "online"

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -1,0 +1,31 @@
+@agent_endpoint_integration
+Feature: Fleet Mode Agent with Endpoint Integration
+  Scenarios for Agent to deploy Endpoint and sending data to Ingest Manager and Elasticsearch.
+
+@deploy-endpoint-with-agent
+Scenario: Deploy Endpoint with Agent and see host in Security App
+  Given an agent is deployed to Fleet
+  When the "Endpoint" latest package version is installed successfully
+    And a "Endpoint" package datasource is added to the 'default' configuration
+  Then the "default" configuration shows the "Endpoint" datasource added
+    And the host name is shown in the security app hosts list api
+    
+@endpoint-policy-check
+Scenario: Deploy Endpoint and see policy return successful in Security App
+  Given an Endpoint is successfully deployed with Agent
+  Then the policy response will be listed in the security app api
+
+@set-policy-and-check-changes
+Scenario: Deploy Endpoint and change default policy and verify in Security App
+  Given an Endpoint is successfully deployed with Agent
+  When the policy is updated to have malware in detect mode
+  Then the policy response with detect mode settings will be listed in the security app api
+
+@deploy-endpoint-then-unenroll-agent-and-verify
+Scenario: Deploy Endpoint and then un-enroll Agent to confirm Endpoint shuts down
+  Given an Endpoint is successfully deployed with Agent
+  When the agent is un-enrolled
+  Then the agent is not listed as online in Fleet
+    And the endpoint is not listed as on-line in Security App
+    And the endpoint process is stopped on the host
+

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -13,24 +13,24 @@ Scenario: Adding the Endpoint Integration to an Agent makes the host to show in 
 @endpoint-policy-check
 Scenario: Deploying an Endpoint makes policies to appear in the Security App
   Given an Endpoint is successfully deployed with Agent
-  Then the policy response will be listed in the Security App
+  Then the policy response will be shown in the Security App
 
 @set-policy-and-check-changes
-Scenario: Deploy Endpoint and change default policy and verify in Security App
+Scenario: Changing an Agent policy is reflected in the Security App
   Given an Endpoint is successfully deployed with Agent
   When the policy is updated to have malware in detect mode
-  Then the policy response will be listed in the Security App
+  Then the policy will reflect the change in the Security App
 
-@deploy-endpoint-then-unenroll-agent-and-verify
-Scenario: Deploy Endpoint and then un-enroll Agent to confirm Endpoint stops
+@deploy-endpoint-then-unenroll-agent
+Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
   Given an Endpoint is successfully deployed with Agent
   When the agent is un-enrolled
   Then the agent is not listed in Fleet as online
     And the endpoint is not listed in Security App as online
     And the "elastic-endpoint" process is "stopped" on the host
 
-@deploy-endpoint-then-remove-it-from-configuration-and-verify
-Scenario: Deploy Endpoint and remove it from the configuration then confirm Endpoint stops
+@deploy-endpoint-then-remove-it-from-configuration
+Scenario: Removing Endpoint from Agent configuration stops the connected Endpoint
   Given an Endpoint is successfully deployed with Agent
   When the "Endpoint" integration is "removed" in the "default" configuration
   Then the agent is listed in Fleet as online

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -3,7 +3,7 @@ Feature: Agent Endpoint Integration
   Scenarios for Agent to deploy Endpoint and sending data to Ingest Manager and Elasticsearch.
 
 @deploy-endpoint-with-agent
-Scenario: Deploy Agent and add Endpoint Integration and host shows in Security App
+Scenario: Adding the Endpoint Integration to an Agent makes the host to show in Security App
   Given an agent is deployed to Fleet
   When the "Endpoint" latest package version is installed successfully
     And the "Endpoint" integration is "added" in the "default" configuration

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -18,7 +18,7 @@ Scenario: Deploying an Endpoint makes policies to appear in the Security App
 @set-policy-and-check-changes
 Scenario: Changing an Agent policy is reflected in the Security App
   Given an Endpoint is successfully deployed with a "centos" Agent
-  When the policy is updated to have malware in detect mode
+  When the policy is updated to have "malware" in "detect" mode
   Then the policy will reflect the change in the Security App
 
 @deploy-endpoint-then-unenroll-agent

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -8,7 +8,7 @@ Scenario: Adding the Endpoint Integration to an Agent makes the host to show in 
   When the "latest" version of the "Endpoint" package is installed
     And the "Endpoint" integration is "added" in the "default" configuration
   Then the "Endpoint" datasource is shown in the "default" configuration as added
-#    And the host name is shown in the Security App
+    And the host name is shown in the Security App as "online"
     
 @endpoint-policy-check
 Scenario: Deploying an Endpoint makes policies to appear in the Security App

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -1,5 +1,5 @@
 @agent_endpoint_integration
-Feature: Fleet Mode Agent with Endpoint Integration
+Feature: Agent Endpoint Integration
   Scenarios for Agent to deploy Endpoint and sending data to Ingest Manager and Elasticsearch.
 
 @deploy-endpoint-with-agent

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -25,14 +25,14 @@ Scenario: Changing an Agent policy is reflected in the Security App
 Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
   Given an Endpoint is successfully deployed with a "centos" Agent
   When the agent is un-enrolled
-  Then the agent is listed as "inactive" in Fleet
-#    And the endpoint is not listed in Security App as online
+  Then the agent is listed in Fleet as "inactive"
+    And the endpoint is listed in Security App as "offline"
     And the "elastic-endpoint" process is in the "stopped" state on the host
 
 @deploy-endpoint-then-remove-it-from-configuration
 Scenario: Removing Endpoint from Agent configuration stops the connected Endpoint
   Given an Endpoint is successfully deployed with a "centos" Agent
   When the "Endpoint" integration is "removed" in the "default" configuration
-  Then the agent is listed as "inactive" in Fleet
-#    And the endpoint is not listed in Security App as online
+  Then the agent is listed in Fleet as "inactive"
+    And the endpoint is listed in Security App as "offline"
     And the "elastic-endpoint" process is in the "stopped" state on the host

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -4,7 +4,7 @@ Feature: Agent Endpoint Integration
 
 @deploy-endpoint-with-agent
 Scenario: Adding the Endpoint Integration to an Agent makes the host to show in Security App
-  Given an agent running on "centos-systemd" is deployed to Fleet
+  Given a "centos" agent is deployed to Fleet
   When the "latest" version of the "Endpoint" package is installed
     And the "Endpoint" integration is "added" in the "default" configuration
   Then the "Endpoint" datasource is shown in the "default" configuration as added
@@ -25,7 +25,7 @@ Scenario: Changing an Agent policy is reflected in the Security App
 Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
   Given an Endpoint is successfully deployed with Agent
   When the agent is un-enrolled
-  Then the agent is not listed in Fleet as online
+  Then the agent is not listed as online in Fleet
     And the endpoint is not listed in Security App as online
     And the "elastic-endpoint" process is "stopped" on the host
 
@@ -33,6 +33,6 @@ Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
 Scenario: Removing Endpoint from Agent configuration stops the connected Endpoint
   Given an Endpoint is successfully deployed with Agent
   When the "Endpoint" integration is "removed" in the "default" configuration
-  Then the agent is listed in Fleet as online
+  Then the agent is not listed as online in Fleet
     And the endpoint is not listed in Security App as online
     And the "elastic-endpoint" process is "stopped" on the host

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -7,7 +7,7 @@ Scenario: Adding the Endpoint Integration to an Agent makes the host to show in 
   Given an agent is deployed to Fleet
   When the "latest" version of the "Endpoint" package is installed
     And the "Endpoint" integration is "added" in the "default" configuration
-  Then the "default" configuration shows the "Endpoint" datasource added
+  Then the "Endpoint" datasource is shown in the "default" configuration as added
     And the host name is shown in the Security App
     
 @endpoint-policy-check

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -8,18 +8,18 @@ Scenario: Adding the Endpoint Integration to an Agent makes the host to show in 
   When the "Endpoint" latest package version is installed successfully
     And the "Endpoint" integration is "added" in the "default" configuration
   Then the "default" configuration shows the "Endpoint" datasource added
-    And the host name is shown in the security app
+    And the host name is shown in the Security App
     
 @endpoint-policy-check
-Scenario: Deploy Endpoint and see policy return successful in Security App
+Scenario: Deploying an Endpoint makes policies to appear in the Security App
   Given an Endpoint is successfully deployed with Agent
-  Then the policy response will be listed in the security app
+  Then the policy response will be listed in the Security App
 
 @set-policy-and-check-changes
 Scenario: Deploy Endpoint and change default policy and verify in Security App
   Given an Endpoint is successfully deployed with Agent
   When the policy is updated to have malware in detect mode
-  Then the policy response will be listed in the security app
+  Then the policy response will be listed in the Security App
 
 @deploy-endpoint-then-unenroll-agent-and-verify
 Scenario: Deploy Endpoint and then un-enroll Agent to confirm Endpoint stops

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -26,7 +26,7 @@ Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
   Given an Endpoint is successfully deployed with Agent
   When the agent is un-enrolled
   Then the agent is not listed as online in Fleet
-    And the endpoint is not listed in Security App as online
+#    And the endpoint is not listed in Security App as online
     And the "elastic-endpoint" process is "stopped" on the host
 
 @deploy-endpoint-then-remove-it-from-configuration
@@ -34,5 +34,5 @@ Scenario: Removing Endpoint from Agent configuration stops the connected Endpoin
   Given an Endpoint is successfully deployed with Agent
   When the "Endpoint" integration is "removed" in the "default" configuration
   Then the agent is not listed as online in Fleet
-    And the endpoint is not listed in Security App as online
+#    And the endpoint is not listed in Security App as online
     And the "elastic-endpoint" process is "stopped" on the host

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -4,7 +4,7 @@ Feature: Agent Endpoint Integration
 
 @deploy-endpoint-with-agent
 Scenario: Adding the Endpoint Integration to an Agent makes the host to show in Security App
-  Given an agent is deployed to Fleet
+  Given an agent running on "centos-systemd" is deployed to Fleet
   When the "latest" version of the "Endpoint" package is installed
     And the "Endpoint" integration is "added" in the "default" configuration
   Then the "Endpoint" datasource is shown in the "default" configuration as added

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -27,7 +27,7 @@ Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
   When the agent is un-enrolled
   Then the agent is not listed as online in Fleet
 #    And the endpoint is not listed in Security App as online
-    And the "elastic-endpoint" process is "stopped" on the host
+    And the "elastic-endpoint" process is in the "stopped" state on the host
 
 @deploy-endpoint-then-remove-it-from-configuration
 Scenario: Removing Endpoint from Agent configuration stops the connected Endpoint
@@ -35,4 +35,4 @@ Scenario: Removing Endpoint from Agent configuration stops the connected Endpoin
   When the "Endpoint" integration is "removed" in the "default" configuration
   Then the agent is not listed as online in Fleet
 #    And the endpoint is not listed in Security App as online
-    And the "elastic-endpoint" process is "stopped" on the host
+    And the "elastic-endpoint" process is in the "stopped" state on the host

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -8,24 +8,23 @@ Scenario: Deploy Endpoint with Agent and see host in Security App
   When the "Endpoint" latest package version is installed successfully
     And a "Endpoint" package datasource is added to the 'default' configuration
   Then the "default" configuration shows the "Endpoint" datasource added
-    And the host name is shown in the security app hosts list api
+    And the host name is shown in the security app
     
 @endpoint-policy-check
 Scenario: Deploy Endpoint and see policy return successful in Security App
   Given an Endpoint is successfully deployed with Agent
-  Then the policy response will be listed in the security app api
+  Then the policy response will be listed in the security app
 
 @set-policy-and-check-changes
 Scenario: Deploy Endpoint and change default policy and verify in Security App
   Given an Endpoint is successfully deployed with Agent
   When the policy is updated to have malware in detect mode
-  Then the policy response with detect mode settings will be listed in the security app api
+  Then the policy response will be listed in the security app
 
 @deploy-endpoint-then-unenroll-agent-and-verify
 Scenario: Deploy Endpoint and then un-enroll Agent to confirm Endpoint shuts down
   Given an Endpoint is successfully deployed with Agent
   When the agent is un-enrolled
   Then the agent is not listed as online in Fleet
-    And the endpoint is not listed as on-line in Security App
+    And the endpoint is not listed as online in Security App
     And the endpoint process is stopped on the host
-

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -33,6 +33,6 @@ Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
 Scenario: Removing Endpoint from Agent configuration stops the connected Endpoint
   Given an Endpoint is successfully deployed with a "centos" Agent
   When the "Elastic Endpoint" integration is "removed" in the "default" configuration
-  Then the agent is listed in Fleet as "inactive"
-    And the host name is not shown in the Administration view in the Security App
+  Then the agent is listed in Fleet as "online"
+    But the host name is not shown in the Administration view in the Security App
     And the "elastic-endpoint" process is in the "stopped" state on the host

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -3,10 +3,10 @@ Feature: Fleet Mode Agent with Endpoint Integration
   Scenarios for Agent to deploy Endpoint and sending data to Ingest Manager and Elasticsearch.
 
 @deploy-endpoint-with-agent
-Scenario: Deploy Endpoint with Agent and see host in Security App
+Scenario: Deploy Agent and add Endpoint Integration and host shows in Security App
   Given an agent is deployed to Fleet
   When the "Endpoint" latest package version is installed successfully
-    And a "Endpoint" package datasource is added to the 'default' configuration
+    And the "Endpoint" integration is "added" in the "default" configuration
   Then the "default" configuration shows the "Endpoint" datasource added
     And the host name is shown in the security app
     
@@ -22,9 +22,17 @@ Scenario: Deploy Endpoint and change default policy and verify in Security App
   Then the policy response will be listed in the security app
 
 @deploy-endpoint-then-unenroll-agent-and-verify
-Scenario: Deploy Endpoint and then un-enroll Agent to confirm Endpoint shuts down
+Scenario: Deploy Endpoint and then un-enroll Agent to confirm Endpoint stops
   Given an Endpoint is successfully deployed with Agent
   When the agent is un-enrolled
-  Then the agent is not listed as online in Fleet
-    And the endpoint is not listed as online in Security App
-    And the endpoint process is stopped on the host
+  Then the agent is not listed in Fleet as online
+    And the endpoint is not listed in Security App as online
+    And the "elastic-endpoint" process is "stopped" on the host
+
+@deploy-endpoint-then-remove-it-from-configuration-and-verify
+Scenario: Deploy Endpoint and remove it from the configuration then confirm Endpoint stops
+  Given an Endpoint is successfully deployed with Agent
+  When the "Endpoint" integration is "removed" in the "default" configuration
+  Then the agent is listed in Fleet as online
+    And the endpoint is not listed in Security App as online
+    And the "elastic-endpoint" process is "stopped" on the host

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -5,7 +5,7 @@ Feature: Agent Endpoint Integration
 @deploy-endpoint-with-agent
 Scenario: Adding the Endpoint Integration to an Agent makes the host to show in Security App
   Given an agent is deployed to Fleet
-  When the "Endpoint" latest package version is installed successfully
+  When the latest version of the "Endpoint" package is installed successfully
     And the "Endpoint" integration is "added" in the "default" configuration
   Then the "default" configuration shows the "Endpoint" datasource added
     And the host name is shown in the Security App

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -25,7 +25,7 @@ Scenario: Changing an Agent policy is reflected in the Security App
 Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
   Given an Endpoint is successfully deployed with a "centos" Agent
   When the agent is un-enrolled
-  Then the agent is not listed as online in Fleet
+  Then the agent is listed as "inactive" in Fleet
 #    And the endpoint is not listed in Security App as online
     And the "elastic-endpoint" process is in the "stopped" state on the host
 
@@ -33,6 +33,6 @@ Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
 Scenario: Removing Endpoint from Agent configuration stops the connected Endpoint
   Given an Endpoint is successfully deployed with a "centos" Agent
   When the "Endpoint" integration is "removed" in the "default" configuration
-  Then the agent is not listed as online in Fleet
+  Then the agent is listed as "inactive" in Fleet
 #    And the endpoint is not listed in Security App as online
     And the "elastic-endpoint" process is in the "stopped" state on the host

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -6,8 +6,8 @@ Feature: Agent Endpoint Integration
 Scenario: Adding the Endpoint Integration to an Agent makes the host to show in Security App
   Given a "centos" agent is deployed to Fleet
     And the agent is listed in Fleet as "online"
-  When the "Endpoint" integration is "added" in the "default" configuration
-  Then the "Endpoint" datasource is shown in the "default" configuration as added
+  When the "Elastic Endpoint" integration is "added" in the "default" configuration
+  Then the "Elastic Endpoint" datasource is shown in the "default" configuration as added
     And the host name is shown in the Administration view in the Security App as "online"
     
 @endpoint-policy-check
@@ -32,7 +32,7 @@ Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
 @deploy-endpoint-then-remove-it-from-configuration
 Scenario: Removing Endpoint from Agent configuration stops the connected Endpoint
   Given an Endpoint is successfully deployed with a "centos" Agent
-  When the "Endpoint" integration is "removed" in the "default" configuration
+  When the "Elastic Endpoint" integration is "removed" in the "default" configuration
   Then the agent is listed in Fleet as "inactive"
     And the host name is not shown in the Administration view in the Security App
     And the "elastic-endpoint" process is in the "stopped" state on the host

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -5,7 +5,7 @@ Feature: Agent Endpoint Integration
 @deploy-endpoint-with-agent
 Scenario: Adding the Endpoint Integration to an Agent makes the host to show in Security App
   Given an agent is deployed to Fleet
-  When the "latest" version of the "Endpoint" package is installed successfully
+  When the "latest" version of the "Endpoint" package is installed
     And the "Endpoint" integration is "added" in the "default" configuration
   Then the "default" configuration shows the "Endpoint" datasource added
     And the host name is shown in the Security App

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -8,7 +8,7 @@ Scenario: Adding the Endpoint Integration to an Agent makes the host to show in 
     And the agent is listed in Fleet as "online"
   When the "Endpoint" integration is "added" in the "default" configuration
   Then the "Endpoint" datasource is shown in the "default" configuration as added
-    And the host name is shown in the Security App as "online"
+    And the host name is shown in the Administration view in the Security App as "online"
     
 @endpoint-policy-check
 Scenario: Deploying an Endpoint makes policies to appear in the Security App
@@ -26,7 +26,7 @@ Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
   Given an Endpoint is successfully deployed with a "centos" Agent
   When the agent is un-enrolled
   Then the agent is listed in Fleet as "inactive"
-    And the endpoint is listed in Security App as "offline"
+    And the host name is not shown in the Administration view in the Security App
     And the "elastic-endpoint" process is in the "stopped" state on the host
 
 @deploy-endpoint-then-remove-it-from-configuration
@@ -34,5 +34,5 @@ Scenario: Removing Endpoint from Agent configuration stops the connected Endpoin
   Given an Endpoint is successfully deployed with a "centos" Agent
   When the "Endpoint" integration is "removed" in the "default" configuration
   Then the agent is listed in Fleet as "inactive"
-    And the endpoint is listed in Security App as "offline"
+    And the host name is not shown in the Administration view in the Security App
     And the "elastic-endpoint" process is in the "stopped" state on the host

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -8,7 +8,7 @@ Scenario: Adding the Endpoint Integration to an Agent makes the host to show in 
   When the "latest" version of the "Endpoint" package is installed
     And the "Endpoint" integration is "added" in the "default" configuration
   Then the "Endpoint" datasource is shown in the "default" configuration as added
-    And the host name is shown in the Security App
+#    And the host name is shown in the Security App
     
 @endpoint-policy-check
 Scenario: Deploying an Endpoint makes policies to appear in the Security App

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -12,18 +12,18 @@ Scenario: Adding the Endpoint Integration to an Agent makes the host to show in 
     
 @endpoint-policy-check
 Scenario: Deploying an Endpoint makes policies to appear in the Security App
-  Given an Endpoint is successfully deployed with Agent
+  Given an Endpoint is successfully deployed with a "centos" Agent
   Then the policy response will be shown in the Security App
 
 @set-policy-and-check-changes
 Scenario: Changing an Agent policy is reflected in the Security App
-  Given an Endpoint is successfully deployed with Agent
+  Given an Endpoint is successfully deployed with a "centos" Agent
   When the policy is updated to have malware in detect mode
   Then the policy will reflect the change in the Security App
 
 @deploy-endpoint-then-unenroll-agent
 Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
-  Given an Endpoint is successfully deployed with Agent
+  Given an Endpoint is successfully deployed with a "centos" Agent
   When the agent is un-enrolled
   Then the agent is not listed as online in Fleet
 #    And the endpoint is not listed in Security App as online
@@ -31,7 +31,7 @@ Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
 
 @deploy-endpoint-then-remove-it-from-configuration
 Scenario: Removing Endpoint from Agent configuration stops the connected Endpoint
-  Given an Endpoint is successfully deployed with Agent
+  Given an Endpoint is successfully deployed with a "centos" Agent
   When the "Endpoint" integration is "removed" in the "default" configuration
   Then the agent is not listed as online in Fleet
 #    And the endpoint is not listed in Security App as online

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -5,8 +5,7 @@ Feature: Agent Endpoint Integration
 @deploy-endpoint-with-agent
 Scenario: Adding the Endpoint Integration to an Agent makes the host to show in Security App
   Given a "centos" agent is deployed to Fleet
-  When the "latest" version of the "Endpoint" package is installed
-    And the "Endpoint" integration is "added" in the "default" configuration
+  When the "Endpoint" integration is "added" in the "default" configuration
   Then the "Endpoint" datasource is shown in the "default" configuration as added
     And the host name is shown in the Security App as "online"
     

--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -5,7 +5,7 @@ Feature: Agent Endpoint Integration
 @deploy-endpoint-with-agent
 Scenario: Adding the Endpoint Integration to an Agent makes the host to show in Security App
   Given an agent is deployed to Fleet
-  When the latest version of the "Endpoint" package is installed successfully
+  When the "latest" version of the "Endpoint" package is installed successfully
     And the "Endpoint" integration is "added" in the "default" configuration
   Then the "default" configuration shows the "Endpoint" datasource added
     And the host name is shown in the Security App

--- a/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
+++ b/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
@@ -50,7 +50,7 @@ Scenario Outline: Un-enrolling the <os> agent
   Given a "<os>" agent is deployed to Fleet
   When the agent is un-enrolled
   Then the "elastic-agent" process is in the "started" state on the host
-    And the agent is listed in Fleet as "offline"
+    And the agent is listed in Fleet as "inactive"
 Examples:
 | os     |
 | centos |

--- a/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
+++ b/e2e/_suites/ingest-manager/features/fleet_mode_agent.feature
@@ -5,7 +5,7 @@ Feature: Fleet Mode Agent
 @enroll
 Scenario Outline: Deploying the <os> agent
   When a "<os>" agent is deployed to Fleet
-  Then the agent is listed in Fleet as online
+  Then the agent is listed in Fleet as "online"
     And system package dashboards are listed in Fleet
 Examples:
 | os     |
@@ -50,7 +50,7 @@ Scenario Outline: Un-enrolling the <os> agent
   Given a "<os>" agent is deployed to Fleet
   When the agent is un-enrolled
   Then the "elastic-agent" process is in the "started" state on the host
-    But the agent is not listed as online in Fleet
+    And the agent is listed in Fleet as "offline"
 Examples:
 | os     |
 | centos |
@@ -63,7 +63,7 @@ Scenario Outline: Re-enrolling the <os> agent
     And the "elastic-agent" process is "stopped" on the host
   When the agent is re-enrolled on the host
     And the "elastic-agent" process is "started" on the host
-  Then the agent is listed in Fleet as online
+  Then the agent is listed in Fleet as "online"
 Examples:
 | os     |
 | centos |

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -451,7 +451,7 @@ func (fts *FleetTestSuite) theHostNameIsNotShownInTheAdminViewInTheSecurityApp()
 
 	agentListedInSecurityFn := func() error {
 		host, err := isAgentListedInSecurityApp(fts.Hostname)
-		if err != nil || host != nil {
+		if err != nil {
 			log.WithFields(log.Fields{
 				"elapsedTime": exp.GetElapsedTime(),
 				"err":         err,
@@ -463,6 +463,19 @@ func (fts *FleetTestSuite) theHostNameIsNotShownInTheAdminViewInTheSecurityApp()
 			retryCount++
 
 			return err
+		}
+
+		if host != nil {
+			log.WithFields(log.Fields{
+				"elapsedTime": exp.GetElapsedTime(),
+				"host":        host,
+				"hostname":    fts.Hostname,
+				"retry":       retryCount,
+			}).Warn("The host is still present in the Administration view in the Security App")
+
+			retryCount++
+
+			return fmt.Errorf("The host %s is still present in the Administration view in the Security App", fts.Hostname)
 		}
 
 		log.WithFields(log.Fields{

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -500,7 +500,22 @@ func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp() error {
 }
 
 func (fts *FleetTestSuite) anEndpointIsSuccessfullyDeployedWithAgent() error {
-	return godog.ErrPending
+	err := fts.anAgentIsDeployedToFleet("centos")
+	if err != nil {
+		return err
+	}
+
+	err = fts.theVersionOfThePackageIsInstalled("latest", "endpoint")
+	if err != nil {
+		return err
+	}
+
+	err = fts.theIntegrationIsOperatedInTheConfiguration("enpdoint", "added", "default")
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (fts *FleetTestSuite) thePolicyResponseWillBeShownInTheSecurityApp() error {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -36,6 +36,8 @@ type FleetTestSuite struct {
 	CurrentToken    string // current enrollment token
 	CurrentTokenID  string // current enrollment tokenID
 	Hostname        string // the hostname of the container
+	// integrations
+	Integration IntegrationPackage // the installed integration
 }
 
 func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
@@ -423,7 +425,11 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 		"package":       packageName,
 	}).Debug("Doing an operation for a package on a configuration")
 
-	return godog.ErrPending
+	if strings.ToLower(action) != "added" {
+		return godog.ErrPending
+	}
+
+	return addIntegrationToConfiguration(fts.Integration, fts.ConfigID)
 }
 
 func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp() error {
@@ -443,7 +449,13 @@ func (fts *FleetTestSuite) theVersionOfThePackageIsInstalled(version string, pac
 		return err
 	}
 
-	return installIntegrationAssets(name, version)
+	installedIntegration, err := installIntegrationAssets(name, version)
+	if err != nil {
+		return err
+	}
+	fts.Integration = installedIntegration
+
+	return nil
 }
 
 func (fts *FleetTestSuite) anAttemptToEnrollANewAgentFails() error {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -498,12 +498,12 @@ func (fts *FleetTestSuite) anEndpointIsSuccessfullyDeployedWithAgent(image strin
 		return err
 	}
 
-	err = fts.theIntegrationIsOperatedInTheConfiguration("enpdoint", actionADDED, "default")
+	err = fts.theAgentIsListedInFleetWithStatus("online")
 	if err != nil {
 		return err
 	}
 
-	return nil
+	return fts.theIntegrationIsOperatedInTheConfiguration("enpdoint", actionADDED, "default")
 }
 
 func (fts *FleetTestSuite) thePolicyResponseWillBeShownInTheSecurityApp() error {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -41,7 +41,7 @@ type FleetTestSuite struct {
 	Hostname       string // the hostname of the container
 	// integrations
 	Integration     IntegrationPackage // the installed integration
-	PolicyUpdatedAt string             // the moment the policy was updated
+	ConfigUpdatedAt string             // the moment the configuration was updated
 }
 
 func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
@@ -695,7 +695,7 @@ func (fts *FleetTestSuite) thePolicyIsUpdatedToHaveMode(name string, mode string
 	// we use a string because we are not able to process what comes in the event, so we will do
 	// an alphabetical order, as they share same layour but different millis and timezone format
 	updatedAt := response.Path("item.updated_at").Data().(string)
-	fts.PolicyUpdatedAt = updatedAt
+	fts.ConfigUpdatedAt = updatedAt
 	return nil
 }
 
@@ -711,7 +711,7 @@ func (fts *FleetTestSuite) thePolicyWillReflectTheChangeInTheSecurityApp() error
 	exp := e2e.GetExponentialBackOff(maxTimeout)
 
 	getEventsFn := func() error {
-		err := getAgentEvents("endpoint-security", agentID, fts.Integration.packageConfigID, fts.PolicyUpdatedAt)
+		err := getAgentEvents("endpoint-security", agentID, fts.Integration.packageConfigID, fts.ConfigUpdatedAt)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"elapsedTime": exp.GetElapsedTime(),

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -177,6 +177,12 @@ func (fts *FleetTestSuite) setup() error {
 	}
 	fts.ConfigID = defaultConfig.Path("id").Data().(string)
 
+	// install enddpoint assets on
+	err = fts.theVersionOfThePackageIsInstalled("latest", "endpoint")
+	if err != nil {
+		log.Warn(err)
+	}
+
 	return nil
 }
 

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -162,10 +162,11 @@ func (fts *FleetTestSuite) setup() error {
 		return err
 	}
 
-	fts.ConfigID, err = getAgentDefaultConfig()
+	defaultConfig, err := getAgentDefaultConfig()
 	if err != nil {
 		return err
 	}
+	fts.ConfigID = defaultConfig.Path("id").Data().(string)
 
 	return nil
 }
@@ -701,7 +702,7 @@ func enrollAgent(installer ElasticAgentInstaller, token string) error {
 }
 
 // getAgentDefaultConfig sends a GET request to Fleet for the existing default configuration
-func getAgentDefaultConfig() (string, error) {
+func getAgentDefaultConfig() (*gabs.Container, error) {
 	r := createDefaultHTTPRequest(ingestManagerAgentConfigsURL)
 	body, err := curl.Get(r)
 	if err != nil {
@@ -710,7 +711,7 @@ func getAgentDefaultConfig() (string, error) {
 			"error": err,
 			"url":   ingestManagerAgentConfigsURL,
 		}).Error("Could not get Fleet's configs")
-		return "", err
+		return nil, err
 	}
 
 	jsonParsed, err := gabs.ParseJSON([]byte(body))
@@ -719,7 +720,7 @@ func getAgentDefaultConfig() (string, error) {
 			"error":        err,
 			"responseBody": body,
 		}).Error("Could not parse response into JSON")
-		return "", err
+		return nil, err
 	}
 
 	// data streams should contain array of elements
@@ -729,8 +730,10 @@ func getAgentDefaultConfig() (string, error) {
 		"count": len(configs.Children()),
 	}).Debug("Fleet configs retrieved")
 
-	configID := configs.Index(0).Path("id").Data().(string)
-	return configID, nil
+	// TODO: perform a strong check to capture default config
+	defaultConfig := configs.Index(0)
+
+	return defaultConfig, nil
 }
 
 // getAgentID sends a GET request to Fleet for the existing agents

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -19,6 +19,7 @@ import (
 )
 
 const fleetAgentsURL = kibanaBaseURL + "/api/ingest_manager/fleet/agents"
+const fleetAgentEventsURL = kibanaBaseURL + "/api/ingest_manager/fleet/agents/%s/events"
 const fleetAgentsUnEnrollURL = kibanaBaseURL + "/api/ingest_manager/fleet/agents/%s/unenroll"
 const fleetEnrollmentTokenURL = kibanaBaseURL + "/api/ingest_manager/fleet/enrollment-api-keys"
 const fleetSetupURL = kibanaBaseURL + "/api/ingest_manager/fleet/setup"
@@ -39,7 +40,8 @@ type FleetTestSuite struct {
 	CurrentTokenID string // current enrollment tokenID
 	Hostname       string // the hostname of the container
 	// integrations
-	Integration IntegrationPackage // the installed integration
+	Integration     IntegrationPackage // the installed integration
+	PolicyUpdatedAt string             // the moment the policy was updated
 }
 
 func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
@@ -644,11 +646,50 @@ func (fts *FleetTestSuite) thePolicyIsUpdatedToHaveMode(name string, mode string
 		return fmt.Errorf("The update of the integration package configuration failed. %v", response)
 	}
 
+	// we use a string because we are not able to process what comes in the event, so we will do
+	// an alphabetical order, as they share same layour but different millis and timezone format
+	updatedAt := response.Path("item.updated_at").Data().(string)
+	fts.PolicyUpdatedAt = updatedAt
 	return nil
 }
 
 func (fts *FleetTestSuite) thePolicyWillReflectTheChangeInTheSecurityApp() error {
-	return godog.ErrPending
+	agentID, err := getAgentID(fts.Hostname)
+	if err != nil {
+		return err
+	}
+
+	maxTimeout := 2 * time.Minute
+	retryCount := 1
+
+	exp := e2e.GetExponentialBackOff(maxTimeout)
+
+	getEventsFn := func() error {
+		err := getAgentEvents(agentID, fts.PolicyID, fts.PolicyUpdatedAt)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"elapsedTime": exp.GetElapsedTime(),
+				"err":         err,
+				"retries":     retryCount,
+			}).Warn("There are no events for the agent in Fleet")
+			retryCount++
+
+			return err
+		}
+
+		log.WithFields(log.Fields{
+			"elapsedTime": exp.GetElapsedTime(),
+			"retries":     retryCount,
+		}).Info("There are events for the agent in Fleet")
+		return nil
+	}
+
+	err = backoff.Retry(getEventsFn, exp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // theVersionOfThePackageIsInstalled installs a package in a version
@@ -966,6 +1007,61 @@ func getAgentDefaultConfig() (*gabs.Container, error) {
 	defaultConfig := configs.Index(0)
 
 	return defaultConfig, nil
+}
+
+func getAgentEvents(agentID string, policyID string, updatedAt string) error {
+	url := fmt.Sprintf(fleetAgentEventsURL, agentID)
+	getReq := createDefaultHTTPRequest(url)
+	getReq.QueryString = "page=1&perPage=20"
+
+	body, err := curl.Get(getReq)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"agentID": agentID,
+			"body":    body,
+			"error":   err,
+			"url":     url,
+		}).Error("Could not get agent events from Fleet")
+		return err
+	}
+
+	jsonResponse, err := gabs.ParseJSON([]byte(body))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":        err,
+			"responseBody": body,
+		}).Error("Could not parse response into JSON")
+		return err
+	}
+
+	listItems := jsonResponse.Path("list").Children()
+	for _, item := range listItems {
+		message := item.Path("message").Data().(string)
+		timestamp := item.Path("timestamp").Data().(string)
+
+		log.WithFields(log.Fields{
+			"agentID":    agentID,
+			"policyID":   policyID,
+			"event_at":   timestamp,
+			"message":    message,
+			"updated_at": updatedAt,
+		}).Trace("Event found")
+
+		matches := (strings.Contains(message, "endpoint-security") &&
+			strings.Contains(message, "["+agentID+"]: State changed to RUNNING: Running") &&
+			strings.Contains(message, "Protecting with policy {"+policyID+"}"))
+
+		if matches && timestamp > updatedAt {
+			log.WithFields(log.Fields{
+				"updated_at": updatedAt,
+				"event_at":   timestamp,
+				"message":    message,
+			}).Info("Event after the update was found")
+			return nil
+		}
+	}
+
+	return fmt.Errorf("No events where found for the agent in the policy")
 }
 
 // getAgentID sends a GET request to Fleet for a existing hostname

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -434,7 +434,7 @@ func (fts *FleetTestSuite) theConfigurationShowsTheDatasourceAdded(configuration
 			log.WithFields(log.Fields{
 				"error":           err,
 				"packageConfigID": fts.Integration.packageConfigID,
-				"configurationID": fts.PolicyID,
+				"configurationID": fts.ConfigID,
 				"retry":           retryCount,
 			}).Warn("An error retrieving the configuration happened")
 
@@ -450,7 +450,7 @@ func (fts *FleetTestSuite) theConfigurationShowsTheDatasourceAdded(configuration
 			if id == fts.Integration.packageConfigID {
 				log.WithFields(log.Fields{
 					"packageConfigID": fts.Integration.packageConfigID,
-					"configurationID": fts.PolicyID,
+					"configurationID": fts.ConfigID,
 				}).Info("The integration was found in the configuration")
 				return nil
 			}
@@ -458,7 +458,7 @@ func (fts *FleetTestSuite) theConfigurationShowsTheDatasourceAdded(configuration
 
 		log.WithFields(log.Fields{
 			"packageConfigID": fts.Integration.packageConfigID,
-			"configurationID": fts.PolicyID,
+			"configurationID": fts.ConfigID,
 			"retry":           retryCount,
 		}).Warn("The integration was not found in the configuration")
 
@@ -483,7 +483,7 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 	}).Debug("Doing an operation for a package on a configuration")
 
 	if strings.ToLower(action) == actionADDED {
-		integrationConfigurationID, err := addIntegrationToPolicy(fts.Integration, fts.PolicyID)
+		integrationConfigurationID, err := addIntegrationToConfiguration(fts.Integration, fts.ConfigID)
 		if err != nil {
 			return err
 		}
@@ -491,12 +491,12 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 		fts.Integration.packageConfigID = integrationConfigurationID
 		return nil
 	} else if strings.ToLower(action) == actionREMOVED {
-		err := deleteIntegrationFromPolicy(fts.Integration, fts.PolicyID)
+		err := deleteIntegrationFromConfiguration(fts.Integration, fts.ConfigID)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"err":             err,
 				"packageConfigID": fts.Integration.packageConfigID,
-				"configurationID": fts.PolicyID,
+				"configurationID": fts.ConfigID,
 			}).Error("The integration could not be deleted from the configuration")
 			return err
 		}

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -437,7 +437,12 @@ func (fts *FleetTestSuite) theVersionOfThePackageIsInstalled(version string, pac
 		"version": version,
 	}).Debug("Checking if package version is installed")
 
-	return godog.ErrPending
+	name, version, err := getIntegrationLatestVersion(packageName)
+	if err != nil {
+		return err
+	}
+
+	return installIntegrationAssets(name, version)
 }
 
 func (fts *FleetTestSuite) anAttemptToEnrollANewAgentFails() error {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -54,7 +54,6 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
 	s.Step(`^the "([^"]*)" process is "([^"]*)" on the host$`, fts.processStateChangedOnTheHost)
 
 	// endpoint steps
-	s.Step(`^the "([^"]*)" version of the "([^"]*)" package is installed$`, fts.theVersionOfThePackageIsInstalled)
 	s.Step(`^the "([^"]*)" integration is "([^"]*)" in the "([^"]*)" configuration$`, fts.theIntegrationIsOperatedInTheConfiguration)
 	s.Step(`^the "([^"]*)" datasource is shown in the "([^"]*)" configuration as added$`, fts.theConfigurationShowsTheDatasourceAdded)
 	s.Step(`^the host name is shown in the Administration view in the Security App as "([^"]*)"$`, fts.theHostNameIsShownInTheAdminViewInTheSecurityApp)
@@ -172,12 +171,6 @@ func (fts *FleetTestSuite) setup() error {
 		return err
 	}
 	fts.ConfigID = defaultConfig.Path("id").Data().(string)
-
-	// install enddpoint assets on
-	err = fts.theVersionOfThePackageIsInstalled("latest", "endpoint")
-	if err != nil {
-		log.Warn(err)
-	}
 
 	return nil
 }
@@ -558,6 +551,7 @@ func (fts *FleetTestSuite) thePolicyWillReflectTheChangeInTheSecurityApp() error
 	return godog.ErrPending
 }
 
+// theVersionOfThePackageIsInstalled installs a package in a version
 func (fts *FleetTestSuite) theVersionOfThePackageIsInstalled(version string, packageName string) error {
 	log.WithFields(log.Fields{
 		"package": packageName,

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/Jeffail/gabs/v2"
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/cucumber/godog"
 	"github.com/elastic/e2e-testing/cli/services"
 	curl "github.com/elastic/e2e-testing/cli/shell"

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -58,11 +58,11 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
 	s.Step(`^the "([^"]*)" integration is "([^"]*)" in the "([^"]*)" configuration$`, fts.theIntegrationIsOperatedInTheConfiguration)
 	s.Step(`^the "([^"]*)" datasource is shown in the "([^"]*)" configuration as added$`, fts.theConfigurationShowsTheDatasourceAdded)
 	s.Step(`^the host name is shown in the Security App as "([^"]*)"$`, fts.theHostNameIsShownInTheSecurityApp)
+	s.Step(`^the host name is not shown in the Security App$`, fts.theHostNameIsNotShownInTheSecurityApp)
 	s.Step(`^an Endpoint is successfully deployed with a "([^"]*)" Agent$`, fts.anEndpointIsSuccessfullyDeployedWithAgent)
 	s.Step(`^the policy response will be shown in the Security App$`, fts.thePolicyResponseWillBeShownInTheSecurityApp)
 	s.Step(`^the policy is updated to have malware in detect mode$`, fts.thePolicyIsUpdatedToHaveMalwareInDetectMode)
 	s.Step(`^the policy will reflect the change in the Security App$`, fts.thePolicyWillReflectTheChangeInTheSecurityApp)
-	s.Step(`^the endpoint is listed in Security App as "([^"]*)"$`, fts.theEndpointIsListedInSecurityAppAs)
 }
 
 func (fts *FleetTestSuite) anAgentIsDeployedToFleet(image string) error {
@@ -449,6 +449,46 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 	return godog.ErrPending
 }
 
+func (fts *FleetTestSuite) theHostNameIsNotShownInTheSecurityApp() error {
+	log.Debug("Checking if the hostname is not shown in the Security App")
+
+	maxTimeout := 2 * time.Minute
+	retryCount := 1
+
+	exp := e2e.GetExponentialBackOff(maxTimeout)
+
+	agentListedInSecurityFn := func() error {
+		host, err := isAgentListedInSecurityApp(fts.Hostname)
+		if err != nil || host != nil {
+			log.WithFields(log.Fields{
+				"elapsedTime": exp.GetElapsedTime(),
+				"err":         err,
+				"host":        host,
+				"hostname":    fts.Hostname,
+				"retry":       retryCount,
+			}).Warn("We could not check the agent in the Security App yet")
+
+			retryCount++
+
+			return err
+		}
+
+		log.WithFields(log.Fields{
+			"elapsedTime": exp.GetElapsedTime(),
+			"hostname":    fts.Hostname,
+			"retries":     retryCount,
+		}).Info("The Agent is not listed in the Security App")
+		return nil
+	}
+
+	err := backoff.Retry(agentListedInSecurityFn, exp)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp(status string) error {
 	log.Debug("Checking if the hostname is shown in the Security App")
 
@@ -515,10 +555,6 @@ func (fts *FleetTestSuite) thePolicyIsUpdatedToHaveMalwareInDetectMode() error {
 }
 
 func (fts *FleetTestSuite) thePolicyWillReflectTheChangeInTheSecurityApp() error {
-	return godog.ErrPending
-}
-
-func (fts *FleetTestSuite) theEndpointIsListedInSecurityAppAs(status string) error {
 	return godog.ErrPending
 }
 

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -186,7 +186,25 @@ func (fts *FleetTestSuite) theAgentIsListedInFleetWithStatus(desiredStatus strin
 	agentOnlineFn := func() error {
 		agentID, err := getAgentID(fts.Hostname)
 		if err != nil {
+			retryCount++
 			return err
+		}
+
+		if agentID == "" {
+			// the agent is not listed in Fleet
+			if desiredStatus == "inactive" {
+				log.WithFields(log.Fields{
+					"isAgentInStatus": isAgentInStatus,
+					"elapsedTime":     exp.GetElapsedTime(),
+					"hostname":        fts.Hostname,
+					"retries":         retryCount,
+					"status":          desiredStatus,
+				}).Info("The Agent is not present in Fleet, as expected")
+				return nil
+			} else if desiredStatus == "online" {
+				retryCount++
+				return fmt.Errorf("The agent is not present in Fleet, but it should")
+			}
 		}
 
 		isAgentInStatus, err := isAgentInStatus(agentID, desiredStatus)
@@ -974,7 +992,7 @@ func getAgentID(agentHostname string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("The Agent with hostname %s is not listed in Fleet", agentHostname)
+	return "", nil
 }
 
 // getDataStreams sends a GET request to Fleet for the existing data-streams

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -68,7 +68,7 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleet(image string) error {
 
 	log.WithFields(log.Fields{
 		"image": image,
-	}).Debug("Deploying an agent to Fleet with base image")
+	}).Trace("Deploying an agent to Fleet with base image")
 
 	fts.Image = image
 
@@ -130,7 +130,7 @@ func (fts *FleetTestSuite) processStateChangedOnTheHost(process string, state st
 	log.WithFields(log.Fields{
 		"service": serviceName,
 		"process": process,
-	}).Debug("Stopping process on the service")
+	}).Trace("Stopping process on the service")
 
 	err := systemctlRun(profile, image, serviceName, "stop")
 	if err != nil {
@@ -153,7 +153,7 @@ func (fts *FleetTestSuite) processStateChangedOnTheHost(process string, state st
 }
 
 func (fts *FleetTestSuite) setup() error {
-	log.Debug("Creating Fleet setup")
+	log.Trace("Creating Fleet setup")
 
 	err := createFleetConfiguration()
 	if err != nil {
@@ -175,7 +175,7 @@ func (fts *FleetTestSuite) setup() error {
 }
 
 func (fts *FleetTestSuite) theAgentIsListedInFleetWithStatus(desiredStatus string) error {
-	log.Debugf("Checking if agent is listed in Fleet as %s", desiredStatus)
+	log.Tracef("Checking if agent is listed in Fleet as %s", desiredStatus)
 
 	maxTimeout := 2 * time.Minute
 	retryCount := 1
@@ -257,7 +257,7 @@ func (fts *FleetTestSuite) theHostIsRestarted() error {
 }
 
 func (fts *FleetTestSuite) systemPackageDashboardsAreListedInFleet() error {
-	log.Debug("Checking system Package dashboards in Fleet")
+	log.Trace("Checking system Package dashboards in Fleet")
 
 	dataStreamsCount := 0
 	maxTimeout := 2 * time.Minute
@@ -321,7 +321,7 @@ func (fts *FleetTestSuite) theAgentIsUnenrolled() error {
 }
 
 func (fts *FleetTestSuite) theAgentIsReenrolledOnTheHost() error {
-	log.Debug("Re-enrolling the agent on the host with same token")
+	log.Trace("Re-enrolling the agent on the host with same token")
 
 	installer := fts.Installers[fts.Image]
 
@@ -337,7 +337,7 @@ func (fts *FleetTestSuite) theEnrollmentTokenIsRevoked() error {
 	log.WithFields(log.Fields{
 		"token":   fts.CurrentToken,
 		"tokenID": fts.CurrentTokenID,
-	}).Debug("Revoking enrollment token")
+	}).Trace("Revoking enrollment token")
 
 	err := fts.removeToken()
 	if err != nil {
@@ -356,7 +356,7 @@ func (fts *FleetTestSuite) theConfigurationShowsTheDatasourceAdded(configuration
 	log.WithFields(log.Fields{
 		"configuration": configurationName,
 		"package":       packageName,
-	}).Debug("Checking if the configuration shows the package added")
+	}).Trace("Checking if the configuration shows the package added")
 
 	maxTimeout := time.Minute
 	retryCount := 1
@@ -415,7 +415,7 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 		"action":        action,
 		"configuration": configurationName,
 		"package":       packageName,
-	}).Debug("Doing an operation for a package on a configuration")
+	}).Trace("Doing an operation for a package on a configuration")
 
 	if strings.ToLower(action) == actionADDED {
 		integrationConfigurationID, err := addIntegrationToConfiguration(fts.Integration, fts.ConfigID)
@@ -442,7 +442,7 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 }
 
 func (fts *FleetTestSuite) theHostNameIsNotShownInTheAdminViewInTheSecurityApp() error {
-	log.Debug("Checking if the hostname is not shown in the Administration view in the Security App")
+	log.Trace("Checking if the hostname is not shown in the Administration view in the Security App")
 
 	maxTimeout := 2 * time.Minute
 	retryCount := 1
@@ -482,7 +482,7 @@ func (fts *FleetTestSuite) theHostNameIsNotShownInTheAdminViewInTheSecurityApp()
 }
 
 func (fts *FleetTestSuite) theHostNameIsShownInTheAdminViewInTheSecurityApp(status string) error {
-	log.Debug("Checking if the hostname is shown in the Admin view in the Security App")
+	log.Trace("Checking if the hostname is shown in the Admin view in the Security App")
 
 	maxTimeout := 2 * time.Minute
 	retryCount := 1
@@ -555,7 +555,7 @@ func (fts *FleetTestSuite) theVersionOfThePackageIsInstalled(version string, pac
 	log.WithFields(log.Fields{
 		"package": packageName,
 		"version": version,
-	}).Debug("Checking if package version is installed")
+	}).Trace("Checking if package version is installed")
 
 	name, version, err := getIntegrationLatestVersion(packageName)
 	if err != nil {
@@ -572,7 +572,7 @@ func (fts *FleetTestSuite) theVersionOfThePackageIsInstalled(version string, pac
 }
 
 func (fts *FleetTestSuite) anAttemptToEnrollANewAgentFails() error {
-	log.Debug("Enrolling a new agent with an revoked token")
+	log.Trace("Enrolling a new agent with an revoked token")
 
 	installer := fts.Installers[fts.Image]
 
@@ -625,7 +625,7 @@ func (fts *FleetTestSuite) removeToken() error {
 
 // unenrollHostname deletes the statuses for an existing agent, filtering by hostname
 func (fts *FleetTestSuite) unenrollHostname(force bool) error {
-	log.Debugf("Un-enrolling all agentIDs for %s", fts.Hostname)
+	log.Tracef("Un-enrolling all agentIDs for %s", fts.Hostname)
 
 	jsonParsed, err := getOnlineAgents()
 	if err != nil {
@@ -667,7 +667,7 @@ func checkFleetConfiguration() error {
 		URL: fleetSetupURL,
 	}
 
-	log.Debug("Ensuring Fleet setup was initialised")
+	log.Trace("Ensuring Fleet setup was initialised")
 	responseBody, err := curl.Get(getReq)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -709,7 +709,7 @@ func createFleetConfiguration() error {
 
 	log.WithFields(log.Fields{
 		"responseBody": body,
-	}).Debug("Fleet setup done")
+	}).Info("Fleet setup done")
 
 	return nil
 }
@@ -859,7 +859,7 @@ func getAgentDefaultConfig() (*gabs.Container, error) {
 
 	log.WithFields(log.Fields{
 		"count": len(configs.Children()),
-	}).Debug("Fleet configs retrieved")
+	}).Trace("Fleet configs retrieved")
 
 	// TODO: perform a strong check to capture default config
 	defaultConfig := configs.Index(0)
@@ -870,7 +870,7 @@ func getAgentDefaultConfig() (*gabs.Container, error) {
 // getAgentIDs sends a GET request to Fleet for a existing hostname
 // This method will retrieve all agent IDs for a hostname
 func getAgentIDs(agentHostname string) ([]string, error) {
-	log.Debugf("Retrieving agentID for %s", agentHostname)
+	log.Tracef("Retrieving agentID for %s", agentHostname)
 
 	jsonParsed, err := getOnlineAgents()
 	if err != nil {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -49,6 +49,12 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
 	s.Step(`^the enrollment token is revoked$`, fts.theEnrollmentTokenIsRevoked)
 	s.Step(`^an attempt to enroll a new agent fails$`, fts.anAttemptToEnrollANewAgentFails)
 	s.Step(`^the "([^"]*)" process is "([^"]*)" on the host$`, fts.processStateChangedOnTheHost)
+
+	// endpoint steps
+	s.Step(`^the "([^"]*)" version of the "([^"]*)" package is installed$`, fts.theVersionOfThePackageIsInstalled)
+	s.Step(`^the "([^"]*)" integration is "([^"]*)" in the "([^"]*)" configuration$`, fts.theIntegrationIsOperatedInTheConfiguration)
+	s.Step(`^the "([^"]*)" datasource is shown in the "([^"]*)" configuration as added$`, fts.theConfigurationShowsTheDatasourceAdded)
+	s.Step(`^the host name is shown in the Security App$`, fts.theHostNameIsShownInTheSecurityApp)
 }
 
 func (fts *FleetTestSuite) anAgentIsDeployedToFleet(image string) error {
@@ -398,6 +404,40 @@ func (fts *FleetTestSuite) theEnrollmentTokenIsRevoked() error {
 	}).Debug("Token was revoked")
 
 	return nil
+}
+
+func (fts *FleetTestSuite) theConfigurationShowsTheDatasourceAdded(configurationName string, packageName string) error {
+	log.WithFields(log.Fields{
+		"configuration": configurationName,
+		"package":       packageName,
+	}).Debug("Checking if the configuration shows the package added")
+
+	return godog.ErrPending
+}
+
+func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageName string, action string, configurationName string) error {
+	log.WithFields(log.Fields{
+		"action":        action,
+		"configuration": configurationName,
+		"package":       packageName,
+	}).Debug("Doing an operation for a package on a configuration")
+
+	return godog.ErrPending
+}
+
+func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp() error {
+	log.Debug("Checking if the hostname is shown in the Security App")
+
+	return godog.ErrPending
+}
+
+func (fts *FleetTestSuite) theVersionOfThePackageIsInstalled(version string, packageName string) error {
+	log.WithFields(log.Fields{
+		"package": packageName,
+		"version": version,
+	}).Debug("Checking if package version is installed")
+
+	return godog.ErrPending
 }
 
 func (fts *FleetTestSuite) anAttemptToEnrollANewAgentFails() error {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -60,7 +60,7 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
 	s.Step(`^the "([^"]*)" integration is "([^"]*)" in the "([^"]*)" configuration$`, fts.theIntegrationIsOperatedInTheConfiguration)
 	s.Step(`^the "([^"]*)" datasource is shown in the "([^"]*)" configuration as added$`, fts.theConfigurationShowsTheDatasourceAdded)
 	s.Step(`^the host name is shown in the Security App$`, fts.theHostNameIsShownInTheSecurityApp)
-	s.Step(`^an Endpoint is successfully deployed with Agent$`, fts.anEndpointIsSuccessfullyDeployedWithAgent)
+	s.Step(`^an Endpoint is successfully deployed with a "([^"]*)" Agent$`, fts.anEndpointIsSuccessfullyDeployedWithAgent)
 	s.Step(`^the policy response will be shown in the Security App$`, fts.thePolicyResponseWillBeShownInTheSecurityApp)
 	s.Step(`^the policy is updated to have malware in detect mode$`, fts.thePolicyIsUpdatedToHaveMalwareInDetectMode)
 	s.Step(`^the policy will reflect the change in the Security App$`, fts.thePolicyWillReflectTheChangeInTheSecurityApp)
@@ -512,8 +512,8 @@ func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp() error {
 	return godog.ErrPending
 }
 
-func (fts *FleetTestSuite) anEndpointIsSuccessfullyDeployedWithAgent() error {
-	err := fts.anAgentIsDeployedToFleet("centos")
+func (fts *FleetTestSuite) anEndpointIsSuccessfullyDeployedWithAgent(image string) error {
+	err := fts.anAgentIsDeployedToFleet(image)
 	if err != nil {
 		return err
 	}

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -57,6 +57,11 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
 	s.Step(`^the "([^"]*)" integration is "([^"]*)" in the "([^"]*)" configuration$`, fts.theIntegrationIsOperatedInTheConfiguration)
 	s.Step(`^the "([^"]*)" datasource is shown in the "([^"]*)" configuration as added$`, fts.theConfigurationShowsTheDatasourceAdded)
 	s.Step(`^the host name is shown in the Security App$`, fts.theHostNameIsShownInTheSecurityApp)
+	s.Step(`^an Endpoint is successfully deployed with Agent$`, fts.anEndpointIsSuccessfullyDeployedWithAgent)
+	s.Step(`^the policy response will be shown in the Security App$`, fts.thePolicyResponseWillBeShownInTheSecurityApp)
+	s.Step(`^the policy is updated to have malware in detect mode$`, fts.thePolicyIsUpdatedToHaveMalwareInDetectMode)
+	s.Step(`^the policy will reflect the change in the Security App$`, fts.thePolicyWillReflectTheChangeInTheSecurityApp)
+	s.Step(`^the endpoint is not listed in Security App as online$`, fts.theEndpointIsNotListedInSecurityAppAsOnline)
 }
 
 func (fts *FleetTestSuite) anAgentIsDeployedToFleet(image string) error {
@@ -491,6 +496,26 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp() error {
 	log.Debug("Checking if the hostname is shown in the Security App")
 
+	return godog.ErrPending
+}
+
+func (fts *FleetTestSuite) anEndpointIsSuccessfullyDeployedWithAgent() error {
+	return godog.ErrPending
+}
+
+func (fts *FleetTestSuite) thePolicyResponseWillBeShownInTheSecurityApp() error {
+	return godog.ErrPending
+}
+
+func (fts *FleetTestSuite) thePolicyIsUpdatedToHaveMalwareInDetectMode() error {
+	return godog.ErrPending
+}
+
+func (fts *FleetTestSuite) thePolicyWillReflectTheChangeInTheSecurityApp() error {
+	return godog.ErrPending
+}
+
+func (fts *FleetTestSuite) theEndpointIsNotListedInSecurityAppAsOnline() error {
 	return godog.ErrPending
 }
 

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -693,22 +692,10 @@ func checkFleetConfiguration() error {
 // createFleetConfiguration sends a POST request to Fleet forcing the
 // recreation of the configuration
 func createFleetConfiguration() error {
-	type payload struct {
-		ForceRecreate bool `json:"forceRecreate"`
-	}
-
-	data := payload{
-		ForceRecreate: true,
-	}
-	payloadBytes, err := json.Marshal(data)
-	if err != nil {
-		log.Error("Could not serialise payload")
-		return err
-	}
-
 	postReq := createDefaultHTTPRequest(fleetSetupURL)
-
-	postReq.Payload = payloadBytes
+	postReq.Payload = `{
+		"forceRecreate": true
+	}`
 
 	body, err := curl.Post(postReq)
 	if err != nil {
@@ -743,24 +730,11 @@ func createDefaultHTTPRequest(url string) curl.HTTPRequest {
 
 // createFleetToken sends a POST request to Fleet creating a new token with a name
 func createFleetToken(name string, configID string) (*gabs.Container, error) {
-	type payload struct {
-		ConfigID string `json:"config_id"`
-		Name     string `json:"name"`
-	}
-
-	data := payload{
-		ConfigID: configID,
-		Name:     name,
-	}
-	payloadBytes, err := json.Marshal(data)
-	if err != nil {
-		log.Error("Could not serialise payload")
-		return nil, err
-	}
-
 	postReq := createDefaultHTTPRequest(fleetEnrollmentTokenURL)
-
-	postReq.Payload = payloadBytes
+	postReq.Payload = `{
+		"config_id": "` + configID + `",
+		"name": "` + name + `"
+	}`
 
 	body, err := curl.Post(postReq)
 	if err != nil {
@@ -1027,19 +1001,9 @@ func unenrollAgent(agentID string, force bool) error {
 	postReq := createDefaultHTTPRequest(unEnrollURL)
 
 	if force {
-		type payload struct {
-			Force bool `json:"force"`
-		}
-
-		data := payload{
-			Force: true,
-		}
-		payloadBytes, err := json.Marshal(data)
-		if err != nil {
-			log.Error("Could not serialise payload")
-			return err
-		}
-		postReq.Payload = payloadBytes
+		postReq.Payload = `{
+			"force": true
+		}`
 	}
 
 	body, err := curl.Post(postReq)

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -60,7 +60,7 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
 	s.Step(`^the host name is not shown in the Administration view in the Security App$`, fts.theHostNameIsNotShownInTheAdminViewInTheSecurityApp)
 	s.Step(`^an Endpoint is successfully deployed with a "([^"]*)" Agent$`, fts.anEndpointIsSuccessfullyDeployedWithAgent)
 	s.Step(`^the policy response will be shown in the Security App$`, fts.thePolicyResponseWillBeShownInTheSecurityApp)
-	s.Step(`^the policy is updated to have malware in detect mode$`, fts.thePolicyIsUpdatedToHaveMalwareInDetectMode)
+	s.Step(`^the policy is updated to have "([^"]*)" in "([^"]*)" mode$`, fts.thePolicyIsUpdatedToHaveMode)
 	s.Step(`^the policy will reflect the change in the Security App$`, fts.thePolicyWillReflectTheChangeInTheSecurityApp)
 }
 
@@ -580,8 +580,53 @@ func (fts *FleetTestSuite) thePolicyResponseWillBeShownInTheSecurityApp() error 
 	return godog.ErrPending
 }
 
-func (fts *FleetTestSuite) thePolicyIsUpdatedToHaveMalwareInDetectMode() error {
-	return godog.ErrPending
+func (fts *FleetTestSuite) thePolicyIsUpdatedToHaveMode(name string, mode string) error {
+	if name != "malware" {
+		log.WithFields(log.Fields{
+			"name": name,
+		}).Warn("We only support 'malware' policy to be updated")
+		return godog.ErrPending
+	}
+
+	if mode != "detect" && mode != "prevent" {
+		log.WithFields(log.Fields{
+			"name": name,
+			"mode": mode,
+		}).Warn("We only support 'detect' and 'prevent' modes")
+		return godog.ErrPending
+	}
+
+	integration, err := getIntegrationFromAgentConfiguration("Elastic Endpoint", fts.ConfigID)
+	if err != nil {
+		return err
+	}
+	fts.Integration = integration
+
+	integrationJSON := fts.Integration.json
+
+	// prune fields not allowed in the API side
+	prunedFields := []string{
+		"created_at", "created_by", "id", "revision", "updated_at", "updated_by",
+	}
+	for _, f := range prunedFields {
+		integrationJSON.Delete(f)
+	}
+
+	// wee only support Windows and Mac, not Linux
+	integrationJSON.SetP(mode, "inputs.0.config.policy.value.windows."+name+".mode")
+	integrationJSON.SetP(mode, "inputs.0.config.policy.value.mac."+name+".mode")
+
+	response, err := updateIntegrationPackageConfig(fts.Integration.packageConfigID, integrationJSON.String())
+	if err != nil {
+		return err
+	}
+
+	success := response.Path("success").Data().(bool)
+	if !success {
+		return fmt.Errorf("The update of the integration package configuration failed. %v", response)
+	}
+
+	return nil
 }
 
 func (fts *FleetTestSuite) thePolicyWillReflectTheChangeInTheSecurityApp() error {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -63,7 +63,7 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
 	s.Step(`^the policy response will be shown in the Security App$`, fts.thePolicyResponseWillBeShownInTheSecurityApp)
 	s.Step(`^the policy is updated to have malware in detect mode$`, fts.thePolicyIsUpdatedToHaveMalwareInDetectMode)
 	s.Step(`^the policy will reflect the change in the Security App$`, fts.thePolicyWillReflectTheChangeInTheSecurityApp)
-	s.Step(`^the endpoint is not listed in Security App as online$`, fts.theEndpointIsNotListedInSecurityAppAsOnline)
+	s.Step(`^the endpoint is listed in Security App as "([^"]*)"$`, fts.theEndpointIsListedInSecurityAppAs)
 }
 
 func (fts *FleetTestSuite) anAgentIsDeployedToFleet(image string) error {
@@ -540,7 +540,7 @@ func (fts *FleetTestSuite) thePolicyWillReflectTheChangeInTheSecurityApp() error
 	return godog.ErrPending
 }
 
-func (fts *FleetTestSuite) theEndpointIsNotListedInSecurityAppAsOnline() error {
+func (fts *FleetTestSuite) theEndpointIsListedInSecurityAppAs(status string) error {
 	return godog.ErrPending
 }
 

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -434,7 +434,7 @@ func (fts *FleetTestSuite) theConfigurationShowsTheDatasourceAdded(configuration
 			log.WithFields(log.Fields{
 				"error":           err,
 				"packageConfigID": fts.Integration.packageConfigID,
-				"configurationID": fts.ConfigID,
+				"configurationID": fts.PolicyID,
 				"retry":           retryCount,
 			}).Warn("An error retrieving the configuration happened")
 
@@ -450,7 +450,7 @@ func (fts *FleetTestSuite) theConfigurationShowsTheDatasourceAdded(configuration
 			if id == fts.Integration.packageConfigID {
 				log.WithFields(log.Fields{
 					"packageConfigID": fts.Integration.packageConfigID,
-					"configurationID": fts.ConfigID,
+					"configurationID": fts.PolicyID,
 				}).Info("The integration was found in the configuration")
 				return nil
 			}
@@ -458,7 +458,7 @@ func (fts *FleetTestSuite) theConfigurationShowsTheDatasourceAdded(configuration
 
 		log.WithFields(log.Fields{
 			"packageConfigID": fts.Integration.packageConfigID,
-			"configurationID": fts.ConfigID,
+			"configurationID": fts.PolicyID,
 			"retry":           retryCount,
 		}).Warn("The integration was not found in the configuration")
 
@@ -483,7 +483,7 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 	}).Debug("Doing an operation for a package on a configuration")
 
 	if strings.ToLower(action) == actionADDED {
-		integrationConfigurationID, err := addIntegrationToConfiguration(fts.Integration, fts.ConfigID)
+		integrationConfigurationID, err := addIntegrationToPolicy(fts.Integration, fts.PolicyID)
 		if err != nil {
 			return err
 		}
@@ -491,12 +491,12 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 		fts.Integration.packageConfigID = integrationConfigurationID
 		return nil
 	} else if strings.ToLower(action) == actionREMOVED {
-		err := deleteIntegrationFromConfiguration(fts.Integration, fts.ConfigID)
+		err := deleteIntegrationFromPolicy(fts.Integration, fts.PolicyID)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"err":             err,
 				"packageConfigID": fts.Integration.packageConfigID,
-				"configurationID": fts.ConfigID,
+				"configurationID": fts.PolicyID,
 			}).Error("The integration could not be deleted from the configuration")
 			return err
 		}

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -515,11 +515,6 @@ func (fts *FleetTestSuite) anEndpointIsSuccessfullyDeployedWithAgent(image strin
 		return err
 	}
 
-	err = fts.theVersionOfThePackageIsInstalled("latest", "endpoint")
-	if err != nil {
-		return err
-	}
-
 	err = fts.theIntegrationIsOperatedInTheConfiguration("enpdoint", actionADDED, "default")
 	if err != nil {
 		return err

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -328,8 +328,23 @@ func (fts *FleetTestSuite) theAgentIsUnenrolled() error {
 		"agentID": fts.EnrolledAgentID,
 	}).Debug("Un-enrolling agent in Fleet")
 
+	type payload struct {
+		Force bool `json:"force"`
+	}
+
+	data := payload{
+		Force: true,
+	}
+	payloadBytes, err := json.Marshal(data)
+	if err != nil {
+		log.Error("Could not serialise payload")
+		return err
+	}
+
 	unEnrollURL := fmt.Sprintf(fleetAgentsUnEnrollURL, fts.EnrolledAgentID)
 	postReq := createDefaultHTTPRequest(unEnrollURL)
+
+	postReq.Payload = payloadBytes
 
 	body, err := curl.Post(postReq)
 	if err != nil {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -711,7 +711,7 @@ func (fts *FleetTestSuite) thePolicyWillReflectTheChangeInTheSecurityApp() error
 	exp := e2e.GetExponentialBackOff(maxTimeout)
 
 	getEventsFn := func() error {
-		err := getAgentEvents(agentID, fts.PolicyID, fts.PolicyUpdatedAt)
+		err := getAgentEvents("endpoint-security", agentID, fts.Integration.packageConfigID, fts.PolicyUpdatedAt)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"elapsedTime": exp.GetElapsedTime(),
@@ -1055,7 +1055,7 @@ func getAgentDefaultConfig() (*gabs.Container, error) {
 	return defaultConfig, nil
 }
 
-func getAgentEvents(agentID string, policyID string, updatedAt string) error {
+func getAgentEvents(applicationName string, agentID string, packagePolicyID string, updatedAt string) error {
 	url := fmt.Sprintf(fleetAgentEventsURL, agentID)
 	getReq := createDefaultHTTPRequest(url)
 	getReq.QueryString = "page=1&perPage=20"
@@ -1063,10 +1063,12 @@ func getAgentEvents(agentID string, policyID string, updatedAt string) error {
 	body, err := curl.Get(getReq)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"agentID": agentID,
-			"body":    body,
-			"error":   err,
-			"url":     url,
+			"agentID":         agentID,
+			"application":     applicationName,
+			"body":            body,
+			"error":           err,
+			"packagePolicyID": packagePolicyID,
+			"url":             url,
 		}).Error("Could not get agent events from Fleet")
 		return err
 	}
@@ -1086,28 +1088,31 @@ func getAgentEvents(agentID string, policyID string, updatedAt string) error {
 		timestamp := item.Path("timestamp").Data().(string)
 
 		log.WithFields(log.Fields{
-			"agentID":    agentID,
-			"policyID":   policyID,
-			"event_at":   timestamp,
-			"message":    message,
-			"updated_at": updatedAt,
+			"agentID":         agentID,
+			"application":     applicationName,
+			"event_at":        timestamp,
+			"message":         message,
+			"packagePolicyID": packagePolicyID,
+			"updated_at":      updatedAt,
 		}).Trace("Event found")
 
-		matches := (strings.Contains(message, "endpoint-security") &&
-			strings.Contains(message, "["+agentID+"]: State changed to RUNNING: Running") &&
-			strings.Contains(message, "Protecting with policy {"+policyID+"}"))
+		matches := (strings.Contains(message, applicationName) &&
+			strings.Contains(message, "["+agentID+"]: State changed to") &&
+			strings.Contains(message, "Protecting with policy {"+packagePolicyID+"}"))
 
 		if matches && timestamp > updatedAt {
 			log.WithFields(log.Fields{
-				"updated_at": updatedAt,
-				"event_at":   timestamp,
-				"message":    message,
+				"application":     applicationName,
+				"event_at":        timestamp,
+				"packagePolicyID": packagePolicyID,
+				"updated_at":      updatedAt,
+				"message":         message,
 			}).Info("Event after the update was found")
 			return nil
 		}
 	}
 
-	return fmt.Errorf("No events where found for the agent in the policy")
+	return fmt.Errorf("No %s events where found for the agent in the %s policy", applicationName, packagePolicyID)
 }
 
 // getAgentID sends a GET request to Fleet for a existing hostname

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -815,7 +815,7 @@ func (fts *FleetTestSuite) removeToken() error {
 func (fts *FleetTestSuite) unenrollHostname(force bool) error {
 	log.Tracef("Un-enrolling all agentIDs for %s", fts.Hostname)
 
-	jsonParsed, err := getOnlineAgents()
+	jsonParsed, err := getOnlineAgents(true)
 	if err != nil {
 		return err
 	}
@@ -1115,7 +1115,7 @@ func getAgentEvents(agentID string, policyID string, updatedAt string) error {
 func getAgentID(agentHostname string) (string, error) {
 	log.Tracef("Retrieving agentID for %s", agentHostname)
 
-	jsonParsed, err := getOnlineAgents()
+	jsonParsed, err := getOnlineAgents(false)
 	if err != nil {
 		return "", err
 	}
@@ -1175,13 +1175,13 @@ func getDataStreams() (*gabs.Container, error) {
 // getOnlineAgents sends a GET request to Fleet for the existing online agents
 // Will return the JSON object representing the response of querying Fleet's Agents
 // endpoint
-func getOnlineAgents() (*gabs.Container, error) {
+func getOnlineAgents(showInactive bool) (*gabs.Container, error) {
 	r := createDefaultHTTPRequest(fleetAgentsURL)
 	// let's not URL encode the querystring, as it seems Kibana is not handling
 	// the request properly, returning an 400 Bad Request error with this message:
 	// [request query.page=1&perPage=20&showInactive=true]: definition for this key is missing
 	r.EncodeURL = false
-	r.QueryString = fmt.Sprintf("page=1&perPage=20&showInactive=%t", false)
+	r.QueryString = fmt.Sprintf("page=1&perPage=20&showInactive=%t", showInactive)
 
 	body, err := curl.Get(r)
 	if err != nil {
@@ -1223,11 +1223,7 @@ func isAgentInStatus(agentID string, desiredStatus string) (bool, error) {
 
 	agentStatus := jsonResponse.Path("item.status").Data().(string)
 
-	if strings.ToLower(agentStatus) == desiredStatus {
-		return true, nil
-	}
-
-	return false, fmt.Errorf("There is no agentID in the %s status", desiredStatus)
+	return (strings.ToLower(agentStatus) == strings.ToLower(desiredStatus)), nil
 }
 
 func unenrollAgent(agentID string, force bool) error {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -415,7 +415,56 @@ func (fts *FleetTestSuite) theConfigurationShowsTheDatasourceAdded(configuration
 		"package":       packageName,
 	}).Debug("Checking if the configuration shows the package added")
 
-	return godog.ErrPending
+	maxTimeout := time.Minute
+	retryCount := 1
+
+	exp := e2e.GetExponentialBackOff(maxTimeout)
+
+	configurationIsPresentFn := func() error {
+		defaultConfig, err := getAgentDefaultConfig()
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error":           err,
+				"packageConfigID": fts.Integration.packageConfigID,
+				"configurationID": fts.ConfigID,
+				"retry":           retryCount,
+			}).Warn("An error retrieving the configuration happened")
+
+			retryCount++
+
+			return err
+		}
+
+		packageConfigs := defaultConfig.Path("package_configs")
+
+		for _, child := range packageConfigs.Children() {
+			id := child.Data().(string)
+			if id == fts.Integration.packageConfigID {
+				log.WithFields(log.Fields{
+					"packageConfigID": fts.Integration.packageConfigID,
+					"configurationID": fts.ConfigID,
+				}).Info("The integration was found in the configuration")
+				return nil
+			}
+		}
+
+		log.WithFields(log.Fields{
+			"packageConfigID": fts.Integration.packageConfigID,
+			"configurationID": fts.ConfigID,
+			"retry":           retryCount,
+		}).Warn("The integration was not found in the configuration")
+
+		retryCount++
+
+		return err
+	}
+
+	err := backoff.Retry(configurationIsPresentFn, exp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageName string, action string, configurationName string) error {
@@ -429,7 +478,14 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 		return godog.ErrPending
 	}
 
-	return addIntegrationToConfiguration(fts.Integration, fts.ConfigID)
+	integrationConfigurationID, err := addIntegrationToConfiguration(fts.Integration, fts.ConfigID)
+	if err != nil {
+		return err
+	}
+
+	fts.Integration.packageConfigID = integrationConfigurationID
+
+	return nil
 }
 
 func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp() error {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -58,7 +58,7 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
 	s.Step(`^the "([^"]*)" version of the "([^"]*)" package is installed$`, fts.theVersionOfThePackageIsInstalled)
 	s.Step(`^the "([^"]*)" integration is "([^"]*)" in the "([^"]*)" configuration$`, fts.theIntegrationIsOperatedInTheConfiguration)
 	s.Step(`^the "([^"]*)" datasource is shown in the "([^"]*)" configuration as added$`, fts.theConfigurationShowsTheDatasourceAdded)
-	s.Step(`^the host name is shown in the Security App$`, fts.theHostNameIsShownInTheSecurityApp)
+	s.Step(`^the host name is shown in the Security App as "([^"]*)"$`, fts.theHostNameIsShownInTheSecurityApp)
 	s.Step(`^an Endpoint is successfully deployed with a "([^"]*)" Agent$`, fts.anEndpointIsSuccessfullyDeployedWithAgent)
 	s.Step(`^the policy response will be shown in the Security App$`, fts.thePolicyResponseWillBeShownInTheSecurityApp)
 	s.Step(`^the policy is updated to have malware in detect mode$`, fts.thePolicyIsUpdatedToHaveMalwareInDetectMode)
@@ -464,10 +464,49 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 	return godog.ErrPending
 }
 
-func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp() error {
+func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp(status string) error {
 	log.Debug("Checking if the hostname is shown in the Security App")
 
-	return godog.ErrPending
+	maxTimeout := 2 * time.Minute
+	retryCount := 1
+
+	exp := e2e.GetExponentialBackOff(maxTimeout)
+
+	agentListedInSecurityFn := func() error {
+		matches, err := isAgentListedInSecurityAppWithStatus(fts.Hostname, status)
+		if err != nil || !matches {
+			log.WithFields(log.Fields{
+				"agentID":       fts.EnrolledAgentID,
+				"elapsedTime":   exp.GetElapsedTime(),
+				"desiredStatus": status,
+				"err":           err,
+				"hostname":      fts.Hostname,
+				"matches":       matches,
+				"retry":         retryCount,
+			}).Warn("The agent is not listed in the Security App in the desired status yet")
+
+			retryCount++
+
+			return err
+		}
+
+		log.WithFields(log.Fields{
+			"agentID":       fts.EnrolledAgentID,
+			"elapsedTime":   exp.GetElapsedTime(),
+			"desiredStatus": status,
+			"hostname":      fts.Hostname,
+			"matches":       matches,
+			"retries":       retryCount,
+		}).Info("The Agent is listed in the Security App in the desired status")
+		return nil
+	}
+
+	err := backoff.Retry(agentListedInSecurityFn, exp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (fts *FleetTestSuite) anEndpointIsSuccessfullyDeployedWithAgent(image string) error {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -31,14 +31,13 @@ const actionREMOVED = "removed"
 
 // FleetTestSuite represents the scenarios for Fleet-mode
 type FleetTestSuite struct {
-	EnrolledAgentID string // will be used to store current agent
-	Image           string // base image used to install the agent
-	Installers      map[string]ElasticAgentInstaller
-	Cleanup         bool
-	ConfigID        string // will be used to manage tokens
-	CurrentToken    string // current enrollment token
-	CurrentTokenID  string // current enrollment tokenID
-	Hostname        string // the hostname of the container
+	Image          string // base image used to install the agent
+	Installers     map[string]ElasticAgentInstaller
+	Cleanup        bool
+	ConfigID       string // will be used to manage tokens
+	CurrentToken   string // current enrollment token
+	CurrentTokenID string // current enrollment tokenID
+	Hostname       string // the hostname of the container
 	// integrations
 	Integration IntegrationPackage // the installed integration
 }
@@ -112,9 +111,6 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleet(image string) error {
 	if err != nil {
 		return err
 	}
-
-	// get first agentID in online status, for future processing
-	fts.EnrolledAgentID, err = getAgentID(true, 0)
 
 	return err
 }
@@ -195,14 +191,19 @@ func (fts *FleetTestSuite) theAgentIsListedInFleetWithStatus(desiredStatus strin
 	exp := e2e.GetExponentialBackOff(maxTimeout)
 
 	agentOnlineFn := func() error {
-		isAgentInStatus, err := isAgentInStatus(fts.EnrolledAgentID, desiredStatus)
+		agentIDs, err := getAgentIDs(fts.Hostname)
+		if err != nil {
+			return err
+		}
+
+		isAgentInStatus, err := isAgentInStatus(agentIDs, desiredStatus)
 		if err != nil || !isAgentInStatus {
 			if err == nil {
 				err = fmt.Errorf("The Agent is not in the %s status yet", desiredStatus)
 			}
 
 			log.WithFields(log.Fields{
-				"agentID":         fts.EnrolledAgentID,
+				"agentIDs":        agentIDs,
 				"isAgentInStatus": isAgentInStatus,
 				"elapsedTime":     exp.GetElapsedTime(),
 				"hostname":        fts.Hostname,
@@ -324,44 +325,7 @@ func (fts *FleetTestSuite) systemPackageDashboardsAreListedInFleet() error {
 }
 
 func (fts *FleetTestSuite) theAgentIsUnenrolled() error {
-	log.WithFields(log.Fields{
-		"agentID": fts.EnrolledAgentID,
-	}).Debug("Un-enrolling agent in Fleet")
-
-	type payload struct {
-		Force bool `json:"force"`
-	}
-
-	data := payload{
-		Force: true,
-	}
-	payloadBytes, err := json.Marshal(data)
-	if err != nil {
-		log.Error("Could not serialise payload")
-		return err
-	}
-
-	unEnrollURL := fmt.Sprintf(fleetAgentsUnEnrollURL, fts.EnrolledAgentID)
-	postReq := createDefaultHTTPRequest(unEnrollURL)
-
-	postReq.Payload = payloadBytes
-
-	body, err := curl.Post(postReq)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"agentID": fts.EnrolledAgentID,
-			"body":    body,
-			"error":   err,
-			"url":     unEnrollURL,
-		}).Error("Could unenroll agent")
-		return err
-	}
-
-	log.WithFields(log.Fields{
-		"agentID": fts.EnrolledAgentID,
-	}).Debug("Fleet agent was unenrolled")
-
-	return nil
+	return fts.unenrollHostname()
 }
 
 func (fts *FleetTestSuite) theAgentIsReenrolledOnTheHost() error {
@@ -497,7 +461,6 @@ func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp(status string) err
 		matches, err := isAgentListedInSecurityAppWithStatus(fts.Hostname, status)
 		if err != nil || !matches {
 			log.WithFields(log.Fields{
-				"agentID":       fts.EnrolledAgentID,
 				"elapsedTime":   exp.GetElapsedTime(),
 				"desiredStatus": status,
 				"err":           err,
@@ -512,7 +475,6 @@ func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp(status string) err
 		}
 
 		log.WithFields(log.Fields{
-			"agentID":       fts.EnrolledAgentID,
 			"elapsedTime":   exp.GetElapsedTime(),
 			"desiredStatus": status,
 			"hostname":      fts.Hostname,
@@ -627,6 +589,37 @@ func (fts *FleetTestSuite) removeToken() error {
 			"url":     revokeTokenURL,
 		}).Error("Could not delete token")
 		return err
+	}
+
+	return nil
+}
+
+// unenrollHostname deletes the statuses for an existing agent, filtering by hostname
+func (fts *FleetTestSuite) unenrollHostname() error {
+	log.Debugf("Un-enrolling all agentIDs for %s", fts.Hostname)
+
+	jsonParsed, err := getOnlineAgents()
+	if err != nil {
+		return err
+	}
+
+	hosts := jsonParsed.Path("list").Children()
+
+	for _, host := range hosts {
+		hostname := host.Path("local_metadata.host.hostname").Data().(string)
+		// a hostname has an agentID by status
+		if hostname == fts.Hostname {
+			agentID := host.Path("id").Data().(string)
+			log.WithFields(log.Fields{
+				"hostname": fts.Hostname,
+				"agentID":  agentID,
+			}).Debug("Un-enrolling agent in Fleet")
+
+			err := unenrollAgent(agentID)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -870,23 +863,38 @@ func getAgentDefaultConfig() (*gabs.Container, error) {
 	return defaultConfig, nil
 }
 
-// getAgentID sends a GET request to Fleet for the existing agents
-// allowing to filter by agent status: online, offline. This method will
-// retrieve the agent ID
-func getAgentID(online bool, index int) (string, error) {
+// getAgentIDs sends a GET request to Fleet for a existing hostname
+// This method will retrieve all agent IDs for a hostname
+func getAgentIDs(agentHostname string) ([]string, error) {
+	log.Debugf("Retrieving agentID for %s", agentHostname)
+
 	jsonParsed, err := getOnlineAgents()
 	if err != nil {
-		return "", err
+		return []string{}, err
 	}
 
-	agentID := jsonParsed.Path("list").Index(index).Path("id").Data().(string)
+	hosts := jsonParsed.Path("list").Children()
 
-	log.WithFields(log.Fields{
-		"index":   index,
-		"agentID": agentID,
-	}).Debug("Agent ID retrieved")
+	agentIDs := []string{}
 
-	return agentID, nil
+	for _, host := range hosts {
+		hostname := host.Path("local_metadata.host.hostname").Data().(string)
+		// an agentID by status is created for a hostname: inactive has different ID than online, that's why we must get the ID for online
+		if hostname == agentHostname {
+			agentID := host.Path("id").Data().(string)
+			log.WithFields(log.Fields{
+				"hostname": agentHostname,
+				"agentID":  agentID,
+			}).Debug("Agent listed in Fleet")
+			agentIDs = append(agentIDs, agentID)
+		}
+	}
+
+	if len(agentIDs) > 0 {
+		return agentIDs, nil
+	}
+
+	return agentIDs, fmt.Errorf("The Agent with hostname %s is not listed in Fleet", agentHostname)
 }
 
 // getDataStreams sends a GET request to Fleet for the existing data-streams
@@ -924,7 +932,7 @@ func getDataStreams() (*gabs.Container, error) {
 	return dataStreams, nil
 }
 
-// getAgentsByStatus sends a GET request to Fleet for the existing online agents
+// getOnlineAgents sends a GET request to Fleet for the existing online agents
 // Will return the JSON object representing the response of querying Fleet's Agents
 // endpoint
 func getOnlineAgents() (*gabs.Container, error) {
@@ -959,23 +967,64 @@ func getOnlineAgents() (*gabs.Container, error) {
 
 // isAgentInStatus extracts the status for an agent, identified by its hostname
 // It will query Fleet's agents endpoint
-func isAgentInStatus(agentID string, desiredStatus string) (bool, error) {
-	r := createDefaultHTTPRequest(fleetAgentsURL + "/" + agentID)
-	body, err := curl.Get(r)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"body":  body,
-			"error": err,
-			"url":   r.GetURL(),
-		}).Error("Could not get agent in Fleet")
-		return false, err
+func isAgentInStatus(agentIDs []string, desiredStatus string) (bool, error) {
+	for _, agentID := range agentIDs {
+		r := createDefaultHTTPRequest(fleetAgentsURL + "/" + agentID)
+		body, err := curl.Get(r)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"body":  body,
+				"error": err,
+				"url":   r.GetURL(),
+			}).Error("Could not get agent in Fleet")
+			return false, err
+		}
+
+		jsonResponse, err := gabs.ParseJSON([]byte(body))
+
+		agentStatus := jsonResponse.Path("item.status").Data().(string)
+
+		if strings.ToLower(agentStatus) == desiredStatus {
+			return true, nil
+		}
 	}
 
-	jsonResponse, err := gabs.ParseJSON([]byte(body))
+	return false, fmt.Errorf("There are no agentIDs in the %s status", desiredStatus)
+}
 
-	agentStatus := jsonResponse.Path("item.status").Data().(string)
+func unenrollAgent(agentID string) error {
+	type payload struct {
+		Force bool `json:"force"`
+	}
 
-	isAgentInStatus := (strings.ToLower(agentStatus) == desiredStatus)
+	data := payload{
+		Force: true,
+	}
+	payloadBytes, err := json.Marshal(data)
+	if err != nil {
+		log.Error("Could not serialise payload")
+		return err
+	}
 
-	return isAgentInStatus, nil
+	unEnrollURL := fmt.Sprintf(fleetAgentsUnEnrollURL, agentID)
+	postReq := createDefaultHTTPRequest(unEnrollURL)
+
+	postReq.Payload = payloadBytes
+
+	body, err := curl.Post(postReq)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"agentID": agentID,
+			"body":    body,
+			"error":   err,
+			"url":     unEnrollURL,
+		}).Error("Could unenroll agent")
+		return err
+	}
+
+	log.WithFields(log.Fields{
+		"agentID": agentID,
+	}).Debug("Fleet agent was unenrolled")
+
+	return nil
 }

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -57,8 +57,8 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.Suite) {
 	s.Step(`^the "([^"]*)" version of the "([^"]*)" package is installed$`, fts.theVersionOfThePackageIsInstalled)
 	s.Step(`^the "([^"]*)" integration is "([^"]*)" in the "([^"]*)" configuration$`, fts.theIntegrationIsOperatedInTheConfiguration)
 	s.Step(`^the "([^"]*)" datasource is shown in the "([^"]*)" configuration as added$`, fts.theConfigurationShowsTheDatasourceAdded)
-	s.Step(`^the host name is shown in the Security App as "([^"]*)"$`, fts.theHostNameIsShownInTheSecurityApp)
-	s.Step(`^the host name is not shown in the Security App$`, fts.theHostNameIsNotShownInTheSecurityApp)
+	s.Step(`^the host name is shown in the Administration view in the Security App as "([^"]*)"$`, fts.theHostNameIsShownInTheAdminViewInTheSecurityApp)
+	s.Step(`^the host name is not shown in the Administration view in the Security App$`, fts.theHostNameIsNotShownInTheAdminViewInTheSecurityApp)
 	s.Step(`^an Endpoint is successfully deployed with a "([^"]*)" Agent$`, fts.anEndpointIsSuccessfullyDeployedWithAgent)
 	s.Step(`^the policy response will be shown in the Security App$`, fts.thePolicyResponseWillBeShownInTheSecurityApp)
 	s.Step(`^the policy is updated to have malware in detect mode$`, fts.thePolicyIsUpdatedToHaveMalwareInDetectMode)
@@ -449,8 +449,8 @@ func (fts *FleetTestSuite) theIntegrationIsOperatedInTheConfiguration(packageNam
 	return godog.ErrPending
 }
 
-func (fts *FleetTestSuite) theHostNameIsNotShownInTheSecurityApp() error {
-	log.Debug("Checking if the hostname is not shown in the Security App")
+func (fts *FleetTestSuite) theHostNameIsNotShownInTheAdminViewInTheSecurityApp() error {
+	log.Debug("Checking if the hostname is not shown in the Administration view in the Security App")
 
 	maxTimeout := 2 * time.Minute
 	retryCount := 1
@@ -466,7 +466,7 @@ func (fts *FleetTestSuite) theHostNameIsNotShownInTheSecurityApp() error {
 				"host":        host,
 				"hostname":    fts.Hostname,
 				"retry":       retryCount,
-			}).Warn("We could not check the agent in the Security App yet")
+			}).Warn("We could not check the agent in the Administration view in the Security App yet")
 
 			retryCount++
 
@@ -477,7 +477,7 @@ func (fts *FleetTestSuite) theHostNameIsNotShownInTheSecurityApp() error {
 			"elapsedTime": exp.GetElapsedTime(),
 			"hostname":    fts.Hostname,
 			"retries":     retryCount,
-		}).Info("The Agent is not listed in the Security App")
+		}).Info("The Agent is not listed in the Administration view in the Security App")
 		return nil
 	}
 
@@ -489,8 +489,8 @@ func (fts *FleetTestSuite) theHostNameIsNotShownInTheSecurityApp() error {
 	return nil
 }
 
-func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp(status string) error {
-	log.Debug("Checking if the hostname is shown in the Security App")
+func (fts *FleetTestSuite) theHostNameIsShownInTheAdminViewInTheSecurityApp(status string) error {
+	log.Debug("Checking if the hostname is shown in the Admin view in the Security App")
 
 	maxTimeout := 2 * time.Minute
 	retryCount := 1
@@ -507,7 +507,7 @@ func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp(status string) err
 				"hostname":      fts.Hostname,
 				"matches":       matches,
 				"retry":         retryCount,
-			}).Warn("The agent is not listed in the Security App in the desired status yet")
+			}).Warn("The agent is not listed in the Administration view in the Security App in the desired status yet")
 
 			retryCount++
 
@@ -520,7 +520,7 @@ func (fts *FleetTestSuite) theHostNameIsShownInTheSecurityApp(status string) err
 			"hostname":      fts.Hostname,
 			"matches":       matches,
 			"retries":       retryCount,
-		}).Info("The Agent is listed in the Security App in the desired status")
+		}).Info("The Agent is listed in the Administration view in the Security App in the desired status")
 		return nil
 	}
 

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -178,7 +178,7 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 		}
 
 		if imts.Fleet.Cleanup {
-			err := imts.Fleet.unenrollHostname()
+			err := imts.Fleet.unenrollHostname(true)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"err":      err,

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -192,6 +192,15 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 					"tokenID": imts.Fleet.CurrentTokenID,
 				}).Warn("The enrollment token could not be deleted")
 			}
+
+			err = deleteIntegrationFromConfiguration(imts.Fleet.Integration, imts.Fleet.ConfigID)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"err":             err,
+					"packageConfigID": imts.Fleet.Integration.packageConfigID,
+					"configurationID": imts.Fleet.ConfigID,
+				}).Warn("The integration could not be deleted from the configuration")
+			}
 		}
 
 		imts.Fleet.Image = ""

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -82,7 +82,7 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 	imts.StandAlone.contributeSteps(s)
 
 	s.BeforeSuite(func() {
-		log.Debug("Installing ingest-manager runtime dependencies")
+		log.Trace("Installing ingest-manager runtime dependencies")
 
 		workDir, _ := os.Getwd()
 		profileEnv = map[string]string{
@@ -120,7 +120,7 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 		imts.StandAlone.RuntimeDependenciesStartDate = time.Now().UTC()
 	})
 	s.BeforeScenario(func(*messages.Pickle) {
-		log.Debug("Before Ingest Manager scenario")
+		log.Trace("Before Ingest Manager scenario")
 
 		imts.StandAlone.Cleanup = false
 	})
@@ -159,7 +159,7 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 		}
 	})
 	s.AfterScenario(func(*messages.Pickle, error) {
-		log.Debug("After Ingest Manager scenario")
+		log.Trace("After Ingest Manager scenario")
 
 		if imts.StandAlone.Cleanup {
 			serviceName := ElasticAgentServiceName
@@ -295,7 +295,7 @@ func execCommandInService(profile string, image string, serviceName string, cmds
 func getContainerHostname(containerName string) (string, error) {
 	log.WithFields(log.Fields{
 		"containerName": containerName,
-	}).Debug("Retrieving container name from the Docker client")
+	}).Trace("Retrieving container name from the Docker client")
 
 	hostname, err := docker.ExecCommandIntoContainer(context.Background(), containerName, "root", []string{"hostname"})
 	if err != nil {
@@ -310,7 +310,7 @@ func getContainerHostname(containerName string) (string, error) {
 		hostname = strings.ReplaceAll(hostname, "\x01\x00\x00\x00\x00\x00\x00\r", "")
 		log.WithFields(log.Fields{
 			"hostname": hostname,
-		}).Debug("Container name has been sanitized")
+		}).Trace("Container name has been sanitized")
 	}
 
 	log.WithFields(log.Fields{

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -178,6 +178,14 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 		}
 
 		if imts.Fleet.Cleanup {
+			err := imts.Fleet.unenrollHostname()
+			if err != nil {
+				log.WithFields(log.Fields{
+					"err":      err,
+					"hostname": imts.Fleet.Hostname,
+				}).Warn("The agentIDs for the hostname could not be unenrolled")
+			}
+
 			serviceName := imts.Fleet.Image
 			if !developerMode {
 				_ = serviceManager.RemoveServicesFromCompose(IngestManagerProfileName, []string{serviceName}, profileEnv)
@@ -185,7 +193,7 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 				log.WithField("service", serviceName).Info("Because we are running in development mode, the service won't be stopped")
 			}
 
-			err := imts.Fleet.removeToken()
+			err = imts.Fleet.removeToken()
 			if err != nil {
 				log.WithFields(log.Fields{
 					"err":     err,

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -193,12 +193,12 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 				}).Warn("The enrollment token could not be deleted")
 			}
 
-			err = deleteIntegrationFromConfiguration(imts.Fleet.Integration, imts.Fleet.ConfigID)
+			err = deleteIntegrationFromPolicy(imts.Fleet.Integration, imts.Fleet.PolicyID)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"err":             err,
 					"packageConfigID": imts.Fleet.Integration.packageConfigID,
-					"configurationID": imts.Fleet.ConfigID,
+					"configurationID": imts.Fleet.PolicyID,
 				}).Warn("The integration could not be deleted from the configuration")
 			}
 		}

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -193,12 +193,12 @@ func IngestManagerFeatureContext(s *godog.Suite) {
 				}).Warn("The enrollment token could not be deleted")
 			}
 
-			err = deleteIntegrationFromPolicy(imts.Fleet.Integration, imts.Fleet.PolicyID)
+			err = deleteIntegrationFromConfiguration(imts.Fleet.Integration, imts.Fleet.ConfigID)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"err":             err,
 					"packageConfigID": imts.Fleet.Integration.packageConfigID,
-					"configurationID": imts.Fleet.PolicyID,
+					"configurationID": imts.Fleet.ConfigID,
 				}).Warn("The integration could not be deleted from the configuration")
 			}
 		}

--- a/e2e/_suites/ingest-manager/integrations.go
+++ b/e2e/_suites/ingest-manager/integrations.go
@@ -22,8 +22,8 @@ type IntegrationPackage struct {
 	version         string `json:"version"`
 }
 
-// installIntegration sends a POST request to Ingest Manager adding an integration to a configuration
-func addIntegrationToConfiguration(integrationPackage IntegrationPackage, configurationID string) (string, error) {
+// addIntegrationToPolicy sends a POST request to Ingest Manager adding an integration to a configuration
+func addIntegrationToPolicy(integrationPackage IntegrationPackage, configurationID string) (string, error) {
 	postReq := createDefaultHTTPRequest(ingestManagerIntegrationConfigsURL)
 
 	data := `{
@@ -73,8 +73,8 @@ func addIntegrationToConfiguration(integrationPackage IntegrationPackage, config
 	return integrationConfigurationID, nil
 }
 
-// deleteIntegrationFromConfiguration sends a POST request to Ingest Manager deleting an integration from a configuration
-func deleteIntegrationFromConfiguration(integrationPackage IntegrationPackage, configurationID string) error {
+// deleteIntegrationFromPolicy sends a POST request to Ingest Manager deleting an integration from a configuration
+func deleteIntegrationFromPolicy(integrationPackage IntegrationPackage, configurationID string) error {
 	postReq := createDefaultHTTPRequest(ingestManagerIntegrationDeleteURL)
 
 	data := `{"packageConfigIds":["` + integrationPackage.packageConfigID + `"]}`

--- a/e2e/_suites/ingest-manager/integrations.go
+++ b/e2e/_suites/ingest-manager/integrations.go
@@ -132,7 +132,7 @@ func getIntegrationLatestVersion(integrationName string) (string, string, error)
 
 	log.WithFields(log.Fields{
 		"count": len(integrations),
-	}).Debug("Integrations retrieved")
+	}).Trace("Integrations retrieved")
 
 	for _, integration := range integrations {
 		name := integration.Path("name").Data().(string)
@@ -163,7 +163,7 @@ func installIntegrationAssets(integration string, version string) (IntegrationPa
 	log.WithFields(log.Fields{
 		"integration": integration,
 		"version":     version,
-	}).Debug("Assets for the integration where installed")
+	}).Info("Assets for the integration where installed")
 
 	jsonParsed, err := gabs.ParseJSON([]byte(body))
 	if err != nil {
@@ -236,7 +236,7 @@ func isAgentListedInSecurityApp(hostName string) (*gabs.Container, error) {
 
 	log.WithFields(log.Fields{
 		"hosts": hosts,
-	}).Debug("Hosts in the Security App")
+	}).Trace("Hosts in the Security App")
 
 	for _, host := range hosts {
 		metadataHostname := host.Path("metadata.host.hostname").Data().(string)

--- a/e2e/_suites/ingest-manager/integrations.go
+++ b/e2e/_suites/ingest-manager/integrations.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Jeffail/gabs/v2"
+	curl "github.com/elastic/e2e-testing/cli/shell"
+	log "github.com/sirupsen/logrus"
+)
+
+const ingestManagerIntegrationURL = kibanaBaseURL + "/api/ingest_manager/epm/packages/%s-%s"
+const ingestManagerIntegrationsURL = kibanaBaseURL + "/api/ingest_manager/epm/packages?experimental=true&category="
+
+// getIntegrationLatestVersion sends a GET request to Ingest Manager for the existing integrations
+// checking if the desired integration exists in the package registry. If so, it will
+// return name and version (latest) of the integration
+func getIntegrationLatestVersion(integrationName string) (string, string, error) {
+	r := createDefaultHTTPRequest(ingestManagerIntegrationsURL)
+	body, err := curl.Get(r)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":  body,
+			"error": err,
+			"url":   ingestManagerIntegrationsURL,
+		}).Error("Could not get Integrations")
+		return "", "", err
+	}
+
+	jsonParsed, err := gabs.ParseJSON([]byte(body))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":        err,
+			"responseBody": body,
+		}).Error("Could not parse response into JSON")
+		return "", "", err
+	}
+
+	// data streams should contain array of elements
+	integrations := jsonParsed.Path("response").Children()
+
+	log.WithFields(log.Fields{
+		"count": len(integrations),
+	}).Debug("Integrations retrieved")
+
+	for _, integration := range integrations {
+		name := integration.Path("name").Data().(string)
+		if name == strings.ToLower(integrationName) {
+			version := integration.Path("version").Data().(string)
+			return name, version, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("The %s integration was not found", integrationName)
+}
+
+// installIntegration sends a POST request to Ingest Manager installing the assets for an integration
+func installIntegrationAssets(integration string, version string) error {
+	url := fmt.Sprintf(ingestManagerIntegrationURL, integration, version)
+	postReq := createDefaultHTTPRequest(url)
+
+	body, err := curl.Post(postReq)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":  body,
+			"error": err,
+			"url":   url,
+		}).Error("Could not install assets for the integration")
+		return err
+	}
+
+	log.WithFields(log.Fields{
+		"integration": integration,
+		"version":     version,
+	}).Debug("Assets for the integration where installed")
+
+	return nil
+}

--- a/e2e/_suites/ingest-manager/integrations.go
+++ b/e2e/_suites/ingest-manager/integrations.go
@@ -103,6 +103,90 @@ func deleteIntegrationFromConfiguration(integrationPackage IntegrationPackage, c
 	return nil
 }
 
+// getIntegration returns metadata from an integration from Fleet, without the package ID
+func getIntegration(packageName string, version string) (IntegrationPackage, error) {
+	url := fmt.Sprintf(ingestManagerIntegrationURL, packageName, version)
+	getReq := createDefaultHTTPRequest(url)
+
+	body, err := curl.Get(getReq)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":  body,
+			"error": err,
+			"url":   url,
+		}).Error("Could not get the integration from Package Registry")
+		return IntegrationPackage{}, err
+	}
+
+	jsonParsed, err := gabs.ParseJSON([]byte(body))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":        err,
+			"responseBody": body,
+		}).Error("Could not parse get response into JSON")
+		return IntegrationPackage{}, err
+	}
+
+	response := jsonParsed.Path("response")
+	integrationPackage := IntegrationPackage{
+		name:    response.Path("name").Data().(string),
+		title:   response.Path("title").Data().(string),
+		version: response.Path("latestVersion").Data().(string),
+	}
+
+	return integrationPackage, nil
+}
+
+// getIntegrationFromAgentConfiguration inspects the integrations added to an agent configuration, returning the
+// a struct representing the package, including the packageID for the integration in the configuration
+func getIntegrationFromAgentConfiguration(packageName string, agentConfigID string) (IntegrationPackage, error) {
+	url := fmt.Sprintf(ingestManagerAgentConfigURL, agentConfigID)
+	reqReq := createDefaultHTTPRequest(url)
+
+	body, err := curl.Get(reqReq)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":        body,
+			"error":       err,
+			"packageName": packageName,
+			"configID":    agentConfigID,
+			"url":         url,
+		}).Error("Could not get integration packages from the configuration")
+		return IntegrationPackage{}, err
+	}
+
+	jsonParsed, err := gabs.ParseJSON([]byte(body))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":        err,
+			"responseBody": body,
+		}).Error("Could not parse response into JSON")
+		return IntegrationPackage{}, err
+	}
+
+	packageConfigs := jsonParsed.Path("item.package_configs").Children()
+	for _, packageConfig := range packageConfigs {
+		title := packageConfig.Path("package.title").Data().(string)
+		if title == packageName {
+			integrationPackage := IntegrationPackage{
+				packageConfigID: packageConfig.Path("id").Data().(string),
+				name:            packageConfig.Path("package.name").Data().(string),
+				title:           title,
+				version:         packageConfig.Path("package.version").Data().(string),
+			}
+
+			log.WithFields(log.Fields{
+				"package":  integrationPackage,
+				"configID": agentConfigID,
+			}).Debug("Package config found in the configuration")
+
+			return integrationPackage, nil
+		}
+	}
+
+	return IntegrationPackage{}, fmt.Errorf("%s package config not found in the configuration", packageName)
+}
+
 // getIntegrationLatestVersion sends a GET request to Ingest Manager for the existing integrations
 // checking if the desired integration exists in the package registry. If so, it will
 // return name and version (latest) of the integration
@@ -135,9 +219,15 @@ func getIntegrationLatestVersion(integrationName string) (string, string, error)
 	}).Trace("Integrations retrieved")
 
 	for _, integration := range integrations {
-		name := integration.Path("name").Data().(string)
-		if name == strings.ToLower(integrationName) {
+		title := integration.Path("title").Data().(string)
+		if strings.ToLower(title) == strings.ToLower(integrationName) {
+			name := integration.Path("name").Data().(string)
 			version := integration.Path("version").Data().(string)
+			log.WithFields(log.Fields{
+				"name":    name,
+				"title":   title,
+				"version": version,
+			}).Debug("Integration in latest version found")
 			return name, version, nil
 		}
 	}
@@ -178,32 +268,12 @@ func installIntegrationAssets(integration string, version string) (IntegrationPa
 	packageConfigID := response.Path("id").Data().(string)
 
 	// get the integration again in the case it's already installed
-	body, err = curl.Get(postReq)
+	integrationPackage, err := getIntegration(integration, version)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"body":  body,
-			"error": err,
-			"url":   url,
-		}).Error("Could not get the integration")
 		return IntegrationPackage{}, err
 	}
 
-	jsonParsed, err = gabs.ParseJSON([]byte(body))
-	if err != nil {
-		log.WithFields(log.Fields{
-			"error":        err,
-			"responseBody": body,
-		}).Error("Could not parse get response into JSON")
-		return IntegrationPackage{}, err
-	}
-
-	response = jsonParsed.Path("response")
-	integrationPackage := IntegrationPackage{
-		packageConfigID: packageConfigID,
-		name:            response.Path("name").Data().(string),
-		title:           response.Path("title").Data().(string),
-		version:         response.Path("latestVersion").Data().(string),
-	}
+	integrationPackage.packageConfigID = packageConfigID
 
 	return integrationPackage, nil
 }

--- a/e2e/_suites/ingest-manager/integrations.go
+++ b/e2e/_suites/ingest-manager/integrations.go
@@ -41,7 +41,8 @@ func addIntegrationToConfiguration(integrationPackage IntegrationPackage, config
 			"version":"` + integrationPackage.version + `"
 		}
 	}`
-	postReq.Payload = []byte(data)
+	postReq.Payload = data
+
 	body, err := curl.Post(postReq)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -79,7 +80,8 @@ func deleteIntegrationFromConfiguration(integrationPackage IntegrationPackage, c
 	postReq := createDefaultHTTPRequest(ingestManagerIntegrationDeleteURL)
 
 	data := `{"packageConfigIds":["` + integrationPackage.packageConfigID + `"]}`
-	postReq.Payload = []byte(data)
+	postReq.Payload = data
+
 	body, err := curl.Post(postReq)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/e2e/_suites/ingest-manager/integrations.go
+++ b/e2e/_suites/ingest-manager/integrations.go
@@ -22,8 +22,8 @@ type IntegrationPackage struct {
 	version         string `json:"version"`
 }
 
-// addIntegrationToPolicy sends a POST request to Ingest Manager adding an integration to a configuration
-func addIntegrationToPolicy(integrationPackage IntegrationPackage, configurationID string) (string, error) {
+// installIntegration sends a POST request to Ingest Manager adding an integration to a configuration
+func addIntegrationToConfiguration(integrationPackage IntegrationPackage, configurationID string) (string, error) {
 	postReq := createDefaultHTTPRequest(ingestManagerIntegrationConfigsURL)
 
 	data := `{
@@ -73,8 +73,8 @@ func addIntegrationToPolicy(integrationPackage IntegrationPackage, configuration
 	return integrationConfigurationID, nil
 }
 
-// deleteIntegrationFromPolicy sends a POST request to Ingest Manager deleting an integration from a configuration
-func deleteIntegrationFromPolicy(integrationPackage IntegrationPackage, configurationID string) error {
+// deleteIntegrationFromConfiguration sends a POST request to Ingest Manager deleting an integration from a configuration
+func deleteIntegrationFromConfiguration(integrationPackage IntegrationPackage, configurationID string) error {
 	postReq := createDefaultHTTPRequest(ingestManagerIntegrationDeleteURL)
 
 	data := `{"packageConfigIds":["` + integrationPackage.packageConfigID + `"]}`

--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -177,6 +177,6 @@ func systemctlRun(profile string, image string, service string, command string) 
 	log.WithFields(log.Fields{
 		"command": cmd,
 		"service": service,
-	}).Debug("Systemctl executed")
+	}).Trace("Systemctl executed")
 	return nil
 }

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -45,7 +45,7 @@ func (sats *StandAloneTestSuite) contributeSteps(s *godog.Suite) {
 }
 
 func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed() error {
-	log.Debug("Deploying an agent to Fleet")
+	log.Trace("Deploying an agent to Fleet")
 
 	serviceManager := services.NewServiceManager()
 
@@ -107,7 +107,7 @@ func (sats *StandAloneTestSuite) thereIsNewDataInTheIndexFromAgent() error {
 		return err
 	}
 
-	log.Debugf("Search result: %v", result)
+	log.Tracef("Search result: %v", result)
 
 	return e2e.AssertHitsArePresent(result)
 }

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -163,7 +163,7 @@ func MetricbeatFeatureContext(s *godog.Suite) {
 	s.Step(`^metricbeat is installed using "([^"]*)" configuration$`, testSuite.installedUsingConfiguration)
 
 	s.BeforeSuite(func() {
-		log.Debug("Before Metricbeat Suite...")
+		log.Trace("Before Metricbeat Suite...")
 		serviceManager := services.NewServiceManager()
 
 		env := map[string]string{
@@ -187,7 +187,7 @@ func MetricbeatFeatureContext(s *godog.Suite) {
 		}
 	})
 	s.BeforeScenario(func(*messages.Pickle) {
-		log.Debug("Before scenario...")
+		log.Trace("Before scenario...")
 	})
 	s.AfterSuite(func() {
 		if !developerMode {
@@ -201,7 +201,7 @@ func MetricbeatFeatureContext(s *godog.Suite) {
 		}
 	})
 	s.AfterScenario(func(*messages.Pickle, error) {
-		log.Debug("After scenario...")
+		log.Trace("After scenario...")
 		err := testSuite.CleanUp()
 		if err != nil {
 			log.Errorf("CleanUp failed: %v", err)

--- a/e2e/elasticsearch.go
+++ b/e2e/elasticsearch.go
@@ -122,7 +122,7 @@ func RetrySearch(indexName string, esQuery map[string]interface{}, maxAttempts i
 				"query":         esQuery,
 				"retryAttempts": maxAttempts,
 				"retryTimeout":  retryTimeout,
-			}).Debugf("Waiting %d seconds for the index to be ready", retryTimeout)
+			}).Tracef("Waiting %d seconds for the index to be ready", retryTimeout)
 			time.Sleep(time.Duration(retryTimeout) * time.Second)
 		}
 	}
@@ -295,7 +295,7 @@ func WaitForIndices() (string, error) {
 			"retries":        retryCount,
 			"statusEndpoint": r.URL,
 			"elapsedTime":    exp.GetElapsedTime(),
-		}).Debug("The Elasticsearc Cat Indices API is available")
+		}).Trace("The Elasticsearc Cat Indices API is available")
 
 		body = response
 		return nil

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -260,7 +260,7 @@ func DownloadFile(url string) (string, error) {
 			"retries":     retryCount,
 			"path":        filepath,
 			"url":         url,
-		}).Debug("File downloaded")
+		}).Trace("File downloaded")
 
 		fileReader = resp.Body
 
@@ -270,7 +270,7 @@ func DownloadFile(url string) (string, error) {
 	log.WithFields(log.Fields{
 		"url":  url,
 		"path": filepath,
-	}).Debug("Downloading file")
+	}).Trace("Downloading file")
 
 	err = backoff.Retry(download, exp)
 	if err != nil {
@@ -320,7 +320,7 @@ func Sleep(seconds string) error {
 		return err
 	}
 
-	log.WithFields(fields).Debugf("Waiting %s seconds", seconds)
+	log.WithFields(fields).Tracef("Waiting %s seconds", seconds)
 	time.Sleep(time.Duration(s) * time.Second)
 
 	return nil
@@ -341,7 +341,7 @@ func WaitForProcess(containerName string, process string, desiredState string, m
 		log.WithFields(log.Fields{
 			"desiredState": desiredState,
 			"process":      process,
-		}).Debug("Checking process desired state on the container")
+		}).Trace("Checking process desired state on the container")
 
 		output, err := docker.ExecCommandIntoContainer(context.Background(), containerName, "root", []string{"pgrep", "-n", "-l", process})
 		if err != nil {


### PR DESCRIPTION
>Hello darkness, my old friend
>I've come to talk with you again
>Because a vision softly creeping
>Left its seeds while I was sleeping
>And the vision that was planted in my brain
>Still remains
>Within the sound of silence


<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR backports #222 to 7.9.x, and this is needed because the APIs for Fleet configurations were renamed to Fleet policies **after 7.9.0**.

I did it commit by commit instead of using the squashed one (33f06e971148a7152ca60f09d44c38e139f51bb9) for some reasons:

- doing it commit by commit, although slower, allowed me 2 things:
	1. refresh the behaviour of the feature
	2. build the feature again, commit by commit, understanding each diff trying not to forget any policy left-over.
- My OCD for names: I love variable names absolutely meaningful, so I renamed methods, variables, log entries, params, etc, so that everything is consistent.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We want to test the endpoint integration in 7.9.x too

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] I ran all Fleet suites (fleet-mode, stand-alone-mode and endpoint-integration) 

## How to test this PR locally

Run:
```shell
$ cd e2e/_suites/ingest-manager
$ OP_LOG_LEVEL=TRACE DEVELOPER_MODE=true godog
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Backports #222 


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
As in the master branch, the following scenario is failing:

```gherkin
Scenario: Deploying an Endpoint makes policies to appear in the Security App
  When an Endpoint is successfully deployed with a "centos" Agent
  Then the policy response will be shown in the Security App
```

This is because there are a few things broken in the security side, so we prefer having the tests broken on CI meanwhile we fix this. At some point we could skip this test for green builds, although I'd prefer priorisating the fix.

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->