### PR TITLE
chore: simplify junit report name (#518) backport for 7.10.x

### DIFF
--- a/.ci/scripts/functional-test.sh
+++ b/.ci/scripts/functional-test.sh
@@ -26,11 +26,7 @@ TARGET_ARCH=${GOARCH:-amd64}
 rm -rf outputs || true
 mkdir -p outputs
 
-## Parse TAGS if not empty then enable the flags to be passed to the functional-test wrapper
-REPORT=outputs/TEST-${SUITE}
-if [ "${TAGS}" != "" ] ; then
-  REPORT=outputs/TEST-${SUITE}-${TAGS}
-fi
+REPORT="outputs/TEST-${SUITE}"
 
 ## Generate test report even if make failed.
 set +e


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - chore: simplify junit report name (#518)