### PR TITLE
chore: fail warm-up if the installers could not be downloaded

### DIFF
--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -172,18 +172,28 @@ func GetElasticAgentInstaller(image string) ElasticAgentInstaller {
 		"image": image,
 	}).Debug("Configuring installer for the agent")
 
+	var installer ElasticAgentInstaller
+	var err error
 	if "centos-systemd" == image {
-		return newCentosInstaller("centos-systemd", "latest")
+		installer, err = newCentosInstaller("centos-systemd", "latest")
 	} else if "debian-systemd" == image {
-		return newDebianInstaller()
+		installer, err = newDebianInstaller()
+	} else {
+		log.WithField("image", image).Fatal("Sorry, we currently do not support this installer")
+		return ElasticAgentInstaller{}
 	}
 
-	log.WithField("image", image).Fatal("Sorry, we currently do not support this installer")
-	return ElasticAgentInstaller{}
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+			"image": image,
+		}).Fatal("Sorry, we could not download the installer")
+	}
+	return installer
 }
 
 // newCentosInstaller returns an instance of the Centos installer
-func newCentosInstaller(image string, tag string) ElasticAgentInstaller {
+func newCentosInstaller(image string, tag string) (ElasticAgentInstaller, error) {
 	service := image
 	profile := IngestManagerProfileName
 
@@ -204,6 +214,7 @@ func newCentosInstaller(image string, tag string) ElasticAgentInstaller {
 			"extension": extension,
 			"error":     err,
 		}).Error("Could not download the binary for the agent")
+		return ElasticAgentInstaller{}, err
 	}
 
 	fn := func() error {
@@ -229,11 +240,11 @@ func newCentosInstaller(image string, tag string) ElasticAgentInstaller {
 		profile:           profile,
 		service:           service,
 		tag:               tag,
-	}
+	}, nil
 }
 
 // newDebianInstaller returns an instance of the Debian installer
-func newDebianInstaller() ElasticAgentInstaller {
+func newDebianInstaller() (ElasticAgentInstaller, error) {
 	image := "debian-systemd"
 	service := image
 	tag := "stretch"
@@ -256,6 +267,7 @@ func newDebianInstaller() ElasticAgentInstaller {
 			"extension": extension,
 			"error":     err,
 		}).Error("Could not download the binary for the agent")
+		return ElasticAgentInstaller{}, err
 	}
 
 	fn := func() error {
@@ -281,7 +293,7 @@ func newDebianInstaller() ElasticAgentInstaller {
 		profile:           profile,
 		service:           service,
 		tag:               tag,
-	}
+	}, nil
 }
 
 func systemctlRun(profile string, image string, service string, command string) error {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It fails test execution (error level > 0) if the runtime dependencies represented by the agent binaries cannot be downloaded.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
If this error is not handled, the test ramework will continue using an empty file as the binary, causing not real errors.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

Try to download a non existing binary:

```shell
$ OP_LOG_LEVEL=TRACE DEVELOPER_MODE=true ELASTIC_AGENT_USE_CI_SNAPSHOTS=true ELASTIC_AGENT_VERSION=pr-21asdasd godog -t "fleet_mode && enroll"
```

Expected output:

```
ERRO[0034] Could not download the binary for the agent   arch=x86_64 artifact=elastic-agent error="Reached the end of the pages and the pull-requests/pr-21asdasd/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm object was not found for the beats-ci-artifacts bucket" extension=rpm os=linux version=pr-21asdasd
FATA[0036] Sorry, we could not download the installer    error="Reached the end of the pages and the pull-requests/pr-21asdasd/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm object was not found for the beats-ci-artifacts bucket" image=centos-systemd
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Discovered while testing #318


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
Please backport to 7.9.x
<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->