### PR TITLE
fix: double down the timeout to check security events (#389) backport for 7.9.x

### DIFF
--- a/e2e/_suites/ingest-manager/fleet.go
+++ b/e2e/_suites/ingest-manager/fleet.go
@@ -772,7 +772,7 @@ func (fts *FleetTestSuite) thePolicyWillReflectTheChangeInTheSecurityApp() error
 		return err
 	}
 
-	maxTimeout := time.Duration(timeoutFactor) * time.Minute
+	maxTimeout := time.Duration(timeoutFactor) * time.Minute * 2
 	retryCount := 1
 
 	exp := e2e.GetExponentialBackOff(maxTimeout)


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: double down the timeout to check security events (#389)