### PR TITLE
chore: add make goals to clean up local workspace and docker (#354) backport for 7.9.x

### DIFF
--- a/.ci/scripts/clean-docker.sh
+++ b/.ci/scripts/clean-docker.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+## Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+## or more contributor license agreements. Licensed under the Elastic License;
+## you may not use this file except in compliance with the Elastic License.
+
+set -euxo pipefail
+#
+# Build and test the app using the install and test make goals.
+#
+
+readonly VERSION="8.0.0-SNAPSHOT"
+
+main() {
+  # refresh docker images
+  cat <<EOF >.tmp_images
+docker.elastic.co/beats/elastic-agent:${VERSION}
+docker.elastic.co/beats/elastic-agent-ubi8:${VERSION}
+docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+docker.elastic.co/kibana/kibana:${VERSION}
+docker.elastic.co/observability-ci/elastic-agent:${VERSION}
+docker.elastic.co/observability-ci/elastic-agent-ubi8:${VERSION}
+docker.elastic.co/observability-ci/elasticsearch:${VERSION}
+docker.elastic.co/observability-ci/kibana:${VERSION}
+EOF
+
+  pull_images "$(cat .tmp_images)"
+
+  rm .tmp_images
+}
+
+pull_images() {
+  local desired_images="${1}"
+  local image_name
+
+  echo "INFO: Starting to pull images."
+
+  while read -r image_name; do
+    _remove_image "${image_name}"
+    _pull_image "${image_name}"
+  done<<<"$desired_images"
+}
+
+_pull_image() {
+  local image=$1
+  printf "\n\e[1;31m Pulling: [..%s..] \e[0m\n" "${image}"
+  docker pull "${image}" || true
+}
+
+_remove_image() {
+  local image=$1
+  printf "\n\e[1;31m Removing: [..%s..] \e[0m\n" "${image_name}"
+  docker image remove "${image}" || true
+}
+
+main "$@"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,14 @@
+.PHONY: clean
+clean: clean-workspace clean-docker
+
+.PHONY: clean-docker
+clean-docker:
+	./.ci/scripts/clean-docker.sh || true
+
+.PHONY: clean-workspace
+clean-workspace:
+	rm -fr ~/.op/compose
+
 .PHONY: install
 install:
 	go get -v -t ./...

--- a/e2e/_suites/ingest-manager/README.md
+++ b/e2e/_suites/ingest-manager/README.md
@@ -113,8 +113,15 @@ Sometimes the tests could fail to configure or start a product such as Metricbea
 this happened, look at your terminal log in DEBUG mode. If a `docker-compose.yml` file is not present please execute this command:
 
 ```shell
-## Will remove tool's existing default files and will update them with the bundled ones
-rm -fr ~/.op/compose
+## Will remove tool's existing default files and will update them with the bundled ones.
+make clean-workspace
+```
+
+If you see the docker images are outdated, please execute this command:
+
+```shell
+## Will refresh stack images
+make clean-docker
 ```
 
 Note what you find and file a bug in the `elastic/e2e-testing` repository, requiring a fix to the ingest-manager suite to properly configure and start the product.

--- a/e2e/_suites/metricbeat/README.md
+++ b/e2e/_suites/metricbeat/README.md
@@ -104,8 +104,15 @@ Sometimes the tests coulf fail to configure or start a product such as Metricbea
 this happened, look at your terminal log in DEBUG mode. If a `docker-compose.yml` file is not present please execute this command:
 
 ```shell
-## Will remove tool's existing default files and will update them with the bundled ones
-rm -fr ~/.op/compose
+## Will remove tool's existing default files and will update them with the bundled ones.
+make clean-workspace
+```
+
+If you see the docker images are outdated, please execute this command:
+
+```shell
+## Will refresh stack images
+make clean-docker
 ```
 
 Note what you find and file a bug in the `elastic/e2e-testing` repository, requiring a fix to the metricbeat suite to properly configure and start the product.


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - chore: add make goals to clean up local workspace and docker (#354)