### PR TITLE
fix: check if agent versions are aliases

### DIFF
--- a/e2e/_suites/fleet/ingest-manager_test.go
+++ b/e2e/_suites/fleet/ingest-manager_test.go
@@ -70,14 +70,19 @@ func init() {
 		log.Info("Running in Developer mode 💻: runtime dependencies between different test runs will be reused to speed up dev cycle")
 	}
 
+	// check if base version is an alias
+	agentVersionBase = e2e.GetElasticArtifactVersion(agentVersionBase)
+
 	timeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", timeoutFactor)
 	agentVersion = shell.GetEnv("ELASTIC_AGENT_VERSION", agentVersionBase)
+
+	// check if version is an alias
+	agentVersion = e2e.GetElasticArtifactVersion(agentVersion)
+
 	stackVersion = shell.GetEnv("STACK_VERSION", stackVersion)
 }
 
 func IngestManagerFeatureContext(s *godog.Suite) {
-	agentVersionBase = e2e.GetElasticArtifactVersion(agentVersionBase)
-
 	imts := IngestManagerTestSuite{
 		Fleet: &FleetTestSuite{
 			Installers: map[string]ElasticAgentInstaller{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a check for agent versions, determining if they are an alias, obtaining the proper artifact name from Elastic's artifactory.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We noticed that if setting the ELASTIC_AGENT_VERSION to an alias (i.e. 7.10-SNAPSHOT) and running the tests, they panic because it uses the alias to query the versions endpoint. With this change we will be normalising the version, which we already did it for the base version (we use base version for PRs targeting a version, i.e. to download binaries in the version: a PR to master will produce binaries with 8.0.0-SNAPSHOT on its name)

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

```shell
git checkout master
SUITE="fleet" ELASTIC_AGENT_VERSION="7.10-SNAPSHOT" \
    TAGS="fleet_mode_agent && install" DEVELOPER_MODE=true \
    TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE \
    make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #480, #502
- Needs to be cherry-picked to #526 and #527 (backports to 7.x and 7.10.x)


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
We need to backport this changes to 7.x and 7.10.x. There are two open PRs (failing until this change is included), so cherry picking this commit to those PRs will be easier
<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->