### PR TITLE
fix: do not use bad words in scenarios

### DIFF
--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -9,7 +9,7 @@ Scenario: Adding the Endpoint Integration to an Agent makes the host to show in 
   When the "Elastic Endpoint Security" integration is "added" in the policy
   Then the "Elastic Endpoint Security" datasource is shown in the policy as added
     And the host name is shown in the Administration view in the Security App as "online"
-    
+
 @endpoint-policy-check
 Scenario: Deploying an Endpoint makes policies to appear in the Security App
   When an Endpoint is successfully deployed with a "centos" Agent

--- a/e2e/_suites/metricbeat/features/apache.feature
+++ b/e2e/_suites/metricbeat/features/apache.feature
@@ -2,7 +2,7 @@
 Feature: Apache
   As a Metricbeat developer I want to check that the Apache module works as expected
 
-Scenario Outline: Check Apache-<apache_version> is sending metrics to Elasticsearch without errors
+Scenario Outline: Apache-<apache_version> sends metrics to Elasticsearch without errors
   Given Apache "<apache_version>" is running for metricbeat
     And metricbeat is installed and configured for Apache module
     And metricbeat waits "20" seconds for the service

--- a/e2e/_suites/metricbeat/features/metricbeat.feature
+++ b/e2e/_suites/metricbeat/features/metricbeat.feature
@@ -2,7 +2,7 @@
 Feature: Metricbeat
   As a Metricbeat developer I want to check that default configuration works as expected
 
-Scenario Outline: Check <configuration> configuration is sending metrics to Elasticsearch without errors
+Scenario Outline: Metricbeat's <configuration> configuration sends metrics to Elasticsearch without errors
   Given metricbeat is installed using "<configuration>" configuration
   When metricbeat runs for "30" seconds
   Then there are "system" events in the index

--- a/e2e/_suites/metricbeat/features/mysql.feature
+++ b/e2e/_suites/metricbeat/features/mysql.feature
@@ -2,7 +2,7 @@
 Feature: Mysql
   As a Metricbeat developer I want to check that the MySQL module works as expected
 
-Scenario Outline: Check <variant>-<version> is sending metrics to Elasticsearch without errors
+Scenario Outline: <variant>-<version> sends metrics to Elasticsearch without errors
   Given "<variant>" v<version>, variant of "MySQL", is running for metricbeat
     And metricbeat is installed and configured for "<variant>", variant of the "MySQL" module
     And metricbeat waits "20" seconds for the service

--- a/e2e/_suites/metricbeat/features/redis.feature
+++ b/e2e/_suites/metricbeat/features/redis.feature
@@ -2,7 +2,7 @@
 Feature: Redis
   As a Metricbeat developer I want to check that the Redis module works as expected
 
-Scenario Outline: Check Redis-<redis_version> is sending metrics to Elasticsearch without errors
+Scenario Outline: Redis-<redis_version> sends metrics to Elasticsearch without errors
   Given Redis "<redis_version>" is running for metricbeat
     And metricbeat is installed and configured for Redis module
     And metricbeat waits "20" seconds for the service

--- a/e2e/_suites/metricbeat/features/vsphere.feature
+++ b/e2e/_suites/metricbeat/features/vsphere.feature
@@ -2,7 +2,7 @@
 Feature: vSphere
   As a Metricbeat developer I want to check that the vSphere module works as expected
 
-Scenario Outline: Check vSphere-<vsphere_version> is sending metrics to Elasticsearch without errors
+Scenario Outline: vSphere-<vsphere_version> sends metrics to Elasticsearch without errors
   Given vSphere "<vsphere_version>" is running for metricbeat
     And metricbeat is installed and configured for vSphere module
     And metricbeat waits "120" seconds for the service


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It removes the "Check" word froom scenario names, using a higher level of asbtraction.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The words test, verif, check are considered  bad words by gherkin-lint
See https://www.rubydoc.info/gems/gherkin_lint/0.1.2/GherkinLint%2FBadScenarioName:lint

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Run local pre-commit and `make -C e2e lint` to verify it.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

#### Before these changes: BadScenarioName is returned
```shell
$ make -C e2e lint
BadScenarioName - Prefer to rely just on Given and When steps when name your scenario to keep it stable
  e2e/_suites/metricbeat/features/vsphere.feature (5): vSphere.Check vSphere-<vsphere_version> is sending metrics to Elasticsearch without errors
BadScenarioName - Prefer to rely just on Given and When steps when name your scenario to keep it stable
  e2e/_suites/metricbeat/features/redis.feature (5): Redis.Check Redis-<redis_version> is sending metrics to Elasticsearch without errors
BadScenarioName - Prefer to rely just on Given and When steps when name your scenario to keep it stable
  e2e/_suites/metricbeat/features/metricbeat.feature (5): Metricbeat.Check <configuration> configuration is sending metrics to Elasticsearch without errors
BadScenarioName - Prefer to rely just on Given and When steps when name your scenario to keep it stable
  e2e/_suites/metricbeat/features/apache.feature (5): Apache.Check Apache is sending metrics to Elasticsearch without errors
BadScenarioName - Prefer to rely just on Given and When steps when name your scenario to keep it stable
  e2e/_suites/metricbeat/features/mysql.feature (5): Mysql.Check <variant>-<version> is sending metrics to Elasticsearch without errors
AvoidScripting - Multiple Actions
  e2e/_suites/ingest-manager/features/fleet_mode_agent.feature (60): Fleet Mode Agent.Re-enrolling the <os> agent
make: *** [lint] Error 255
```

#### After these changes: BadScenario is not returned
```shell
➜  e2e-testing git:(fix-gherkin) ✗ make -C e2e lint
AvoidScripting - Multiple Actions
  e2e/_suites/ingest-manager/features/fleet_mode_agent.feature (60): Fleet Mode Agent.Re-enrolling the <os> agent
make: *** [lint] Error 255
```


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #219


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
There is a PR in the shared library supporting reading the arguments passed by in the pre-commit hook, which disablles the same configurations than in the makefile.

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->