### PR TITLE
chore: update GCP bucket calculation

### DIFF
--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -65,14 +65,14 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 
 		// We will use the snapshots produced by Beats CI
 		bucket := "beats-ci-artifacts"
-		object := fmt.Sprintf("snapshots/%s-%s-%s.%s", artifact, version, arch, extension)
+		object := fmt.Sprintf("snapshots/%s", fileName)
 
 		// we are setting a version from a pull request: the version of the artifact will be kept as the base one
 		// i.e. /pull-requests/pr-21100/elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm
 		// i.e. /pull-requests/pr-21100/elastic-agent-8.0.0-SNAPSHOT-amd64.deb
 		if strings.HasPrefix(version, "pr-") {
 			log.WithField("PR", version).Debug("Using CI snapshots a pull request")
-			object = fmt.Sprintf("pull-requests/%s/%s/%s-%s-%s.%s", version, artifact, artifact, agentVersionBase, arch, extension)
+			object = fmt.Sprintf("pull-requests/%s/%s/%s", version, artifact, fileName)
 		}
 
 		downloadURL, err = e2e.GetObjectURLFromBucket(bucket, object)

--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/elastic/e2e-testing/cli/config"
 	"github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
 	log "github.com/sirupsen/logrus"
 )
+
+const agentVersionBase = "8.0.0-SNAPSHOT"
 
 // agentVersion is the version of the agent to use
 // It can be overriden by ELASTIC_AGENT_VERSION env var
@@ -16,7 +20,7 @@ var agentVersion = "8.0.0-SNAPSHOT"
 func init() {
 	config.Init()
 
-	agentVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", agentVersion)
+	agentVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", agentVersionBase)
 }
 
 // ElasticAgentInstaller represents how to install an agent, depending of the box type
@@ -39,13 +43,53 @@ type ElasticAgentInstaller struct {
 
 // downloadAgentBinary it downloads the binary and stores the location of the downloaded file
 // into the installer struct, to be used else where
-func downloadAgentBinary(artifact string, version string, os string, arch string, extension string) (string, string, error) {
-	downloadURL, err := e2e.GetElasticArtifactURL(artifact, version, os, arch, extension)
+// If the environment variable ELASTIC_AGENT_DOWNLOAD_URL exists, then the artifact to be downloaded will
+// be defined by that value
+// Else, if the environment variable ELASTIC_AGENT_USE_CI_SNAPSHOTS is set, then the artifact
+// to be downloaded will be defined by the latest snapshot produced by the Beats CI.
+func downloadAgentBinary(artifact string, version string, OS string, arch string, extension string) (string, string, error) {
+	fileName := fmt.Sprintf("%s-%s-%s.%s", artifact, version, arch, extension)
+
+	if downloadURL, exists := os.LookupEnv("ELASTIC_AGENT_DOWNLOAD_URL"); exists {
+		filePath, err := e2e.DownloadFile(downloadURL)
+
+		return fileName, filePath, err
+	}
+
+	var downloadURL string
+	var err error
+
+	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
+	if useCISnapshots {
+		log.Debug("Using CI snapshots for the Elastic Agent")
+
+		// We will use the snapshots produced by Beats CI
+		bucket := "beats-ci-artifacts"
+		object := fmt.Sprintf("snapshots/%s-%s-%s.%s", artifact, version, arch, extension)
+
+		// we are setting a version from a pull request: the version of the artifact will be kept as the base one
+		// i.e. /pull-requests/pr-21100/elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm
+		// i.e. /pull-requests/pr-21100/elastic-agent-8.0.0-SNAPSHOT-amd64.deb
+		if strings.HasPrefix(version, "pr-") {
+			log.WithField("PR", version).Debug("Using CI snapshots a pull request")
+			object = fmt.Sprintf("pull-requests/%s/%s/%s-%s-%s.%s", version, artifact, artifact, agentVersionBase, arch, extension)
+		}
+
+		downloadURL, err = e2e.GetObjectURLFromBucket(bucket, object)
+		if err != nil {
+			return "", "", err
+		}
+
+		filePath, err := e2e.DownloadFile(downloadURL)
+
+		return fileName, filePath, err
+	}
+
+	downloadURL, err = e2e.GetElasticArtifactURL(artifact, agentVersionBase, OS, arch, extension)
 	if err != nil {
 		return "", "", err
 	}
 
-	fileName := fmt.Sprintf("%s-%s-%s-%s.%s", artifact, version, os, arch, extension)
 	filePath, err := e2e.DownloadFile(downloadURL)
 
 	return fileName, filePath, err

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -18,6 +18,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const standAloneVersionBase = "8.0.0-SNAPSHOT"
+
 // standAloneVersion is the version of the agent to use
 // It can be overriden by ELASTIC_AGENT_VERSION env var
 var standAloneVersion = "8.0.0-SNAPSHOT"
@@ -25,7 +27,7 @@ var standAloneVersion = "8.0.0-SNAPSHOT"
 func init() {
 	config.Init()
 
-	standAloneVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", standAloneVersion)
+	standAloneVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", standAloneVersionBase)
 }
 
 // StandAloneTestSuite represents the scenarios for Stand-alone-mode

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -71,10 +71,10 @@ func GetElasticArtifactURL(artifact string, version string, OS string, arch stri
 	if useCISnapshots {
 		// We will use the snapshots produced by Beats CI
 		bucket := "beats-ci-artifacts"
-		object := fmt.Sprintf("%s-%s-%s-%s.%s", artifact, version, OS, arch, extension)
+		object := fmt.Sprintf("snapshots/%s-%s-%s-%s.%s", artifact, version, OS, arch, extension)
 
 		if agentVersion, exists := os.LookupEnv("ELASTIC_AGENT_VERSION"); exists {
-			object = fmt.Sprintf("pull-requests/%s/%s-%s-%s-%s.%s", agentVersion, artifact, version, OS, arch, extension)
+			object = fmt.Sprintf("pull-requests/%s/%s/%s-%s-%s-%s.%s", agentVersion, artifact, artifact, version, OS, arch, extension)
 		}
 
 		return GetObjectURLFromBucket(bucket, object)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -21,7 +21,6 @@ import (
 	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/elastic/e2e-testing/cli/docker"
 	curl "github.com/elastic/e2e-testing/cli/shell"
-	shell "github.com/elastic/e2e-testing/cli/shell"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -138,22 +137,23 @@ func GetObjectURLFromBucket(bucket string, object string) (string, error) {
 
 	retryCount := 1
 
-	body := ""
+	currentPage := 0
+	pageTokenQueryParam := ""
+	mediaLink := ""
 
 	storageAPI := func() error {
 		r := curl.HTTPRequest{
-			URL: fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o", bucket),
+			URL: fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o%s", bucket, pageTokenQueryParam),
 		}
 
 		response, err := curl.Get(r)
 		if err != nil {
 			log.WithFields(log.Fields{
-				"bucket":         bucket,
-				"elapsedTime":    exp.GetElapsedTime(),
-				"error":          err,
-				"object":         object,
-				"retry":          retryCount,
-				"statusEndpoint": r.URL,
+				"bucket":      bucket,
+				"elapsedTime": exp.GetElapsedTime(),
+				"error":       err,
+				"object":      object,
+				"retry":       retryCount,
 			}).Warn("Google Cloud Storage API is not available yet")
 
 			retryCount++
@@ -162,15 +162,51 @@ func GetObjectURLFromBucket(bucket string, object string) (string, error) {
 		}
 
 		log.WithFields(log.Fields{
-			"bucket":         bucket,
-			"elapsedTime":    exp.GetElapsedTime(),
-			"object":         object,
-			"retries":        retryCount,
-			"statusEndpoint": r.URL,
-		}).Debug("Google Cloud Storage API is available")
+			"bucket":      bucket,
+			"elapsedTime": exp.GetElapsedTime(),
+			"object":      object,
+			"retries":     retryCount,
+			"url":         r.URL,
+		}).Trace("Google Cloud Storage API is available")
 
-		body = response
-		return nil
+		jsonParsed, err := gabs.ParseJSON([]byte(response))
+		if err != nil {
+			log.WithFields(log.Fields{
+				"bucket": bucket,
+				"object": object,
+			}).Warn("Could not parse the response body for the object")
+
+			retryCount++
+
+			return err
+		}
+
+		nextPageToken := jsonParsed.Path("nextPageToken").Data().(string)
+
+		for _, item := range jsonParsed.Path("items").Children() {
+			itemID := item.Path("id").Data().(string)
+			objectPath := bucket + "/" + object + "/"
+			if strings.HasPrefix(itemID, objectPath) {
+				mediaLink = item.Path("mediaLink").Data().(string)
+
+				log.WithFields(log.Fields{
+					"bucket": bucket,
+					"object": object,
+				}).Debug("Media link found for the object")
+				return nil
+			}
+		}
+
+		pageTokenQueryParam = "?pageToken=" + nextPageToken
+		currentPage++
+
+		log.WithFields(log.Fields{
+			"currentPage": currentPage,
+			"bucket":      bucket,
+			"object":      object,
+		}).Warn("Object not found in current page. Continuing")
+
+		return fmt.Errorf("The %s object could not be found in the current page (%d) the %s bucket", object, currentPage, bucket)
 	}
 
 	err := backoff.Retry(storageAPI, exp)
@@ -178,23 +214,7 @@ func GetObjectURLFromBucket(bucket string, object string) (string, error) {
 		return "", err
 	}
 
-	jsonParsed, err := gabs.ParseJSON([]byte(body))
-	if err != nil {
-		log.WithFields(log.Fields{
-			"bucket": bucket,
-			"object": object,
-		}).Error("Could not parse the response body for the object")
-		return "", err
-	}
-
-	for _, item := range jsonParsed.Path("items").Children() {
-		itemID := item.Path("id").Data().(string)
-		if strings.Contains(itemID, object) {
-			return item.Path("mediaLink").Data().(string), nil
-		}
-	}
-
-	return "", fmt.Errorf("The %s object could not be found in the %s bucket", object, bucket)
+	return mediaLink, nil
 }
 
 // DownloadFile will download a url and store it in a temporary path.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
As a result of https://github.com/elastic/beats/pull/20903, we detected the URLs to get the snapshots needed to be updated. This PR is addressing this need, including some refactors:

- move code specific to the elastic-agent to the downloadAgentBinary method, instead of overloading the generic one that uses the artifactory to get the artifacts (separation of concerns). This change will enable using a default value for the version, because snapshots for PRs hardcode the target version in the file name (i.e. `/pull-requests/pr-21100/elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm`).
- fix the download process from a GCP bucket: we only used the first page in the response, being now possible to paginate over the different  pages in the response following the `nextPageToken` attribute in the response. If this attribute is present, and we did not find the object in the current page, we continue paginating using the token as a query string parameter. This way, the backoff strategy will fail (and retry) if:
    - the endpoint URL for the GCP bucket is not available
    - it's not possible to parse response into a JSON object
    - we reached the end of the current page and the object is not present, having more pages (controlled by the nextPageToken attribute)
    - we reached the end of the current page and the object is not present, not having more pages (the nextPageToken attribute is not present)

If the object is present, then we return it's media-link, which is the public URL for the object in the bucket.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
This change will allow us to enable the execution of the test suite alongside any PR, simply setting the environment with a few values to use the CI snapshots for branches and pull requests:

- for branches, we must just set ELASTIC_AGENT_USE_CI_SNAPSHOTS=true. It will use snapshots for the current branch
- for pull requests, we must just set ELASTIC_AGENT_USE_CI_SNAPSHOTS=true and ELASTIC_AGENT_VERSION=pr-21100. It will use snapshots for the PR identified by the agent version (i.e. pr-21100 represents the Github PR with 21100 as PR ID).

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Run tests without the snapshots variables: the test suite fetches what is described in the compose files and/or default values for agent in the current branch (Stack will honour compose files). This is the default behavior when developing on this project.
- [x] Run tests for CI snapshots without setting agent's version: the test suite fetches the snapshot for the current branch that was already pushed to GCP (Stack will honour compose files). This is the behavior for branches in the Beats repo, which will trigger the test suite right after the packaging job finishes.
- [x] Run tests for CI snapshots setting agent's version: the test suite fetches the snapshot for the current pull request that was already pushed to GCP (Stack will honour compose files). This is the behavior for PRs in the Beats repo, which will trigger the test suite right after the packaging job finishes.
- [x] Run tests for CI snapshots setting a non existent version for the agent: the test suite is not able to find the object in the GCP bucket, failing.

## How to test this PR locally

#### Testing old behavior
```shell
$ OP_LOG_LEVEL=TRACE DEVELOPER_MODE=true godog -t "stand_alone_mode"
$ OP_LOG_LEVEL=TRACE DEVELOPER_MODE=true godog -t "fleet_mode"
```
It will use the elastic-agent:8.0.0-SNAPSHOT image, and the agent binaries from the official artifactory.

#### Testing an already packaged branch
```shell
$ OP_LOG_LEVEL=TRACE DEVELOPER_MODE=true ELASTIC_AGENT_USE_CI_SNAPSHOTS=true godog -t "stand_alone_mode"
$ OP_LOG_LEVEL=TRACE DEVELOPER_MODE=true ELASTIC_AGENT_USE_CI_SNAPSHOTS=true godog -t "fleet_mode"
```
It will use the elastic-agent image built for the branch, and the agent binaries snapshots from the GCP bucket.

#### Testing an already packaged pull request
```shell
$ OP_LOG_LEVEL=TRACE DEVELOPER_MODE=true ELASTIC_AGENT_USE_CI_SNAPSHOTS=true ELASTIC_AGENT_VERSION=pr-21100 godog -t "stand_alone_mode"
$ OP_LOG_LEVEL=TRACE DEVELOPER_MODE=true ELASTIC_AGENT_USE_CI_SNAPSHOTS=true ELASTIC_AGENT_VERSION=pr-21100 godog -t "fleet_mode"
```
It will use the elastic-agent image built for the PR, and the agent binaries snapshots from the GCP bucket.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/pull/20903
- Closes #305
- Relates https://github.com/elastic/beats/pull/21100
- Relates https://github.com/elastic/beats/issues/20131
- Relates https://github.com/elastic/beats/issues/19291


## Use cases

```gherkin
Scenario: Run tests while developing the test project
When the test framework is changed
Then it uses versions defined in the compose files

Scenario: Run tests for Beats branches
Given a branch on Beats
When the packages (binaries and images) for the PR are published after a merge
Then the test project uses versions for the branch

Scenario: Run tests for Beats pull requests
Given a PR on Beats
When the packages (binaries and images) for the PR are published with the packaging job
Then the test project uses versions for the PR
```

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->