### PR TITLE
fix: calculate bucket path properly (#318) backport for 7.9.x

### DIFF
--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -95,10 +95,14 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 		object := fmt.Sprintf("snapshots/%s", fileName)
 
 		// we are setting a version from a pull request: the version of the artifact will be kept as the base one
-		// i.e. /pull-requests/pr-21100/elastic-agent-7.9.1-x86_64.rpm
-		// i.e. /pull-requests/pr-21100/elastic-agent-7.9.1-amd64.deb
+		// i.e. /pull-requests/pr-21100/elastic-agent/elastic-agent-7.9.1-x86_64.rpm
+		// i.e. /pull-requests/pr-21100/elastic-agent/elastic-agent-7.9.1-amd64.deb
 		if strings.HasPrefix(version, "pr-") {
-			log.WithField("PR", version).Debug("Using CI snapshots a pull request")
+			fileName = fmt.Sprintf("%s-%s-%s.%s", artifact, agentVersionBase, arch, extension)
+			log.WithFields(log.Fields{
+				"agentVersion": agentVersionBase,
+				"PR":           version,
+			}).Debug("Using CI snapshots for a pull request")
 			object = fmt.Sprintf("pull-requests/%s/%s/%s", version, artifact, fileName)
 		}
 


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: calculate bucket path properly (#318)