### PR TITLE
chore: disable telemetry in tests (#412) backport for 7.10.x

### DIFF
--- a/e2e/_suites/fleet/configurations/kibana.config.yml
+++ b/e2e/_suites/fleet/configurations/kibana.config.yml
@@ -2,6 +2,8 @@
 server.name: kibana
 server.host: "0"
 
+telemetry.enabled: false
+
 elasticsearch.hosts: [ "http://elasticsearch:9200" ]
 elasticsearch.username: elastic
 elasticsearch.password: changeme


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - chore: disable telemetry in tests (#412)