### PR TITLE
chore(ci): fail fast the  parallel execution for the e2e tests

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -164,10 +164,7 @@ pipeline {
           }
         }
         stage('End-To-End Tests') {
-          options {
-            skipDefaultCheckout()
-            parallelsAlwaysFailFast()
-          }
+          options { skipDefaultCheckout() }
           environment {
             GO111MODULE = 'on'
             PATH = "${env.HOME}/bin:${env.WORKSPACE}/${env.BASE_DIR}/bin:${HOME}/go/bin:${env.PATH}"
@@ -202,6 +199,7 @@ pipeline {
                       }
                     }
                   }
+                  failFast true
                   parallel(parallelTasks)
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -164,6 +164,7 @@ pipeline {
           }
         }
         stage('End-To-End Tests') {
+          failFast true
           options { skipDefaultCheckout() }
           environment {
             GO111MODULE = 'on'
@@ -199,7 +200,6 @@ pipeline {
                       }
                     }
                   }
-                  failFast true
                   parallel(parallelTasks)
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -164,7 +164,10 @@ pipeline {
           }
         }
         stage('End-To-End Tests') {
-          options { skipDefaultCheckout() }
+          options {
+            skipDefaultCheckout()
+            parallelsAlwaysFailFast()
+          }
           environment {
             GO111MODULE = 'on'
             PATH = "${env.HOME}/bin:${env.WORKSPACE}/${env.BASE_DIR}/bin:${HOME}/go/bin:${env.PATH}"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It sets `failfast true` for all subsequent parallel stages in the pipeline, in this case the e2e tests.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It will fail the build, releasing CI resources, as soon an error occurs.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats-tester/pull/186 


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
Backport to 7.9.x and 7.0.x


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->