### PR TITLE
chore: cancel previous running builds when a PR is updated (#300) backport for 7.9.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -71,6 +71,8 @@ pipeline {
       stages {
         stage('Checkout') {
           steps {
+            pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
+            deleteDir()
             gitCheckout(basedir: BASE_DIR, githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             setEnvVar("GO_VERSION", readFile("${env.WORKSPACE}/${env.BASE_DIR}/.go-version").trim())


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - chore: cancel previous running builds when a PR is updated (#300)