### PR TITLE
feat: calculate latest version for Beats (#426) backport for 7.10.x

### DIFF
--- a/e2e/_suites/fleet/ingest-manager_test.go
+++ b/e2e/_suites/fleet/ingest-manager_test.go
@@ -36,9 +36,15 @@ const ElasticAgentServiceName = "elastic-agent"
 // FleetProfileName the name of the profile to run the runtime, backend services
 const FleetProfileName = "fleet"
 
+var agentVersionBase = "7.10-SNAPSHOT"
+
+// agentVersion is the version of the agent to use
+// It can be overriden by ELASTIC_AGENT_VERSION env var
+var agentVersion = agentVersionBase
+
 // stackVersion is the version of the stack to use
 // It can be overriden by STACK_VERSION env var
-var stackVersion = "7.10-SNAPSHOT"
+var stackVersion = agentVersionBase
 
 // profileEnv is the environment to be applied to any execution
 // affecting the runtime dependencies (or profile)
@@ -64,10 +70,13 @@ func init() {
 	}
 
 	timeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", timeoutFactor)
+	agentVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", agentVersionBase)
 	stackVersion = shell.GetEnv("STACK_VERSION", stackVersion)
 }
 
 func IngestManagerFeatureContext(s *godog.Suite) {
+	agentVersionBase = e2e.GetElasticArtifactVersion(agentVersionBase)
+
 	imts := IngestManagerTestSuite{
 		Fleet: &FleetTestSuite{
 			Installers: map[string]ElasticAgentInstaller{

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -6,29 +6,16 @@ import (
 	"os"
 	"strings"
 
-	"github.com/elastic/e2e-testing/cli/config"
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
 	log "github.com/sirupsen/logrus"
 )
 
-const agentVersionBase = "7.10.0"
-
-// agentVersion is the version of the agent to use
-// It can be overriden by ELASTIC_AGENT_VERSION env var
-var agentVersion = agentVersionBase
-
 // to avoid downloading the same artifacts, we are adding this map to cache the URL of the downloaded binaries, using as key
 // the URL of the artifact. If another installer is trying to download the same URL, it will return the location of the
 // already downloaded artifact.
 var binariesCache = map[string]string{}
-
-func init() {
-	config.Init()
-
-	agentVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", agentVersionBase)
-}
 
 // ElasticAgentInstaller represents how to install an agent, depending of the box type
 type ElasticAgentInstaller struct {

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -12,25 +12,11 @@ import (
 	"time"
 
 	"github.com/cucumber/godog"
-	"github.com/elastic/e2e-testing/cli/config"
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/cli/services"
-	"github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
 	log "github.com/sirupsen/logrus"
 )
-
-const standAloneVersionBase = "7.10-SNAPSHOT"
-
-// standAloneVersion is the version of the agent to use
-// It can be overriden by ELASTIC_AGENT_VERSION env var
-var standAloneVersion = standAloneVersionBase
-
-func init() {
-	config.Init()
-
-	standAloneVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", standAloneVersionBase)
-}
 
 // StandAloneTestSuite represents the scenarios for Stand-alone-mode
 type StandAloneTestSuite struct {
@@ -95,7 +81,7 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed(image string) error 
 
 	profileEnv["elasticAgentContainerName"] = containerName
 	profileEnv["elasticAgentConfigFile"] = sats.AgentConfigFilePath
-	profileEnv["elasticAgentTag"] = standAloneVersion
+	profileEnv["elasticAgentTag"] = agentVersion
 
 	err = serviceManager.AddServicesToCompose(FleetProfileName, []string{ElasticAgentServiceName}, profileEnv)
 	if err != nil {

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -41,7 +41,7 @@ var serviceManager services.ServiceManager
 
 // stackVersion is the version of the stack to use
 // It can be overriden by STACK_VERSION env var
-var stackVersion = "7.10-SNAPSHOT"
+var stackVersion = metricbeatVersionBase
 
 func init() {
 	config.Init()

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -53,7 +53,7 @@ func GetExponentialBackOff(elapsedTime time.Duration) *backoff.ExponentialBackOf
 
 // GetElasticArtifactVersion returns the current version:
 // 1. Elastic's artifact repository, building the JSON path query based
-// i.e. GetElasticArtifactVersion("8.0.0-SNAPSHOT")
+// i.e. GetElasticArtifactVersion("7.10.0-SNAPSHOT")
 func GetElasticArtifactVersion(version string) string {
 	exp := GetExponentialBackOff(time.Minute)
 


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - feat: calculate latest version for Beats (#426)