### PR TITLE
fix: update log path for TAR installer (#481) backport for 7.10.x

### DIFF
--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -498,7 +498,7 @@ func newTarInstaller(image string, tag string) (ElasticAgentInstaller, error) {
 		InstallFn:         installFn,
 		installerType:     "tar",
 		logFile:           "elastic-agent.log",
-		logsDir:           "/opt/Elastic/Agent/data/elastic-agent-%s/logs/",
+		logsDir:           "/opt/Elastic/Agent/data/elastic-agent-%s/",
 		name:              tarFile,
 		path:              binaryPath,
 		PostInstallFn:     postInstallFn,


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - fix: update log path for TAR installer (#481)