### PR TITLE
fix: honor ELASTIC_AGENT_VERSION when downloading the agent (#480) | fix: return base version for PRs (#502) backport for 7.10.x

### DIFF
--- a/e2e/_suites/fleet/ingest-manager_test.go
+++ b/e2e/_suites/fleet/ingest-manager_test.go
@@ -205,6 +205,15 @@ func (imts *IngestManagerTestSuite) processStateOnTheHost(process string, state 
 	return checkProcessStateOnTheHost(containerName, process, state)
 }
 
+// checkElasticAgentVersion returns a fallback version (agentVersionBase) if the version set by the environment is empty
+func checkElasticAgentVersion(version string) string {
+	if os.Getenv("ELASTIC_AGENT_VERSION") == "" {
+		return agentVersionBase
+	}
+
+	return version
+}
+
 // name of the container for the service:
 // we are using the Docker client instead of docker-compose
 // because it does not support returning the output of a

--- a/e2e/_suites/fleet/ingest-manager_test.go
+++ b/e2e/_suites/fleet/ingest-manager_test.go
@@ -70,14 +70,19 @@ func init() {
 		log.Info("Running in Developer mode 💻: runtime dependencies between different test runs will be reused to speed up dev cycle")
 	}
 
+	// check if base version is an alias
+	agentVersionBase = e2e.GetElasticArtifactVersion(agentVersionBase)
+
 	timeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", timeoutFactor)
 	agentVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", agentVersionBase)
+
+	// check if version is an alias
+	agentVersion = e2e.GetElasticArtifactVersion(agentVersion)
+
 	stackVersion = shell.GetEnv("STACK_VERSION", stackVersion)
 }
 
 func IngestManagerFeatureContext(s *godog.Suite) {
-	agentVersionBase = e2e.GetElasticArtifactVersion(agentVersionBase)
-
 	imts := IngestManagerTestSuite{
 		Fleet: &FleetTestSuite{
 			Installers: map[string]ElasticAgentInstaller{

--- a/e2e/_suites/fleet/ingest-manager_test.go
+++ b/e2e/_suites/fleet/ingest-manager_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/cucumber/godog"
@@ -207,7 +208,13 @@ func (imts *IngestManagerTestSuite) processStateOnTheHost(process string, state 
 
 // checkElasticAgentVersion returns a fallback version (agentVersionBase) if the version set by the environment is empty
 func checkElasticAgentVersion(version string) string {
-	if os.Getenv("ELASTIC_AGENT_VERSION") == "" {
+	environmentVersion := os.Getenv("ELASTIC_AGENT_VERSION")
+
+	if environmentVersion == "" {
+		return agentVersionBase
+	}
+
+	if strings.HasPrefix(strings.ToLower(environmentVersion), "pr-") {
 		return agentVersionBase
 	}
 

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -222,7 +222,7 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 		return handleDownload(downloadURL, fileName)
 	}
 
-	downloadURL, err = e2e.GetElasticArtifactURL(artifact, agentVersionBase, OS, arch, extension)
+	downloadURL, err = e2e.GetElasticArtifactURL(artifact, checkElasticAgentVersion(version), OS, arch, extension)
 	if err != nil {
 		return "", "", err
 	}
@@ -463,7 +463,7 @@ func newTarInstaller(image string, tag string) (ElasticAgentInstaller, error) {
 
 	preInstallFn := func() error {
 		commitFile := homeDir + commitFile
-		return installFromTar(profile, image, service, tarFile, commitFile, artifact, agentVersionBase, os, arch)
+		return installFromTar(profile, image, service, tarFile, commitFile, artifact, checkElasticAgentVersion(version), os, arch)
 	}
 	installFn := func(containerName string, token string) error {
 		// install the elastic-agent to /usr/bin/elastic-agent using command


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - fix: honor ELASTIC_AGENT_VERSION when downloading the agent (#480)
 - fix: return base version for PRs (#502)
- fix: check if agent versions are aliases (#529)

Supersedes #489 