### PR TITLE
chore: use the proper beats slack channel (#405) | chore: simplify metricbeat waits (#406) backport for 7.10.x

### DIFF
--- a/.ci/e2eTestingIntegrationsDaily.groovy
+++ b/.ci/e2eTestingIntegrationsDaily.groovy
@@ -44,8 +44,9 @@ pipeline {
           parameters: [
             booleanParam(name: 'forceSkipGitChecks', value: true),
             booleanParam(name: 'forceSkipPresubmit', value: true),
+            booleanParam(name: 'notifyOnGreenBuilds', value: true),
             string(name: 'runTestsSuites', value: 'metricbeat'),
-            string(name: 'SLACK_CHANNEL', value: "integrations"),
+            string(name: 'SLACK_CHANNEL', value: "beats-build"),
           ],
           propagate: false,
           wait: false

--- a/e2e/_suites/metricbeat/features/apache.feature
+++ b/e2e/_suites/metricbeat/features/apache.feature
@@ -4,9 +4,7 @@ Feature: Apache
 
 Scenario Outline: Apache-<apache_version> sends metrics to Elasticsearch without errors
   Given Apache "<apache_version>" is running for metricbeat
-    And metricbeat is installed and configured for Apache module
-    And metricbeat waits "20" seconds for the service
-  When metricbeat runs for "20" seconds 
+  When metricbeat is installed and configured for Apache module
   Then there are "Apache" events in the index
     And there are no errors in the index
 Examples:

--- a/e2e/_suites/metricbeat/features/metricbeat.feature
+++ b/e2e/_suites/metricbeat/features/metricbeat.feature
@@ -3,8 +3,7 @@ Feature: Metricbeat
   As a Metricbeat developer I want to check that default configuration works as expected
 
 Scenario Outline: Metricbeat's <configuration> configuration sends metrics to Elasticsearch without errors
-  Given metricbeat is installed using "<configuration>" configuration
-  When metricbeat runs for "30" seconds
+  When metricbeat is installed using "<configuration>" configuration
   Then there are "system" events in the index
     And there are no errors in the index
 Examples:

--- a/e2e/_suites/metricbeat/features/mysql.feature
+++ b/e2e/_suites/metricbeat/features/mysql.feature
@@ -4,9 +4,7 @@ Feature: Mysql
 
 Scenario Outline: <variant>-<version> sends metrics to Elasticsearch without errors
   Given "<variant>" v<version>, variant of "MySQL", is running for metricbeat
-    And metricbeat is installed and configured for "<variant>", variant of the "MySQL" module
-    And metricbeat waits "20" seconds for the service
-  When metricbeat runs for "20" seconds
+  When metricbeat is installed and configured for "<variant>", variant of the "MySQL" module
   Then there are "<variant>" events in the index
     And there are no errors in the index
 Examples:

--- a/e2e/_suites/metricbeat/features/redis.feature
+++ b/e2e/_suites/metricbeat/features/redis.feature
@@ -4,9 +4,7 @@ Feature: Redis
 
 Scenario Outline: Redis-<redis_version> sends metrics to Elasticsearch without errors
   Given Redis "<redis_version>" is running for metricbeat
-    And metricbeat is installed and configured for Redis module
-    And metricbeat waits "20" seconds for the service
-  When metricbeat runs for "20" seconds
+  When metricbeat is installed and configured for Redis module
   Then there are "Redis" events in the index
     And there are no errors in the index
 Examples:

--- a/e2e/_suites/metricbeat/features/vsphere.feature
+++ b/e2e/_suites/metricbeat/features/vsphere.feature
@@ -4,9 +4,7 @@ Feature: vSphere
 
 Scenario Outline: vSphere-<vsphere_version> sends metrics to Elasticsearch without errors
   Given vSphere "<vsphere_version>" is running for metricbeat
-    And metricbeat is installed and configured for vSphere module
-    And metricbeat waits "120" seconds for the service
-  When metricbeat runs for "20" seconds
+  When metricbeat is installed and configured for vSphere module
   Then there are "vSphere" events in the index
     And there are no errors in the index
 Examples:


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - chore: use the proper beats slack channel (#405)
 - chore: simplify metricbeat waits (#406)