### PR TITLE
fix: use full process name to match in pgrep (#475) backport for 7.x

### DIFF
--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -427,7 +427,7 @@ func WaitForProcess(containerName string, process string, desiredState string, m
 			"process":      process,
 		}).Trace("Checking process desired state on the container")
 
-		output, err := docker.ExecCommandIntoContainer(context.Background(), containerName, "root", []string{"pgrep", "-n", "-l", process})
+		output, err := docker.ExecCommandIntoContainer(context.Background(), containerName, "root", []string{"pgrep", "-n", "-l", "-f", process})
 		if err != nil {
 			log.WithFields(log.Fields{
 				"desiredState":  desiredState,
@@ -437,7 +437,7 @@ func WaitForProcess(containerName string, process string, desiredState string, m
 				"mustBePresent": mustBePresent,
 				"process":       process,
 				"retry":         retryCount,
-			}).Warn("Could not execute 'pgrep -n -l' in the container")
+			}).Warn("Could not execute 'pgrep -n -l -f' in the container")
 
 			retryCount++
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: use full process name to match in pgrep (#475)