### PR TITLE
fix: double max timeout when waiting for docs in stand-alone mode

### DIFF
--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -164,7 +164,7 @@ func (sats *StandAloneTestSuite) installTestTools(containerName string) error {
 }
 
 func (sats *StandAloneTestSuite) thereIsNewDataInTheIndexFromAgent() error {
-	maxTimeout := time.Duration(timeoutFactor) * time.Minute
+	maxTimeout := time.Duration(timeoutFactor) * time.Minute * 2
 	minimumHitsCount := 50
 
 	result, err := searchAgentData(sats.Hostname, sats.RuntimeDependenciesStartDate, minimumHitsCount, maxTimeout)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It doubles the maxtimeout when waiting for agent documents in stand-alone mode

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We are observing that the CI jobs started to fail with the error:

>Step there is new data in the index from agent: Not enough hits in the logs-elastic_agent-default index yet. Current: 45, Desired: 50

So:
a. we double down the maxtimeout, giving more time to the test to find 50 docs, or
b. we reduce the expected docs count from 50 to a lower number.

With b) the initial number was set after experimenting with data, so I'd prefer having this number defined by product team, choosing a) because of that.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #482


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs
<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

With the following logs we observe the following:
- it takes 6 seconds in reaching 29 docs in the index -> 6s diff +29 docs
- it takes 23 seconds (total) in reaching 30 docs in the index -> 17s diff +1 doc
- it takes 51 seconds (total) in reaching 33 docs in the index -> 29s diff +3 doc
- it takes 1m20 (total) in reaching 36 docs in the index -> 29s diff +3 doc
- it takes 1m56 (total) in reaching 40 docs in the index -> 36s diff +4 doc
- it takes 2m35 (total) in reaching 44 docs in the index -> 39s diff +4 doc
- it takes 2m51 (total) in reaching 45 docs in the index -> 16s diff +1 doc

>[2020-11-30T21:16:49.676Z] time="2020-11-30T21:16:49Z" level=debug msg="Response information" hits=0 status="200 OK" took=2
[2020-11-30T21:16:49.676Z] time="2020-11-30T21:16:49Z" level=warning msg="Waiting for more hits in the index" currentHits=0 desiredHits=50 elapsedTime=5.646312ms index=logs-elastic_agent-default retry=1
[2020-11-30T21:16:49.935Z] time="2020-11-30T21:16:49Z" level=debug msg="Response information" hits=0 status="200 OK" took=2
[2020-11-30T21:16:49.935Z] time="2020-11-30T21:16:49Z" level=warning msg="Waiting for more hits in the index" currentHits=0 desiredHits=50 elapsedTime=298.62023ms index=logs-elastic_agent-default retry=2
[2020-11-30T21:16:50.505Z] time="2020-11-30T21:16:50Z" level=debug msg="Response information" hits=0 status="200 OK" took=2
[2020-11-30T21:16:50.506Z] time="2020-11-30T21:16:50Z" level=warning msg="Waiting for more hits in the index" currentHits=0 desiredHits=50 elapsedTime=1.026833801s index=logs-elastic_agent-default retry=3
[2020-11-30T21:16:53.052Z] time="2020-11-30T21:16:52Z" level=debug msg="Response information" hits=0 status="200 OK" took=1
[2020-11-30T21:16:53.052Z] time="2020-11-30T21:16:52Z" level=warning msg="Waiting for more hits in the index" currentHits=0 desiredHits=50 elapsedTime=3.39393347s index=logs-elastic_agent-default retry=4
[2020-11-30T21:16:56.344Z] time="2020-11-30T21:16:55Z" level=debug msg="Response information" hits=29 status="200 OK" took=3
[2020-11-30T21:16:56.344Z] time="2020-11-30T21:16:55Z" level=warning msg="Waiting for more hits in the index" currentHits=29 desiredHits=50 elapsedTime=6.372255246s index=logs-elastic_agent-default retry=5
[2020-11-30T21:17:00.542Z] time="2020-11-30T21:16:59Z" level=debug msg="Response information" hits=29 status="200 OK" took=3
[2020-11-30T21:17:00.542Z] time="2020-11-30T21:16:59Z" level=warning msg="Waiting for more hits in the index" currentHits=29 desiredHits=50 elapsedTime=10.439020066s index=logs-elastic_agent-default retry=6
[2020-11-30T21:17:07.123Z] time="2020-11-30T21:17:07Z" level=debug msg="Response information" hits=29 status="200 OK" took=2
[2020-11-30T21:17:07.123Z] time="2020-11-30T21:17:07Z" level=warning msg="Waiting for more hits in the index" currentHits=29 desiredHits=50 elapsedTime=17.612474679s index=logs-elastic_agent-default retry=7
[2020-11-30T21:17:13.695Z] time="2020-11-30T21:17:13Z" level=debug msg="Response information" hits=30 status="200 OK" took=3
[2020-11-30T21:17:13.695Z] time="2020-11-30T21:17:13Z" level=warning msg="Waiting for more hits in the index" currentHits=30 desiredHits=50 elapsedTime=23.832702716s index=logs-elastic_agent-default retry=8
[2020-11-30T21:17:20.276Z] time="2020-11-30T21:17:19Z" level=debug msg="Response information" hits=31 status="200 OK" took=3
[2020-11-30T21:17:20.276Z] time="2020-11-30T21:17:19Z" level=warning msg="Waiting for more hits in the index" currentHits=31 desiredHits=50 elapsedTime=30.347542473s index=logs-elastic_agent-default retry=9
[2020-11-30T21:17:27.012Z] time="2020-11-30T21:17:25Z" level=debug msg="Response information" hits=32 status="200 OK" took=3
[2020-11-30T21:17:27.012Z] time="2020-11-30T21:17:25Z" level=warning msg="Waiting for more hits in the index" currentHits=32 desiredHits=50 elapsedTime=36.509546249s index=logs-elastic_agent-default retry=10
[2020-11-30T21:17:29.657Z] time="2020-11-30T21:17:29Z" level=debug msg="Response information" hits=32 status="200 OK" took=3
[2020-11-30T21:17:29.658Z] time="2020-11-30T21:17:29Z" level=warning msg="Waiting for more hits in the index" currentHits=32 desiredHits=50 elapsedTime=39.934188696s index=logs-elastic_agent-default retry=11
[2020-11-30T21:17:34.945Z] time="2020-11-30T21:17:34Z" level=debug msg="Response information" hits=32 status="200 OK" took=3
[2020-11-30T21:17:34.945Z] time="2020-11-30T21:17:34Z" level=warning msg="Waiting for more hits in the index" currentHits=32 desiredHits=50 elapsedTime=44.585651255s index=logs-elastic_agent-default retry=12
[2020-11-30T21:17:41.520Z] time="2020-11-30T21:17:41Z" level=debug msg="Response information" hits=33 status="200 OK" took=3
[2020-11-30T21:17:41.521Z] time="2020-11-30T21:17:41Z" level=warning msg="Waiting for more hits in the index" currentHits=33 desiredHits=50 elapsedTime=51.581637689s index=logs-elastic_agent-default retry=13
[2020-11-30T21:17:48.102Z] time="2020-11-30T21:17:46Z" level=debug msg="Response information" hits=34 status="200 OK" took=4
[2020-11-30T21:17:48.102Z] time="2020-11-30T21:17:46Z" level=warning msg="Waiting for more hits in the index" currentHits=34 desiredHits=50 elapsedTime=57.509215904s index=logs-elastic_agent-default retry=14
[2020-11-30T21:17:54.691Z] time="2020-11-30T21:17:54Z" level=debug msg="Response information" hits=34 status="200 OK" took=16
[2020-11-30T21:17:54.691Z] time="2020-11-30T21:17:54Z" level=warning msg="Waiting for more hits in the index" currentHits=34 desiredHits=50 elapsedTime=1m4.927759373s index=logs-elastic_agent-default retry=15
[2020-11-30T21:18:02.820Z] time="2020-11-30T21:18:01Z" level=debug msg="Response information" hits=34 status="200 OK" took=4
[2020-11-30T21:18:02.820Z] time="2020-11-30T21:18:01Z" level=warning msg="Waiting for more hits in the index" currentHits=34 desiredHits=50 elapsedTime=1m12.052107864s index=logs-elastic_agent-default retry=16
[2020-11-30T21:18:04.732Z] time="2020-11-30T21:18:04Z" level=debug msg="Response information" hits=35 status="200 OK" took=4
[2020-11-30T21:18:04.732Z] time="2020-11-30T21:18:04Z" level=warning msg="Waiting for more hits in the index" currentHits=35 desiredHits=50 elapsedTime=1m15.018690042s index=logs-elastic_agent-default retry=17
[2020-11-30T21:18:10.013Z] time="2020-11-30T21:18:09Z" level=debug msg="Response information" hits=36 status="200 OK" took=3
[2020-11-30T21:18:10.013Z] time="2020-11-30T21:18:09Z" level=warning msg="Waiting for more hits in the index" currentHits=36 desiredHits=50 elapsedTime=1m19.996292359s index=logs-elastic_agent-default retry=18
[2020-11-30T21:18:16.586Z] time="2020-11-30T21:18:16Z" level=debug msg="Response information" hits=36 status="200 OK" took=3
[2020-11-30T21:18:16.586Z] time="2020-11-30T21:18:16Z" level=warning msg="Waiting for more hits in the index" currentHits=36 desiredHits=50 elapsedTime=1m27.142785113s index=logs-elastic_agent-default retry=19
[2020-11-30T21:18:24.712Z] time="2020-11-30T21:18:23Z" level=debug msg="Response information" hits=37 status="200 OK" took=4
[2020-11-30T21:18:24.712Z] time="2020-11-30T21:18:23Z" level=warning msg="Waiting for more hits in the index" currentHits=37 desiredHits=50 elapsedTime=1m34.430483133s index=logs-elastic_agent-default retry=20
[2020-11-30T21:18:28.911Z] time="2020-11-30T21:18:28Z" level=debug msg="Response information" hits=38 status="200 OK" took=5
[2020-11-30T21:18:28.911Z] time="2020-11-30T21:18:28Z" level=warning msg="Waiting for more hits in the index" currentHits=38 desiredHits=50 elapsedTime=1m38.682449804s index=logs-elastic_agent-default retry=21
[2020-11-30T21:18:34.189Z] time="2020-11-30T21:18:34Z" level=debug msg="Response information" hits=38 status="200 OK" took=4
[2020-11-30T21:18:34.189Z] time="2020-11-30T21:18:34Z" level=warning msg="Waiting for more hits in the index" currentHits=38 desiredHits=50 elapsedTime=1m44.651646286s index=logs-elastic_agent-default retry=22
[2020-11-30T21:18:40.763Z] time="2020-11-30T21:18:40Z" level=debug msg="Response information" hits=38 status="200 OK" took=5
[2020-11-30T21:18:40.763Z] time="2020-11-30T21:18:40Z" level=warning msg="Waiting for more hits in the index" currentHits=38 desiredHits=50 elapsedTime=1m50.71797876s index=logs-elastic_agent-default retry=23
[2020-11-30T21:18:46.038Z] time="2020-11-30T21:18:45Z" level=debug msg="Response information" hits=40 status="200 OK" took=5
[2020-11-30T21:18:46.038Z] time="2020-11-30T21:18:45Z" level=warning msg="Waiting for more hits in the index" currentHits=40 desiredHits=50 elapsedTime=1m56.051371836s index=logs-elastic_agent-default retry=24
[2020-11-30T21:18:51.312Z] time="2020-11-30T21:18:51Z" level=debug msg="Response information" hits=40 status="200 OK" took=4
[2020-11-30T21:18:51.312Z] time="2020-11-30T21:18:51Z" level=warning msg="Waiting for more hits in the index" currentHits=40 desiredHits=50 elapsedTime=2m1.810675502s index=logs-elastic_agent-default retry=25
[2020-11-30T21:18:56.588Z] time="2020-11-30T21:18:56Z" level=debug msg="Response information" hits=40 status="200 OK" took=5
[2020-11-30T21:18:56.588Z] time="2020-11-30T21:18:56Z" level=warning msg="Waiting for more hits in the index" currentHits=40 desiredHits=50 elapsedTime=2m7.087079781s index=logs-elastic_agent-default retry=26
[2020-11-30T21:19:03.160Z] time="2020-11-30T21:19:02Z" level=debug msg="Response information" hits=41 status="200 OK" took=5
[2020-11-30T21:19:03.160Z] time="2020-11-30T21:19:02Z" level=warning msg="Waiting for more hits in the index" currentHits=41 desiredHits=50 elapsedTime=2m13.380783117s index=logs-elastic_agent-default retry=27
[2020-11-30T21:19:07.358Z] time="2020-11-30T21:19:07Z" level=debug msg="Response information" hits=42 status="200 OK" took=5
[2020-11-30T21:19:07.358Z] time="2020-11-30T21:19:07Z" level=warning msg="Waiting for more hits in the index" currentHits=42 desiredHits=50 elapsedTime=2m17.913773893s index=logs-elastic_agent-default retry=28
[2020-11-30T21:19:10.648Z] time="2020-11-30T21:19:10Z" level=debug msg="Response information" hits=42 status="200 OK" took=5
[2020-11-30T21:19:10.648Z] time="2020-11-30T21:19:10Z" level=warning msg="Waiting for more hits in the index" currentHits=42 desiredHits=50 elapsedTime=2m21.081674862s index=logs-elastic_agent-default retry=29
[2020-11-30T21:19:18.772Z] time="2020-11-30T21:19:17Z" level=debug msg="Response information" hits=42 status="200 OK" took=6
[2020-11-30T21:19:18.772Z] time="2020-11-30T21:19:17Z" level=warning msg="Waiting for more hits in the index" currentHits=42 desiredHits=50 elapsedTime=2m28.532391368s index=logs-elastic_agent-default retry=30
[2020-11-30T21:19:25.342Z] time="2020-11-30T21:19:24Z" level=debug msg="Response information" hits=44 status="200 OK" took=6
[2020-11-30T21:19:25.342Z] time="2020-11-30T21:19:24Z" level=warning msg="Waiting for more hits in the index" currentHits=44 desiredHits=50 elapsedTime=2m35.52933024s index=logs-elastic_agent-default retry=31
[2020-11-30T21:19:29.537Z] time="2020-11-30T21:19:29Z" level=debug msg="Response information" hits=44 status="200 OK" took=5
[2020-11-30T21:19:29.537Z] time="2020-11-30T21:19:29Z" level=warning msg="Waiting for more hits in the index" currentHits=44 desiredHits=50 elapsedTime=2m39.653755699s index=logs-elastic_agent-default retry=32
[2020-11-30T21:19:36.109Z] time="2020-11-30T21:19:35Z" level=debug msg="Response information" hits=44 status="200 OK" took=7
[2020-11-30T21:19:36.109Z] time="2020-11-30T21:19:35Z" level=warning msg="Waiting for more hits in the index" currentHits=44 desiredHits=50 elapsedTime=2m45.787074642s index=logs-elastic_agent-default retry=33
[2020-11-30T21:19:41.380Z] time="2020-11-30T21:19:40Z" level=debug msg="Response information" hits=45 status="200 OK" took=5
[2020-11-30T21:19:41.380Z] time="2020-11-30T21:19:40Z" level=warning msg="Waiting for more hits in the index" currentHits=45 desiredHits=50 elapsedTime=2m51.523343702s index=logs-elastic_agent-default retry=34
[2020-11-30T21:19:43.915Z] time="2020-11-30T21:19:43Z" level=debug msg="Response information" hits=45 status="200 OK" took=6
[2020-11-30T21:19:43.915Z] time="2020-11-30T21:19:43Z" level=warning msg="Waiting for more hits in the index" currentHits=45 desiredHits=50 elapsedTime=2m54.465106811s index=logs-elastic_agent-default retry=35

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->