### PR TITLE
[CI] Use user-pass credentials

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
+    JOB_GIT_CREDENTIALS = "2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken"
     DOCKER_ELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -80,11 +80,9 @@ pipeline {
             gitCheckout(basedir: BASE_DIR, githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             setEnvVar("GO_VERSION", readFile("${env.WORKSPACE}/${env.BASE_DIR}/.go-version").trim())
-            script {
-              dir("${BASE_DIR}"){
-                // Skip all the test stages for PR's with markdown changes only
-                env.SKIP_TESTS = isGitRegionMatch(patterns: [ '.*\\.md' ], shouldMatchAll: true)
-              }
+            dir("${BASE_DIR}"){
+              // Skip all the test stages for PR's with markdown changes only
+              setEnvVar("SKIP_TESTS", isGitRegionMatch(patterns: [ '.*\\.md' ], shouldMatchAll: true))
             }
           }
         }


### PR DESCRIPTION
## What does this PR do?

- Use credentials with user and pass rather than the ssh ones.
- Use `setEnvVar` to get rid of the `script` closure

## Why is it important?

To send GH check notifications