### PR TITLE
chore: use URL parameter to avoid adding test stats (#398) backport for 7.9.x

### DIFF
--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -66,7 +66,7 @@ func GetElasticArtifactURL(artifact string, version string, OS string, arch stri
 
 	apiStatus := func() error {
 		r := curl.HTTPRequest{
-			URL: fmt.Sprintf("https://artifacts-api.elastic.co/v1/search/%s/%s", version, artifact),
+			URL: fmt.Sprintf("https://artifacts-api.elastic.co/v1/search/%s/%s?x-elastic-no-kpi=true", version, artifact),
 		}
 
 		response, err := curl.Get(r)


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - chore: use URL parameter to avoid adding test stats (#398)