### PR TITLE
fix: exclude images from non-breaking-spaces lint (#497) backport for 7.10.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,15 @@ repos:
     -   id: check-bash-syntax
     -   id: check-jenkins-pipelines
     -   id: check-unicode-non-breaking-spaces
+        exclude: >
+            (?x)^(
+                .*/?\.*.(gif|jpg|png)
+            )$
     -   id: remove-unicode-non-breaking-spaces
+        exclude: >
+            (?x)^(
+                .*/?\.*.(gif|jpg|png)
+            )$
     -   id: check-en-dashes
     -   id: remove-en-dashes
     -   id: check-jjbb


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - fix: exclude images from non-breaking-spaces lint (#497)