### PR TITLE
feat: calculate latest version for Beats (#426) backport for 7.9.x

### DIFF
--- a/e2e/_suites/ingest-manager/ingest-manager_test.go
+++ b/e2e/_suites/ingest-manager/ingest-manager_test.go
@@ -36,9 +36,15 @@ const ElasticAgentServiceName = "elastic-agent"
 // IngestManagerProfileName the name of the profile to run the runtime, backend services
 const IngestManagerProfileName = "ingest-manager"
 
+var agentVersionBase = "7.9-SNAPSHOT"
+
+// agentVersion is the version of the agent to use
+// It can be overriden by ELASTIC_AGENT_VERSION env var
+var agentVersion = agentVersionBase
+
 // stackVersion is the version of the stack to use
 // It can be overriden by STACK_VERSION env var
-var stackVersion = "7.9-SNAPSHOT"
+var stackVersion = agentVersionBase
 
 // profileEnv is the environment to be applied to any execution
 // affecting the runtime dependencies (or profile)
@@ -64,10 +70,13 @@ func init() {
 	}
 
 	timeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", timeoutFactor)
+	agentVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", agentVersionBase)
 	stackVersion = shell.GetEnv("STACK_VERSION", stackVersion)
 }
 
 func IngestManagerFeatureContext(s *godog.Suite) {
+	agentVersionBase = e2e.GetElasticArtifactVersion(agentVersionBase)
+
 	imts := IngestManagerTestSuite{
 		Fleet: &FleetTestSuite{
 			Installers: map[string]ElasticAgentInstaller{

--- a/e2e/_suites/ingest-manager/services.go
+++ b/e2e/_suites/ingest-manager/services.go
@@ -5,23 +5,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/elastic/e2e-testing/cli/config"
 	"github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
 	log "github.com/sirupsen/logrus"
 )
-
-const agentVersionBase = "7.9.3"
-
-// agentVersion is the version of the agent to use
-// It can be overriden by ELASTIC_AGENT_VERSION env var
-var agentVersion = agentVersionBase
-
-func init() {
-	config.Init()
-
-	agentVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", agentVersionBase)
-}
 
 // ElasticAgentInstaller represents how to install an agent, depending of the box type
 type ElasticAgentInstaller struct {

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -65,7 +65,7 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed() error {
 	serviceName := ElasticAgentServiceName
 	containerName := fmt.Sprintf("%s_%s_%d", profile, serviceName, 1)
 
-	branch := strings.ReplaceAll(standAloneVersion, "-SNAPSHOT", "")
+	branch := strings.ReplaceAll(agentVersion, "-SNAPSHOT", "")
 
 	configurationFileURL := "https://raw.githubusercontent.com/elastic/beats/" + branch + "/x-pack/elastic-agent/elastic-agent.docker.yml"
 

--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -11,24 +11,10 @@ import (
 	"time"
 
 	"github.com/cucumber/godog"
-	"github.com/elastic/e2e-testing/cli/config"
 	"github.com/elastic/e2e-testing/cli/services"
-	"github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
 	log "github.com/sirupsen/logrus"
 )
-
-const standAloneVersionBase = "7.9-SNAPSHOT"
-
-// standAloneVersion is the version of the agent to use
-// It can be overriden by ELASTIC_AGENT_VERSION env var
-var standAloneVersion = standAloneVersionBase
-
-func init() {
-	config.Init()
-
-	standAloneVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", standAloneVersionBase)
-}
 
 // StandAloneTestSuite represents the scenarios for Stand-alone-mode
 type StandAloneTestSuite struct {
@@ -90,7 +76,7 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed() error {
 	sats.AgentConfigFilePath = configurationFilePath
 
 	profileEnv["elasticAgentConfigFile"] = sats.AgentConfigFilePath
-	profileEnv["elasticAgentTag"] = standAloneVersion
+	profileEnv["elasticAgentTag"] = agentVersion
 
 	err = serviceManager.AddServicesToCompose(profile, []string{serviceName}, profileEnv)
 	if err != nil {

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -41,7 +41,7 @@ var serviceManager services.ServiceManager
 
 // stackVersion is the version of the stack to use
 // It can be overriden by STACK_VERSION env var
-var stackVersion = "7.9-SNAPSHOT"
+var stackVersion = metricbeatVersionBase
 
 func init() {
 	config.Init()

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -51,6 +51,77 @@ func GetExponentialBackOff(elapsedTime time.Duration) *backoff.ExponentialBackOf
 	return exp
 }
 
+// GetElasticArtifactVersion returns the current version:
+// 1. Elastic's artifact repository, building the JSON path query based
+// i.e. GetElasticArtifactVersion("7.9-SNAPSHOT")
+func GetElasticArtifactVersion(version string) string {
+	exp := GetExponentialBackOff(time.Minute)
+
+	retryCount := 1
+
+	body := ""
+
+	apiStatus := func() error {
+		r := curl.HTTPRequest{
+			URL: fmt.Sprintf("https://artifacts-api.elastic.co/v1/versions/%s/?x-elastic-no-kpi=true", version),
+		}
+
+		response, err := curl.Get(r)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"version":        version,
+				"error":          err,
+				"retry":          retryCount,
+				"statusEndpoint": r.URL,
+				"elapsedTime":    exp.GetElapsedTime(),
+			}).Warn("The Elastic artifacts API is not available yet")
+
+			retryCount++
+
+			return err
+		}
+
+		log.WithFields(log.Fields{
+			"retries":        retryCount,
+			"statusEndpoint": r.URL,
+			"elapsedTime":    exp.GetElapsedTime(),
+		}).Debug("The Elastic artifacts API is available")
+
+		body = response
+		return nil
+	}
+
+	err := backoff.Retry(apiStatus, exp)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"version": version,
+		}).Fatal("Failed to get version, aborting")
+		return ""
+	}
+
+	jsonParsed, err := gabs.ParseJSON([]byte(body))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"version": version,
+		}).Fatal("Could not parse the response body to retrieve the version, aborting")
+		return ""
+	}
+
+	builds := jsonParsed.Path("version.builds")
+
+	lastBuild := builds.Children()[0]
+	latestVersion := lastBuild.Path("version").Data().(string)
+
+	log.WithFields(log.Fields{
+		"alias":   version,
+		"version": latestVersion,
+	}).Debug("Latest version for current version obtained")
+
+	return latestVersion
+}
+
 // GetElasticArtifactURL returns the URL of a released artifact from two possible sources
 // on the desired OS, architecture and file extension:
 // 1. Observability CI Storage bucket


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - feat: calculate latest version for Beats (#426)