### PR TITLE
chore: add make goals to clean up local workspace and docker

### DIFF
--- a/.ci/scripts/clean-docker.sh
+++ b/.ci/scripts/clean-docker.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+## Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+## or more contributor license agreements. Licensed under the Elastic License;
+## you may not use this file except in compliance with the Elastic License.
+
+set -euxo pipefail
+#
+# Build and test the app using the install and test make goals.
+#
+
+readonly VERSION="8.0.0-SNAPSHOT"
+
+main() {
+  # refresh docker images
+  cat <<EOF >.tmp_images
+docker.elastic.co/beats/elastic-agent:${VERSION}
+docker.elastic.co/beats/elastic-agent-ubi8:${VERSION}
+docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+docker.elastic.co/kibana/kibana:${VERSION}
+docker.elastic.co/observability-ci/elastic-agent:${VERSION}
+docker.elastic.co/observability-ci/elastic-agent-ubi8:${VERSION}
+docker.elastic.co/observability-ci/elasticsearch:${VERSION}
+docker.elastic.co/observability-ci/kibana:${VERSION}
+EOF
+
+  pull_images "$(cat .tmp_images)"
+
+  rm .tmp_images
+}
+
+pull_images() {
+  local desired_images="${1}"
+  local image_name
+
+  echo "INFO: Starting to pull images."
+
+  while read -r image_name; do
+    _remove_image "${image_name}"
+    _pull_image "${image_name}"
+  done<<<"$desired_images"
+}
+
+_pull_image() {
+  local image=$1
+  printf "\n\e[1;31m Pulling: [..%s..] \e[0m\n" "${image}"
+  docker pull "${image}" || true
+}
+
+_remove_image() {
+  local image=$1
+  printf "\n\e[1;31m Removing: [..%s..] \e[0m\n" "${image_name}"
+  docker image remove "${image}" || true
+}
+
+main "$@"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,14 @@
+.PHONY: clean
+clean: clean-workspace clean-docker
+
+.PHONY: clean-docker
+clean-docker:
+	./.ci/scripts/clean-docker.sh || true
+
+.PHONY: clean-workspace
+clean-workspace:
+	rm -fr ~/.op/compose
+
 .PHONY: install
 install:
 	go get -v -t ./...

--- a/e2e/_suites/ingest-manager/README.md
+++ b/e2e/_suites/ingest-manager/README.md
@@ -113,8 +113,15 @@ Sometimes the tests could fail to configure or start a product such as Metricbea
 this happened, look at your terminal log in DEBUG mode. If a `docker-compose.yml` file is not present please execute this command:
 
 ```shell
-## Will remove tool's existing default files and will update them with the bundled ones
-rm -fr ~/.op/compose
+## Will remove tool's existing default files and will update them with the bundled ones.
+make clean-workspace
+```
+
+If you see the docker images are outdated, please execute this command:
+
+```shell
+## Will refresh stack images
+make clean-docker
 ```
 
 Note what you find and file a bug in the `elastic/e2e-testing` repository, requiring a fix to the ingest-manager suite to properly configure and start the product.

--- a/e2e/_suites/metricbeat/README.md
+++ b/e2e/_suites/metricbeat/README.md
@@ -104,8 +104,15 @@ Sometimes the tests coulf fail to configure or start a product such as Metricbea
 this happened, look at your terminal log in DEBUG mode. If a `docker-compose.yml` file is not present please execute this command:
 
 ```shell
-## Will remove tool's existing default files and will update them with the bundled ones
-rm -fr ~/.op/compose
+## Will remove tool's existing default files and will update them with the bundled ones.
+make clean-workspace
+```
+
+If you see the docker images are outdated, please execute this command:
+
+```shell
+## Will refresh stack images
+make clean-docker
 ```
 
 Note what you find and file a bug in the `elastic/e2e-testing` repository, requiring a fix to the metricbeat suite to properly configure and start the product.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds three Make goals to clean up the local state:

- make clean-workspace, which removes the HOME directory for the compose files
- make clean-docker, which refreshes certain docker images that are usually consumed in a SNAPSHOT manner (kibana, elasticsearch, elastic-agent)
- make clean, which invokes the two above goals

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Sometimes it's possible to get undesired results when working with the test framework, changing from a maintenance branch to another.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Executed shellcheck for the new script
- [x] Verified that each of the three goals performs its tasks

## How to test this PR locally

From project's root dir:
```shell
$ make clean
$ make clean-workspace
$ make clean-docker
```
It will remove $HOME/.op/compose directory and will refresh the docker images.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

## Use cases
Developers executing the tests between different maintenance branch will use these new goals to clean up the local state

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
We wil backport this to 7.9.x, updating the defaut version
<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->