### PR TITLE
fix: rename variable after typo (#331) backport for 7.9.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -264,8 +264,8 @@ def doSlackSend(String color) {
     buildStatus = "Passed"
   }
 
-  def testSuites = "${params.runTestsSuites}"
-  if (testSuites == "") {
+  def testsSuites = "${params.runTestsSuites}"
+  if (testsSuites == "") {
     testsSuites = "All suites"
   }
 


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: rename variable after typo (#331)