### PR TITLE
fix: double down the timeout to check security events (#389) backport for 7.10.x

### DIFF
--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -796,7 +796,7 @@ func (fts *FleetTestSuite) thePolicyWillReflectTheChangeInTheSecurityApp() error
 		return err
 	}
 
-	maxTimeout := time.Duration(timeoutFactor) * time.Minute
+	maxTimeout := time.Duration(timeoutFactor) * time.Minute * 2
 	retryCount := 1
 
 	exp := e2e.GetExponentialBackOff(maxTimeout)


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - fix: double down the timeout to check security events (#389)