### PR TITLE
chore: double Helm max timeout

### DIFF
--- a/e2e/_suites/helm/helm_charts_test.go
+++ b/e2e/_suites/helm/helm_charts_test.go
@@ -353,8 +353,10 @@ func (ts *HelmChartTestSuite) install(chart string) error {
 			"chart": ts.Name,
 		}).Info("Rancher Local Path Provisioner and local-path storage class for Elasticsearch volumes installed")
 
+		maxTimeout := timeoutFactor * 450
+
 		log.Debug("Applying workaround to use Rancher's local-path storage class for Elasticsearch volumes")
-		flags = []string{"--wait", "--timeout=900s", "--values", "https://raw.githubusercontent.com/elastic/helm-charts/master/elasticsearch/examples/kubernetes-kind/values.yaml"}
+		flags = []string{"--wait", fmt.Sprintf("--timeout=%ds", maxTimeout), "--values", "https://raw.githubusercontent.com/elastic/helm-charts/master/elasticsearch/examples/kubernetes-kind/values.yaml"}
 	}
 
 	return helm.InstallChart(ts.Name, elasticChart, ts.Version, flags)

--- a/e2e/_suites/helm/helm_charts_test.go
+++ b/e2e/_suites/helm/helm_charts_test.go
@@ -174,7 +174,7 @@ func (ts *HelmChartTestSuite) aResourceWillExposePods(resourceType string) error
 				"resource":    "endpoints",
 				"retry":       retryCount,
 				"selector":    selector,
-			}).Warn("Enpdoints not present yet")
+			}).Warn("Endpoints not present yet")
 
 			retryCount++
 
@@ -186,7 +186,7 @@ func (ts *HelmChartTestSuite) aResourceWillExposePods(resourceType string) error
 			"resource":    "endpoints",
 			"retry":       retryCount,
 			"selector":    selector,
-		}).Info("Enpdoints found")
+		}).Info("Endpoints found")
 
 		return nil
 	}

--- a/e2e/_suites/helm/helm_charts_test.go
+++ b/e2e/_suites/helm/helm_charts_test.go
@@ -353,7 +353,7 @@ func (ts *HelmChartTestSuite) install(chart string) error {
 			"chart": ts.Name,
 		}).Info("Rancher Local Path Provisioner and local-path storage class for Elasticsearch volumes installed")
 
-		maxTimeout := timeoutFactor * 450
+		maxTimeout := timeoutFactor * 100
 
 		log.Debug("Applying workaround to use Rancher's local-path storage class for Elasticsearch volumes")
 		flags = []string{"--wait", fmt.Sprintf("--timeout=%ds", maxTimeout), "--values", "https://raw.githubusercontent.com/elastic/helm-charts/master/elasticsearch/examples/kubernetes-kind/values.yaml"}

--- a/e2e/_suites/helm/helm_charts_test.go
+++ b/e2e/_suites/helm/helm_charts_test.go
@@ -32,7 +32,7 @@ var helm k8s.HelmManager
 
 // timeoutFactor a multiplier for the max timeout when doing backoff retries.
 // It can be overriden by TIMEOUT_FACTOR env var
-var timeoutFactor = 1
+var timeoutFactor = 2
 
 //nolint:unused
 var kubectl k8s.Kubectl


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a global variable setting the max timeout factor to 2. This variable could be modified by an environment variable, set on CI to 3.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It will make the backoff strategies configurable on test time, because it's now fixed to 1 minute.

After a few builds with the new Helm 3 code, it seems to randomly fail for metricbeat, that's why we are allowing this configuration.

Besides that, we noticed that installing the Elasticsearch helm chart took a lot. We found that there was a hardcoded value for the timeout, so we are reusing the new variable here to build the max timeout, also reducing the value from 900s to 200s by default (300 on CI).

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally
```shell
SUITE="helm" TAGS="metricbeat" DEVELOPER_MODE=true TIMEOUT_FACTOR=1 LOG_LEVEL=TRACE make -C e2e functional-test
```

If using TIMEOUT_FACTOR=1, then you'll see this log in the output console (pay attention to the `--timeout=100s`):
>ERRO[2020-11-25T19:12:29+01:00] Error executing command                       args="[install elasticsearch elastic/elasticsearch --version 7.10.0 --wait --timeout=100s --values https://raw.githubusercontent.com/elastic/helm-charts/master/elasticsearch/examples/kubernetes-kind/values.yaml]" baseDir=. command=helm error="exit status 1" stderr="Error: timed out waiting for the condition\n"


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #447


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
Backports to 7.x, 7.9.x and 7.10.x are required

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->