### PR TITLE
fix: enhance GCP queries for PRs

### DIFF
--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -212,7 +212,7 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 			object = fmt.Sprintf("pull-requests/%s/%s/%s", version, artifact, fileName)
 		}
 
-		maxTimeout := time.Minute
+		maxTimeout := time.Duration(timeoutFactor) * time.Minute
 
 		downloadURL, err = e2e.GetObjectURLFromBucket(bucket, object, maxTimeout)
 		if err != nil {

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -198,8 +198,12 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 		// we are setting a version from a pull request: the version of the artifact will be kept as the base one
 		// i.e. /pull-requests/pr-21100/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm
 		// i.e. /pull-requests/pr-21100/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-amd64.deb
+		// i.e. /pull-requests/pr-21100/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz
 		if strings.HasPrefix(strings.ToLower(version), "pr-") {
 			fileName = fmt.Sprintf("%s-%s-%s.%s", artifact, agentVersionBase, arch, extension)
+			if extension == "tar.gz" {
+				fileName = fmt.Sprintf("%s-%s-%s-%s.%s", artifact, agentVersionBase, OS, arch, extension)
+			}
 			log.WithFields(log.Fields{
 				"agentVersion": agentVersionBase,
 				"PR":           version,

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/cli/shell"
@@ -211,7 +212,9 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 			object = fmt.Sprintf("pull-requests/%s/%s/%s", version, artifact, fileName)
 		}
 
-		downloadURL, err = e2e.GetObjectURLFromBucket(bucket, object)
+		maxTimeout := time.Minute
+
+		downloadURL, err = e2e.GetObjectURLFromBucket(bucket, object, maxTimeout)
 		if err != nil {
 			return "", "", err
 		}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -216,7 +216,7 @@ func GetObjectURLFromBucket(bucket string, object string) (string, error) {
 
 	storageAPI := func() error {
 		r := curl.HTTPRequest{
-			URL: fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o%s", bucket, pageTokenQueryParam),
+			URL: fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o?prefix=pull-requests%s", bucket, pageTokenQueryParam),
 		}
 
 		response, err := curl.Get(r)
@@ -279,7 +279,7 @@ func GetObjectURLFromBucket(bucket string, object string) (string, error) {
 		}
 
 		nextPageToken := jsonParsed.Path("nextPageToken").Data().(string)
-		pageTokenQueryParam = "?pageToken=" + nextPageToken
+		pageTokenQueryParam = "&pageToken=" + nextPageToken
 		currentPage++
 
 		log.WithFields(log.Fields{

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -205,8 +205,8 @@ func GetElasticArtifactURL(artifact string, version string, operativeSystem stri
 
 // GetObjectURLFromBucket extracts the media URL for the desired artifact from the
 // Google Cloud Storage bucket used by the CI to push snapshots
-func GetObjectURLFromBucket(bucket string, object string) (string, error) {
-	exp := GetExponentialBackOff(time.Minute)
+func GetObjectURLFromBucket(bucket string, object string, maxtimeout time.Duration) (string, error) {
+	exp := GetExponentialBackOff(maxtimeout)
 
 	retryCount := 1
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It enriches the logs when querying the GCP storage bucket, also reducing the amount of entries to look up adding a filter in the form of a `prefix=PREFIX` query string parameter to limit results to objects that have the specific prefix (See https://cloud.google.com/storage/docs/listing-objects#rest-list-objects).

As a consequence, we noticed that the filename used for the TAR.GZ files for snapshots was incorrect, as it needs the OS after version and before architecture.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Beats packaging jobs were using wrong artifacts, because of several reasons:

1. Beats packaging job was setting the wrong parameter when triggering this job. It caused that the snapshot in the GCP bucket was never used, using the released artifacts from artifactory.
1. Once fixed, the file name for TAR.GZ artifacts was not built properly.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] We follow GCP docs for listing objects: https://cloud.google.com/storage/docs/listing-objects#rest-list-objects
- [x] File names for TAR.GZ and DEB/RPM differ, as the latters do not add the O.S.

## How to test this PR locally

```shell
SUITE="fleet" \
    TAGS="fleet_mode && enroll" DEVELOPER_MODE=true \
    TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE \
    ELASTIC_AGENT_VERSION="pr-22790" ELASTIC_AGENT_USE_CI_SNAPSHOTS=true \
    make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #503
- Relates elastic/beats#22836

## Use cases

- Beats PRs triggering the packaging job will trigger the E2E tests. They need to run the tests using the snapshots produced by the CI
- Local execution of the tests reproducing CI steps, which is useful for manual testing already pushed artifacts/snapshots.

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->