### PR TITLE
chore(ci): fail fast the  parallel execution for the e2e tests (#429) backport for 7.9.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -166,6 +166,7 @@ pipeline {
           }
         }
         stage('End-To-End Tests') {
+          failFast true
           options { skipDefaultCheckout() }
           environment {
             GO111MODULE = 'on'


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - chore(ci): fail fast the  parallel execution for the e2e tests (#429)