### PR TITLE
fix: wrong variable name (#390) backport for 7.10.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -267,7 +267,7 @@ def doNotify(String color, boolean notify) {
     testsSuites = "All suites"
   }
 
-  def header = "*Test Suite*: " + testSuites
+  def header = "*Test Suite*: " + testsSuites
   notifyBuildResult(prComment: true, slackHeader: header, slackChannel: "${env.SLACK_CHANNEL}", slackComment: true, slackNotify: notify)
 }
 


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - fix: wrong variable name (#390)