### PR TITLE
chore: calculate reporter name from isPR or isBranch (#457) backport for 7.9.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -235,7 +235,13 @@ pipeline {
   post {
     cleanup {
       githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILURE')
-      notifyBuildResult(analyzeFlakey: true, flakyReportIdx: "reporter-e2e-tests-end-2-end-tests-pipeline-7.9.x", prComment: true)
+      whenTrue(isBranch()) {
+         setEnvVar("REPORTER_SUFFIX", env.BRANCH_NAME)
+      }
+      whenTrue(isPR()) {
+         setEnvVar("REPORTER_SUFFIX", env.CHANGE_TARGET)
+      }
+      notifyBuildResult(analyzeFlakey: true, flakyReportIdx: "reporter-e2e-tests-end-2-end-tests-pipeline-${env.REPORTER_SUFFIX}", prComment: true)
     }
     success {
       whenTrue(!isPR() && params.notifyOnGreenBuilds) {


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - chore: calculate reporter name from isPR or isBranch (#457)