### PR TITLE
chore: simplify metricbeat waits

### DIFF
--- a/e2e/_suites/metricbeat/features/apache.feature
+++ b/e2e/_suites/metricbeat/features/apache.feature
@@ -4,9 +4,7 @@ Feature: Apache
 
 Scenario Outline: Apache-<apache_version> sends metrics to Elasticsearch without errors
   Given Apache "<apache_version>" is running for metricbeat
-    And metricbeat is installed and configured for Apache module
-    And metricbeat waits "20" seconds for the service
-  When metricbeat runs for "20" seconds 
+  When metricbeat is installed and configured for Apache module
   Then there are "Apache" events in the index
     And there are no errors in the index
 Examples:

--- a/e2e/_suites/metricbeat/features/metricbeat.feature
+++ b/e2e/_suites/metricbeat/features/metricbeat.feature
@@ -3,8 +3,7 @@ Feature: Metricbeat
   As a Metricbeat developer I want to check that default configuration works as expected
 
 Scenario Outline: Metricbeat's <configuration> configuration sends metrics to Elasticsearch without errors
-  Given metricbeat is installed using "<configuration>" configuration
-  When metricbeat runs for "30" seconds
+  When metricbeat is installed using "<configuration>" configuration
   Then there are "system" events in the index
     And there are no errors in the index
 Examples:

--- a/e2e/_suites/metricbeat/features/mysql.feature
+++ b/e2e/_suites/metricbeat/features/mysql.feature
@@ -4,9 +4,7 @@ Feature: Mysql
 
 Scenario Outline: <variant>-<version> sends metrics to Elasticsearch without errors
   Given "<variant>" v<version>, variant of "MySQL", is running for metricbeat
-    And metricbeat is installed and configured for "<variant>", variant of the "MySQL" module
-    And metricbeat waits "20" seconds for the service
-  When metricbeat runs for "20" seconds
+  When metricbeat is installed and configured for "<variant>", variant of the "MySQL" module
   Then there are "<variant>" events in the index
     And there are no errors in the index
 Examples:

--- a/e2e/_suites/metricbeat/features/redis.feature
+++ b/e2e/_suites/metricbeat/features/redis.feature
@@ -4,9 +4,7 @@ Feature: Redis
 
 Scenario Outline: Redis-<redis_version> sends metrics to Elasticsearch without errors
   Given Redis "<redis_version>" is running for metricbeat
-    And metricbeat is installed and configured for Redis module
-    And metricbeat waits "20" seconds for the service
-  When metricbeat runs for "20" seconds
+  When metricbeat is installed and configured for Redis module
   Then there are "Redis" events in the index
     And there are no errors in the index
 Examples:

--- a/e2e/_suites/metricbeat/features/vsphere.feature
+++ b/e2e/_suites/metricbeat/features/vsphere.feature
@@ -4,9 +4,7 @@ Feature: vSphere
 
 Scenario Outline: vSphere-<vsphere_version> sends metrics to Elasticsearch without errors
   Given vSphere "<vsphere_version>" is running for metricbeat
-    And metricbeat is installed and configured for vSphere module
-    And metricbeat waits "120" seconds for the service
-  When metricbeat runs for "20" seconds
+  When metricbeat is installed and configured for vSphere module
   Then there are "vSphere" events in the index
     And there are no errors in the index
 Examples:

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -282,6 +282,10 @@ func (mts *MetricbeatTestSuite) installedUsingConfiguration(configuration string
 
 // runMetricbeatService runs a metricbeat service entity for a service to monitor it
 func (mts *MetricbeatTestSuite) runMetricbeatService() error {
+	// this is needed because, in general, the target service (apache, mysql, redis) does not have a healthcheck
+	waitForService := time.Duration(timeoutFactor) * 10
+	e2e.Sleep(fmt.Sprintf("%d", waitForService))
+
 	serviceManager := services.NewServiceManager()
 
 	logLevel := log.GetLevel().String()

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -157,8 +157,6 @@ func MetricbeatFeatureContext(s *godog.Suite) {
 	s.Step(`^"([^"]*)" v([^"]*), variant of "([^"]*)", is running for metricbeat$`, testSuite.serviceVariantIsRunningForMetricbeat)
 	s.Step(`^metricbeat is installed and configured for ([^"]*) module$`, testSuite.installedAndConfiguredForModule)
 	s.Step(`^metricbeat is installed and configured for "([^"]*)", variant of the "([^"]*)" module$`, testSuite.installedAndConfiguredForVariantModule)
-	s.Step(`^metricbeat waits "([^"]*)" seconds for the service$`, testSuite.waitsSeconds)
-	s.Step(`^metricbeat runs for "([^"]*)" seconds$`, testSuite.runsForSeconds)
 	s.Step(`^there are no errors in the index$`, testSuite.thereAreNoErrorsInTheIndex)
 	s.Step(`^there are "([^"]*)" events in the index$`, testSuite.thereAreEventsInTheIndex)
 
@@ -227,6 +225,11 @@ func (mts *MetricbeatTestSuite) installedAndConfiguredForModule(serviceType stri
 	mts.setEventModule(mts.ServiceType)
 	mts.setServiceVersion(mts.Version)
 
+	err := mts.runMetricbeatService()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -269,18 +272,12 @@ func (mts *MetricbeatTestSuite) installedUsingConfiguration(configuration string
 	mts.setEventModule("system")
 	mts.setServiceVersion(mts.Version)
 
-	return nil
-}
-
-// runsForSeconds waits for a number of seconds so that metricbeat gets
-// an acceptable number of metrics
-func (mts *MetricbeatTestSuite) runsForSeconds(seconds string) error {
-	err := mts.runMetricbeatService()
+	err = mts.runMetricbeatService()
 	if err != nil {
 		return err
 	}
 
-	return e2e.Sleep(seconds)
+	return nil
 }
 
 // runMetricbeatService runs a metricbeat service entity for a service to monitor it
@@ -463,9 +460,4 @@ func (mts *MetricbeatTestSuite) thereAreNoErrorsInTheIndex() error {
 	}
 
 	return e2e.AssertHitsDoNotContainErrors(result, mts.Query)
-}
-
-// waitsSeconds waits for a number of seconds before the next step
-func (mts *MetricbeatTestSuite) waitsSeconds(seconds string) error {
-	return e2e.Sleep(seconds)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It removes the steps that hardcoded the amount of seconds for waits, delegating it to the existing steps that already waited using backoff strategy.

>In fact we are moving the active wait from the specs to the code, as it's an implementation detail. We are waiting 30 secs right before starting metricbeat, so that the target integration service is able to start-up, and metricbeat does not discover errors that are previous to the service gets to the healthy status.

With these changes the wait timeout is configurable with the TIMEOUT_FACTOR variable (default is 3), being the real value 10 times that variable.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It simplifies the feature files, and the code, removing hardcoded values. Besides that, it reduces execution time for the metricbeat test suite.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```shell
$ SUITE="metricbeat" TAGS="apache" DEVELOPER_MODE=false TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE make -C e2e functional-test
$ SUITE="metricbeat" TAGS="metricbeat" DEVELOPER_MODE=false TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE make -C e2e functional-test
$ SUITE="metricbeat" TAGS="mysql" DEVELOPER_MODE=false TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE make -C e2e functional-test
$ SUITE="metricbeat" TAGS="redis" DEVELOPER_MODE=false TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE make -C e2e functional-test
$ SUITE="metricbeat" TAGS="vsphere" DEVELOPER_MODE=false TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE make -C e2e functional-test
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #78 
- Closes #45 

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
Needs backport to 7.9.x and 7.10.x
<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->