### PR TITLE
fix: do not pass TRACE log level to metricbeat (#366) backport for 7.9.x

### DIFF
--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -275,10 +275,15 @@ func (mts *MetricbeatTestSuite) runsForSeconds(seconds string) error {
 func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 	serviceManager := services.NewServiceManager()
 
+	logLevel := log.GetLevel().String()
+	if log.GetLevel() == log.TraceLevel {
+		logLevel = log.DebugLevel.String()
+	}
+
 	env := map[string]string{
 		"BEAT_STRICT_PERMS":     "false",
 		"indexName":             mts.getIndexName(),
-		"logLevel":              log.GetLevel().String(),
+		"logLevel":              logLevel,
 		"metricbeatConfigFile":  mts.configurationFile,
 		"metricbeatTag":         mts.Version,
 		"stackVersion":          stackVersion,


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: do not pass TRACE log level to metricbeat (#366)