### PR TITLE
feat: log elastic-agent logs before terminating its container

### DIFF
--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -102,6 +102,19 @@ func ExecCommandIntoContainer(ctx context.Context, containerName string, user st
 
 	output = strings.ReplaceAll(output, "\n", "")
 
+	patterns := []string{
+		"\x01\x00\x00\x00\x00\x00\x00\r",
+		"\x01\x00\x00\x00\x00\x00\x00)",
+	}
+	for _, pattern := range patterns {
+		if strings.HasPrefix(output, pattern) {
+			output = strings.ReplaceAll(output, pattern, "")
+			log.WithFields(log.Fields{
+				"output": output,
+			}).Trace("Output name has been sanitized")
+		}
+	}
+
 	return output, nil
 }
 

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -48,19 +48,19 @@ type FleetTestSuite struct {
 func (fts *FleetTestSuite) afterScenario() {
 	serviceManager := services.NewServiceManager()
 
+	serviceName := fts.Image
+
+	if log.IsLevelEnabled(log.DebugLevel) {
+		installer := fts.Installers[fts.Image]
+		_ = installer.getElasticAgentLogs(fts.Hostname)
+	}
+
 	err := fts.unenrollHostname(true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"err":      err,
 			"hostname": fts.Hostname,
 		}).Warn("The agentIDs for the hostname could not be unenrolled")
-	}
-
-	serviceName := fts.Image
-
-	if log.IsLevelEnabled(log.DebugLevel) {
-		installer := fts.Installers[fts.Image]
-		_ = installer.getElasticAgentLogs(fts.Hostname)
 	}
 
 	if !developerMode {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -349,7 +349,7 @@ func (fts *FleetTestSuite) systemPackageDashboardsAreListedInFleet() error {
 	log.Trace("Checking system Package dashboards in Fleet")
 
 	dataStreamsCount := 0
-	maxTimeout := 10 * time.Second
+	maxTimeout := 4 * time.Minute
 	retryCount := 1
 
 	exp := e2e.GetExponentialBackOff(maxTimeout)

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -59,10 +59,7 @@ func (fts *FleetTestSuite) afterScenario() {
 	serviceName := fts.Image
 
 	if log.IsLevelEnabled(log.DebugLevel) {
-		err = getContainerLogs(IngestManagerProfileName, serviceName)
-		if err != nil {
-			// NOOP
-		}
+		_ = getContainerLogs(IngestManagerProfileName, serviceName)
 	}
 
 	if !developerMode {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -57,6 +57,14 @@ func (fts *FleetTestSuite) afterScenario() {
 	}
 
 	serviceName := fts.Image
+
+	if log.IsLevelEnabled(log.DebugLevel) {
+		err = getContainerLogs(IngestManagerProfileName, serviceName)
+		if err != nil {
+			// NOOP
+		}
+	}
+
 	if !developerMode {
 		_ = serviceManager.RemoveServicesFromCompose(IngestManagerProfileName, []string{serviceName}, profileEnv)
 	} else {

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -60,7 +60,7 @@ func (fts *FleetTestSuite) afterScenario() {
 
 	if log.IsLevelEnabled(log.DebugLevel) {
 		installer := fts.Installers[fts.Image]
-		_ = installer.getElasticAgentLogs(fts.Hostname, 10000) // 10k lines of log
+		_ = installer.getElasticAgentLogs(fts.Hostname)
 	}
 
 	if !developerMode {
@@ -349,7 +349,7 @@ func (fts *FleetTestSuite) systemPackageDashboardsAreListedInFleet() error {
 	log.Trace("Checking system Package dashboards in Fleet")
 
 	dataStreamsCount := 0
-	maxTimeout := 4 * time.Minute
+	maxTimeout := 10 * time.Second
 	retryCount := 1
 
 	exp := e2e.GetExponentialBackOff(maxTimeout)

--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -59,7 +59,8 @@ func (fts *FleetTestSuite) afterScenario() {
 	serviceName := fts.Image
 
 	if log.IsLevelEnabled(log.DebugLevel) {
-		_ = getContainerLogs(IngestManagerProfileName, serviceName)
+		installer := fts.Installers[fts.Image]
+		_ = installer.getElasticAgentLogs(fts.Hostname, 10000) // 10k lines of log
 	}
 
 	if !developerMode {

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -277,3 +277,23 @@ func getContainerHostname(containerName string) (string, error) {
 
 	return hostname, nil
 }
+
+func getContainerLogs(profile string, serviceName string) error {
+	serviceManager := services.NewServiceManager()
+
+	composes := []string{
+		profile,     // profile name
+		serviceName, // agent service
+	}
+	err := serviceManager.RunCommand(profile, composes, []string{"logs", serviceName}, profileEnv)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"service": serviceName,
+		}).Error("Could not retrieve Elastic Agent logs")
+
+		return err
+	}
+
+	return nil
+}

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -269,23 +269,3 @@ func getContainerHostname(containerName string) (string, error) {
 
 	return hostname, nil
 }
-
-func getContainerLogs(profile string, serviceName string) error {
-	serviceManager := services.NewServiceManager()
-
-	composes := []string{
-		profile,     // profile name
-		serviceName, // agent service
-	}
-	err := serviceManager.RunCommand(profile, composes, []string{"logs", serviceName}, profileEnv)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"error":   err,
-			"service": serviceName,
-		}).Error("Could not retrieve Elastic Agent logs")
-
-		return err
-	}
-
-	return nil
-}

--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/cucumber/godog"
@@ -261,13 +260,6 @@ func getContainerHostname(containerName string) (string, error) {
 			"error":         err,
 		}).Error("Could not retrieve container name from the Docker client")
 		return "", err
-	}
-
-	if strings.HasPrefix(hostname, "\x01\x00\x00\x00\x00\x00\x00\r") {
-		hostname = strings.ReplaceAll(hostname, "\x01\x00\x00\x00\x00\x00\x00\r", "")
-		log.WithFields(log.Fields{
-			"hostname": hostname,
-		}).Trace("Container name has been sanitized")
 	}
 
 	log.WithFields(log.Fields{

--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -70,8 +70,8 @@ func (i *ElasticAgentInstaller) getElasticAgentHash(containerName string) (strin
 	return shortHash, nil
 }
 
-// getElasticAgentLogs uses elastic-agent log dir to read a number of lines from the log file
-func (i *ElasticAgentInstaller) getElasticAgentLogs(hostname string, lines int) error {
+// getElasticAgentLogs uses elastic-agent log dir to read the entire log file
+func (i *ElasticAgentInstaller) getElasticAgentLogs(hostname string) error {
 	containerName := hostname // name of the container, which matches the hostname
 
 	hash, err := i.getElasticAgentHash(containerName)
@@ -86,10 +86,10 @@ func (i *ElasticAgentInstaller) getElasticAgentLogs(hostname string, lines int) 
 
 	logFile := i.logDir + i.logFile
 	cmd := []string{
-		"tail", fmt.Sprintf("-%d", lines), fmt.Sprintf(logFile, hash),
+		"cat", fmt.Sprintf(logFile, hash),
 	}
 
-	logs, err := docker.ExecCommandIntoContainer(context.Background(), containerName, "root", cmd)
+	err = execCommandInService(i.profile, i.image, i.service, cmd, false)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"containerName": containerName,
@@ -100,8 +100,6 @@ func (i *ElasticAgentInstaller) getElasticAgentLogs(hostname string, lines int) 
 
 		return err
 	}
-
-	fmt.Println(logs)
 
 	return nil
 }

--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/elastic/e2e-testing/cli/config"
+	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
 	log "github.com/sirupsen/logrus"
@@ -26,8 +28,12 @@ type ElasticAgentInstaller struct {
 	artifactName      string // name of the artifact
 	artifactOS        string // OS of the artifact
 	artifactVersion   string // version of the artifact
+	commitFile        string // elastic agent commit file
+	homeDir           string // elastic agent home dir
 	image             string // docker image
 	InstallCmds       []string
+	logDir            string // location of the log file
+	logFile           string // the name of the log file
 	name              string // the name for the binary
 	path              string // the local path where the agent for the binary is located
 	processName       string // name of the elastic-agent process
@@ -35,6 +41,69 @@ type ElasticAgentInstaller struct {
 	PostInstallFn     func() error
 	service           string // name of the service
 	tag               string // docker tag
+}
+
+// getElasticAgentHash uses Elastic Agent's home dir to read the file with agent's build hash
+// it will return the first six characters of the hash (short hash)
+func (i *ElasticAgentInstaller) getElasticAgentHash(containerName string) (string, error) {
+	commitFile := i.homeDir + i.commitFile
+
+	cmd := []string{
+		"cat", commitFile,
+	}
+
+	fullHash, err := docker.ExecCommandIntoContainer(context.Background(), containerName, "root", cmd)
+	if err != nil {
+		return "", err
+	}
+
+	runes := []rune(fullHash)
+	shortHash := string(runes[0:6])
+
+	log.WithFields(log.Fields{
+		"commitFile":    commitFile,
+		"containerName": containerName,
+		"hash":          fullHash,
+		"shortHash":     shortHash,
+	}).Debug("Agent build hash found")
+
+	return shortHash, nil
+}
+
+// getElasticAgentLogs uses elastic-agent log dir to read a number of lines from the log file
+func (i *ElasticAgentInstaller) getElasticAgentLogs(hostname string, lines int) error {
+	containerName := hostname // name of the container, which matches the hostname
+
+	hash, err := i.getElasticAgentHash(containerName)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"containerName": containerName,
+			"error":         err,
+		}).Error("Could not get agent hash in the container")
+
+		return err
+	}
+
+	logFile := i.logDir + i.logFile
+	cmd := []string{
+		"tail", fmt.Sprintf("-%d", lines), fmt.Sprintf(logFile, hash),
+	}
+
+	logs, err := docker.ExecCommandIntoContainer(context.Background(), containerName, "root", cmd)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"containerName": containerName,
+			"command":       cmd,
+			"error":         err,
+			"hash":          hash,
+		}).Error("Could not get agent logs in the container")
+
+		return err
+	}
+
+	fmt.Println(logs)
+
+	return nil
 }
 
 // downloadAgentBinary it downloads the binary and stores the location of the downloaded file
@@ -101,8 +170,12 @@ func newCentosInstaller(image string, tag string) ElasticAgentInstaller {
 		artifactName:      artifact,
 		artifactOS:        os,
 		artifactVersion:   version,
+		commitFile:        ".elastic-agent.active.commit",
+		homeDir:           "/etc/elastic-agent/",
 		image:             image,
 		InstallCmds:       []string{"yum", "localinstall", "/" + binaryName, "-y"},
+		logDir:            "/var/lib/elastic-agent/data/elastic-agent-%s/logs/",
+		logFile:           "elastic-agent-json.log",
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     fn,
@@ -149,8 +222,12 @@ func newDebianInstaller() ElasticAgentInstaller {
 		artifactName:      artifact,
 		artifactOS:        os,
 		artifactVersion:   version,
+		commitFile:        ".elastic-agent.active.commit",
+		homeDir:           "/etc/elastic-agent/",
 		image:             image,
 		InstallCmds:       []string{"apt", "install", "/" + binaryName, "-y"},
+		logDir:            "/var/lib/elastic-agent/data/elastic-agent-%s/logs/",
+		logFile:           "elastic-agent-json.log",
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     fn,

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -44,7 +44,7 @@ func (sats *StandAloneTestSuite) afterScenario() {
 	serviceName := ElasticAgentServiceName
 
 	if log.IsLevelEnabled(log.DebugLevel) {
-		_ = getContainerLogs(IngestManagerProfileName, serviceName)
+		_ = sats.getContainerLogs()
 	}
 
 	if !developerMode {
@@ -102,6 +102,29 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed() error {
 
 	sats.Hostname = hostname
 	sats.Cleanup = true
+
+	return nil
+}
+
+func (sats *StandAloneTestSuite) getContainerLogs() error {
+	serviceManager := services.NewServiceManager()
+
+	profile := IngestManagerProfileName
+	serviceName := ElasticAgentServiceName
+
+	composes := []string{
+		profile,     // profile name
+		serviceName, // agent service
+	}
+	err := serviceManager.RunCommand(profile, composes, []string{"logs", serviceName}, profileEnv)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"service": serviceName,
+		}).Error("Could not retrieve Elastic Agent logs")
+
+		return err
+	}
 
 	return nil
 }

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -43,6 +43,13 @@ func (sats *StandAloneTestSuite) afterScenario() {
 	serviceManager := services.NewServiceManager()
 	serviceName := ElasticAgentServiceName
 
+	if log.IsLevelEnabled(log.DebugLevel) {
+		err := getContainerLogs(IngestManagerProfileName, serviceName)
+		if err != nil {
+			// NOOP
+		}
+	}
+
 	if !developerMode {
 		_ = serviceManager.RemoveServicesFromCompose(IngestManagerProfileName, []string{serviceName}, profileEnv)
 	} else {
@@ -98,13 +105,6 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed() error {
 
 	sats.Hostname = hostname
 	sats.Cleanup = true
-
-	if log.IsLevelEnabled(log.DebugLevel) {
-		err = getContainerLogs(profile, serviceName)
-		if err != nil {
-			return err
-		}
-	}
 
 	return nil
 }

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -44,10 +44,7 @@ func (sats *StandAloneTestSuite) afterScenario() {
 	serviceName := ElasticAgentServiceName
 
 	if log.IsLevelEnabled(log.DebugLevel) {
-		err := getContainerLogs(IngestManagerProfileName, serviceName)
-		if err != nil {
-			// NOOP
-		}
+		_ = getContainerLogs(IngestManagerProfileName, serviceName)
 	}
 
 	if !developerMode {

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -100,17 +100,8 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed() error {
 	sats.Cleanup = true
 
 	if log.IsLevelEnabled(log.DebugLevel) {
-		composes := []string{
-			profile,     // profile name
-			serviceName, // agent service
-		}
-		err = serviceManager.RunCommand(profile, composes, []string{"logs", serviceName}, profileEnv)
+		err = getContainerLogs(profile, serviceName)
 		if err != nil {
-			log.WithFields(log.Fields{
-				"error":   err,
-				"service": serviceName,
-			}).Error("Could not retrieve Elastic Agent logs")
-
 			return err
 		}
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
As the native `docker logs CONTAINER` is not retrieving the agent logs, we have to inspect the internals of the agent too fetch the log. For that reason this PR adds a function to retrieve the logs from the internals of the elastic-agent structure, and to achieve it we have to get the build hash of the agent, using a short version of that hash to calculate the path to the log file.

It will be the installer struct the responsible for doing these tasks, as it knows the internals of the agent.

The way we consume this logs is in the afterScenario test life cycle hook, right before removing the docker service representing the agent.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We want to troubleshoot problems on CI

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

```shell
$ OP_LOG_LEVEL=TRACE DEVELOPER_MODE=true godog -t "fleet_mode && start-agent"
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #298


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
The backport to 7.9.x must be done in a manual mode, because agent's new structure (including build hash) is not backported to 7.9.x., so the log file can be retrieved directly from `/var/lib/elastic-agent/logs/elastic-agent-json.log`.


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->