### PR TITLE
fix: do not use bad words in scenarios (#286) backport for 7.9.x

### DIFF
--- a/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/ingest-manager/features/agent_endpoint_integration.feature
@@ -9,7 +9,7 @@ Scenario: Adding the Endpoint Integration to an Agent makes the host to show in 
   When the "Elastic Endpoint Security" integration is "added" in the configuration
   Then the "Elastic Endpoint Security" datasource is shown in the configuration as added
     And the host name is shown in the Administration view in the Security App as "online"
-    
+
 @endpoint-policy-check
 Scenario: Deploying an Endpoint makes policies to appear in the Security App
   When an Endpoint is successfully deployed with a "centos" Agent

--- a/e2e/_suites/metricbeat/features/apache.feature
+++ b/e2e/_suites/metricbeat/features/apache.feature
@@ -2,7 +2,7 @@
 Feature: Apache
   As a Metricbeat developer I want to check that the Apache module works as expected
 
-Scenario Outline: Check Apache-<apache_version> is sending metrics to Elasticsearch without errors
+Scenario Outline: Apache-<apache_version> sends metrics to Elasticsearch without errors
   Given Apache "<apache_version>" is running for metricbeat
     And metricbeat is installed and configured for Apache module
     And metricbeat waits "20" seconds for the service

--- a/e2e/_suites/metricbeat/features/metricbeat.feature
+++ b/e2e/_suites/metricbeat/features/metricbeat.feature
@@ -2,7 +2,7 @@
 Feature: Metricbeat
   As a Metricbeat developer I want to check that default configuration works as expected
 
-Scenario Outline: Check <configuration> configuration is sending metrics to Elasticsearch without errors
+Scenario Outline: Metricbeat's <configuration> configuration sends metrics to Elasticsearch without errors
   Given metricbeat is installed using "<configuration>" configuration
   When metricbeat runs for "30" seconds
   Then there are "system" events in the index

--- a/e2e/_suites/metricbeat/features/mysql.feature
+++ b/e2e/_suites/metricbeat/features/mysql.feature
@@ -2,7 +2,7 @@
 Feature: Mysql
   As a Metricbeat developer I want to check that the MySQL module works as expected
 
-Scenario Outline: Check <variant>-<version> is sending metrics to Elasticsearch without errors
+Scenario Outline: <variant>-<version> sends metrics to Elasticsearch without errors
   Given "<variant>" v<version>, variant of "MySQL", is running for metricbeat
     And metricbeat is installed and configured for "<variant>", variant of the "MySQL" module
     And metricbeat waits "20" seconds for the service

--- a/e2e/_suites/metricbeat/features/redis.feature
+++ b/e2e/_suites/metricbeat/features/redis.feature
@@ -2,7 +2,7 @@
 Feature: Redis
   As a Metricbeat developer I want to check that the Redis module works as expected
 
-Scenario Outline: Check Redis-<redis_version> is sending metrics to Elasticsearch without errors
+Scenario Outline: Redis-<redis_version> sends metrics to Elasticsearch without errors
   Given Redis "<redis_version>" is running for metricbeat
     And metricbeat is installed and configured for Redis module
     And metricbeat waits "20" seconds for the service

--- a/e2e/_suites/metricbeat/features/vsphere.feature
+++ b/e2e/_suites/metricbeat/features/vsphere.feature
@@ -2,7 +2,7 @@
 Feature: vSphere
   As a Metricbeat developer I want to check that the vSphere module works as expected
 
-Scenario Outline: Check vSphere-<vsphere_version> is sending metrics to Elasticsearch without errors
+Scenario Outline: vSphere-<vsphere_version> sends metrics to Elasticsearch without errors
   Given vSphere "<vsphere_version>" is running for metricbeat
     And metricbeat is installed and configured for vSphere module
     And metricbeat waits "120" seconds for the service


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: do not use bad words in scenarios (#286)