### PR TITLE
fix: honor ELASTIC_AGENT_VERSION when downloading the agent

### DIFF
--- a/e2e/_suites/fleet/ingest-manager_test.go
+++ b/e2e/_suites/fleet/ingest-manager_test.go
@@ -205,6 +205,15 @@ func (imts *IngestManagerTestSuite) processStateOnTheHost(process string, state 
 	return checkProcessStateOnTheHost(containerName, process, state)
 }
 
+// checkElasticAgentVersion returns a fallback version (agentVersionBase) if the version set by the environment is empty
+func checkElasticAgentVersion(version string) string {
+	if os.Getenv("ELASTIC_AGENT_VERSION") == "" {
+		return agentVersionBase
+	}
+
+	return version
+}
+
 // name of the container for the service:
 // we are using the Docker client instead of docker-compose
 // because it does not support returning the output of a

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -215,7 +215,7 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 		return handleDownload(downloadURL, fileName)
 	}
 
-	downloadURL, err = e2e.GetElasticArtifactURL(artifact, agentVersionBase, OS, arch, extension)
+	downloadURL, err = e2e.GetElasticArtifactURL(artifact, checkElasticAgentVersion(version), OS, arch, extension)
 	if err != nil {
 		return "", "", err
 	}
@@ -456,7 +456,7 @@ func newTarInstaller(image string, tag string) (ElasticAgentInstaller, error) {
 
 	preInstallFn := func() error {
 		commitFile := homeDir + commitFile
-		return installFromTar(profile, image, service, tarFile, commitFile, artifact, agentVersionBase, os, arch)
+		return installFromTar(profile, image, service, tarFile, commitFile, artifact, checkElasticAgentVersion(version), os, arch)
 	}
 	installFn := func(containerName string, token string) error {
 		// install the elastic-agent to /usr/bin/elastic-agent using command


### PR DESCRIPTION
## What does this PR do?
It checks if the environment variable used to override Agent's version is set. If it's not set, then it will use the base version, which is obtained from:

a. the Elastic Artifacts URL for aliases (7.x, 7.10.x),
b. fixed to the maintenance branch
c. 8.0.0-SNAPSHOT in the master branch

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
I found that running:

```shell
SUITE="fleet" \
    TAGS="fleet_mode && enroll" DEVELOPER_MODE=true \
    TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE \
    ELASTIC_AGENT_VERSION="7.10.1" \
    make -C e2e functional-test
```
was always downloading the version set to the maintenance branch, not honoring the version set in the environment variable.

Because we evaluated the version just once (init method for the test suite), then further calculations were tied to thee base version.


<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)



<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


## How to test this PR locally

Download a different agent version (7.10.1)
```shell
git checkout master
SUITE="fleet" \
    TAGS="fleet_mode && enroll" DEVELOPER_MODE=true \
    TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE \
    ELASTIC_AGENT_VERSION="7.10.1" \
    make -C e2e functional-test
```

Download the default agent version (8.0.0-SNAPSHOT)
```shell
git checkout master
SUITE="fleet" \
    TAGS="fleet_mode && enroll" DEVELOPER_MODE=true \
    TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE \
    make -C e2e functional-test
```


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #403, #306
- Discovered while testing #287

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->