### PR TITLE
chore: remove orphan containers when shutting down the compose

### DIFF
--- a/cli/services/manager.go
+++ b/cli/services/manager.go
@@ -125,7 +125,7 @@ func (sm *DockerServiceManager) StopCompose(isProfile bool, composeNames []strin
 	}
 	persistedEnv := state.Recover(ID, config.Op.Workspace)
 
-	err := executeCompose(sm, isProfile, composeNames, []string{"down"}, persistedEnv)
+	err := executeCompose(sm, isProfile, composeNames, []string{"down", "--remove-orphans"}, persistedEnv)
 	if err != nil {
 		return fmt.Errorf("Could not stop compose file: %v - %v", composeFilePaths, err)
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds the `--remove-orphans` flag to the `docker-compose down` command.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
When adding services oon the fly to a running compose, using `AddServicesToCompose` method, those services/containers are not attached to the destroyed unless it's passed the compose file for each of them. With this flag we won't let containers to be kept running, destroying them alongside its parent compose (the one they are attached to)

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

We should see:
>Stopping fleet_kibana_1           ... done
Stopping fleet_package-registry_1 ... done
Stopping fleet_elasticsearch_1    ... done
Removing orphan container "fleet_centos-systemd_elastic-agent_1"
Removing orphan container "fleet_debian-systemd_elastic-agent_1"
Removing fleet_kibana_1           ... done
Removing fleet_package-registry_1 ... done
Removing fleet_elasticsearch_1    ... done
Removing network fleet_default

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->