### PR TITLE
fix: use policy instead of config

### DIFF
--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -1232,7 +1232,7 @@ func getAgentEvents(applicationName string, agentID string, packageConfiguration
 
 		matches := (strings.Contains(message, applicationName) &&
 			strings.Contains(message, "["+agentID+"]: State changed to") &&
-			strings.Contains(message, "Protecting with config {"+packageConfigurationID+"}"))
+			strings.Contains(message, "Protecting with policy {"+packageConfigurationID+"}"))
 
 		if matches && timestamp > updatedAt {
 			log.WithFields(log.Fields{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It uses the word `policy` instead of `config` when matching the security events for an agent

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Even thought we are in 7.9, the rename of the configs to policies does not affect to this log entry

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

```shell
$ SUITE=ingest-manager DEVELOPER_MODE=true TAGS="agent_endpoint_integration && set-policy-and-check-changes" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #371


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
The evvent is now obtained, but in the DEGRADED state:

>"Application: endpoint-security--7.9.2[ab9e7d89-a285-4cf2-be3b-65d9d87ee096]: State changed to DEGRADED: Protecting with policy {b89ee120-1045-11eb-a219-ff34b6e24c16}"

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->