### PR TITLE
fix: double max timeout when waitin for docs in standalone mode (#483) backport for 7.9.x

### DIFF
--- a/e2e/_suites/ingest-manager/stand-alone.go
+++ b/e2e/_suites/ingest-manager/stand-alone.go
@@ -120,7 +120,7 @@ func (sats *StandAloneTestSuite) getContainerLogs() error {
 }
 
 func (sats *StandAloneTestSuite) thereIsNewDataInTheIndexFromAgent() error {
-	maxTimeout := time.Duration(timeoutFactor) * time.Minute
+	maxTimeout := time.Duration(timeoutFactor) * time.Minute * 2
 	minimumHitsCount := 50
 
 	result, err := searchAgentData(sats.Hostname, sats.RuntimeDependenciesStartDate, minimumHitsCount, maxTimeout)


### PR DESCRIPTION
Backports the following commits to 7.9.x:
 - fix: double max timeout when waitin for docs in standalone mode (#483)