### PR TITLE
chore: reduce GCP storage queries filtering by "pull-requests/" prefix (1d2cadba) | chore: enrich logs when querying GCP storage entries (89df4c8c) | chore: fix GCP filename for TAR files (7d4e7f9c) | chore: pass max timeout to the bucket U

### DIFF
--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -198,8 +198,12 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 		// we are setting a version from a pull request: the version of the artifact will be kept as the base one
 		// i.e. /pull-requests/pr-21100/elastic-agent/elastic-agent-7.10-SNAPSHOT-x86_64.rpm
 		// i.e. /pull-requests/pr-21100/elastic-agent/elastic-agent-7.10-SNAPSHOT-amd64.deb
-		if strings.HasPrefix(version, "pr-") {
+		// i.e. /pull-requests/pr-21100/elastic-agent/elastic-agent-7.10-SNAPSHOT-linux-x86_64.tar.gz
+		if strings.HasPrefix(strings.ToLower(version), "pr-") {
 			fileName = fmt.Sprintf("%s-%s-%s.%s", artifact, agentVersionBase, arch, extension)
+			if extension == "tar.gz" {
+				fileName = fmt.Sprintf("%s-%s-%s-%s.%s", artifact, agentVersionBase, OS, arch, extension)
+			}
 			log.WithFields(log.Fields{
 				"agentVersion": agentVersionBase,
 				"PR":           version,

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -212,7 +212,7 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 			object = fmt.Sprintf("pull-requests/%s/%s/%s", version, artifact, fileName)
 		}
 
-		maxTimeout := time.Minute
+		maxTimeout := time.Duration(timeoutFactor) * time.Minute
 
 		downloadURL, err = e2e.GetObjectURLFromBucket(bucket, object, maxTimeout)
 		if err != nil {

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/cli/shell"
@@ -211,7 +212,9 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 			object = fmt.Sprintf("pull-requests/%s/%s/%s", version, artifact, fileName)
 		}
 
-		downloadURL, err = e2e.GetObjectURLFromBucket(bucket, object)
+		maxTimeout := time.Minute
+
+		downloadURL, err = e2e.GetObjectURLFromBucket(bucket, object, maxTimeout)
 		if err != nil {
 			return "", "", err
 		}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -216,7 +216,7 @@ func GetObjectURLFromBucket(bucket string, object string) (string, error) {
 
 	storageAPI := func() error {
 		r := curl.HTTPRequest{
-			URL: fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o%s", bucket, pageTokenQueryParam),
+			URL: fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o?prefix=pull-requests%s", bucket, pageTokenQueryParam),
 		}
 
 		response, err := curl.Get(r)
@@ -279,7 +279,7 @@ func GetObjectURLFromBucket(bucket string, object string) (string, error) {
 		}
 
 		nextPageToken := jsonParsed.Path("nextPageToken").Data().(string)
-		pageTokenQueryParam = "?pageToken=" + nextPageToken
+		pageTokenQueryParam = "&pageToken=" + nextPageToken
 		currentPage++
 
 		log.WithFields(log.Fields{

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -205,8 +205,8 @@ func GetElasticArtifactURL(artifact string, version string, operativeSystem stri
 
 // GetObjectURLFromBucket extracts the media URL for the desired artifact from the
 // Google Cloud Storage bucket used by the CI to push snapshots
-func GetObjectURLFromBucket(bucket string, object string) (string, error) {
-	exp := GetExponentialBackOff(time.Minute)
+func GetObjectURLFromBucket(bucket string, object string, maxtimeout time.Duration) (string, error) {
+	exp := GetExponentialBackOff(maxtimeout)
 
 	retryCount := 1
 


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - chore: reduce GCP storage queries filtering by "pull-requests/" prefix (1d2cadba)
 - chore: enrich logs when querying GCP storage entries (89df4c8c)
 - chore: fix GCP filename for TAR files (7d4e7f9c)
 - chore: pass max timeout to the bucket URL method (4a0c126d)
 - chore: use timeout factor in the bucket URL method (2009b4a0)