### PR TITLE
fix: preset default values for stack and metricbeat (#360) backport for 7.9.x

### DIFF
--- a/cli/config/compose/profiles/metricbeat/docker-compose.yml
+++ b/cli/config/compose/profiles/metricbeat/docker-compose.yml
@@ -9,6 +9,6 @@ services:
       - xpack.monitoring.collection.enabled=true
       - ELASTIC_USERNAME=elastic
       - ELASTIC_PASSWORD=changeme
-    image: "docker.elastic.co/observability-ci/elasticsearch:${stackVersion}"
+    image: "docker.elastic.co/observability-ci/elasticsearch:${stackVersion:-8.0.0-SNAPSHOT}"
     ports:
       - "9200:9200"

--- a/cli/config/compose/profiles/metricbeat/docker-compose.yml
+++ b/cli/config/compose/profiles/metricbeat/docker-compose.yml
@@ -9,6 +9,6 @@ services:
       - xpack.monitoring.collection.enabled=true
       - ELASTIC_USERNAME=elastic
       - ELASTIC_PASSWORD=changeme
-    image: "docker.elastic.co/observability-ci/elasticsearch:${stackVersion:-8.0.0-SNAPSHOT}"
+    image: "docker.elastic.co/observability-ci/elasticsearch:${stackVersion:-7.9.2}"
     ports:
       - "9200:9200"

--- a/cli/config/compose/services/metricbeat/docker-compose.yml
+++ b/cli/config/compose/services/metricbeat/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ]
     environment:
       - BEAT_STRICT_PERMS=${beatStricPerms:-false}
-    image: "docker.elastic.co/observability-ci/metricbeat:${metricbeatTag:-8.0.0-SNAPSHOT}"
+    image: "docker.elastic.co/observability-ci/metricbeat:${metricbeatTag:-7.9.2}"
     labels:
       co.elastic.logs/module: "${serviceName}"
     volumes:

--- a/cli/config/compose/services/metricbeat/docker-compose.yml
+++ b/cli/config/compose/services/metricbeat/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ]
     environment:
       - BEAT_STRICT_PERMS=${beatStricPerms:-false}
-    image: "docker.elastic.co/observability-ci/metricbeat:${metricbeatTag}"
+    image: "docker.elastic.co/observability-ci/metricbeat:${metricbeatTag:-8.0.0-SNAPSHOT}"
     labels:
       co.elastic.logs/module: "${serviceName}"
     volumes:

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -50,7 +50,7 @@ functional-test: install-godog
 	METRICBEAT_VERSION=${METRICBEAT_VERSION} \
 	STACK_VERSION=${STACK_VERSION} \
 	DEVELOPER_MODE=${DEVELOPER_MODE} \
-	godog --format=${FORMAT} ${TAGS_FLAG} ${TAGS}
+	godog --format=${FORMAT} ${TAGS_FLAG} "${TAGS}"
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: preset default values for stack and metricbeat (#360)