### PR TITLE
fix: move evaluation out of post section (#465) backport for 7.9.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -75,6 +75,13 @@ pipeline {
       stages {
         stage('Checkout') {
           steps {
+            whenTrue(isBranch()) {
+              setEnvVar("REPORTER_SUFFIX", env.BRANCH_NAME)
+            }
+            whenTrue(isPR()) {
+              setEnvVar("REPORTER_SUFFIX", env.CHANGE_TARGET)
+            }
+
             pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
             deleteDir()
             gitCheckout(basedir: BASE_DIR, githubNotifyFirstTimeContributor: true)
@@ -235,12 +242,6 @@ pipeline {
   post {
     cleanup {
       githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILURE')
-      whenTrue(isBranch()) {
-         setEnvVar("REPORTER_SUFFIX", env.BRANCH_NAME)
-      }
-      whenTrue(isPR()) {
-         setEnvVar("REPORTER_SUFFIX", env.CHANGE_TARGET)
-      }
       notifyBuildResult(analyzeFlakey: true, flakyReportIdx: "reporter-e2e-tests-end-2-end-tests-pipeline-${env.REPORTER_SUFFIX}", prComment: true)
     }
     success {


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: move evaluation out of post section (#465)