### PR TITLE
fix: double quote tags if they are set

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -17,6 +17,9 @@ ifeq ($(SKIP_SCENARIOS),true)
 ## We always want to skip scenarios tagged with @skip
 TAGS+= && ~skip
 endif
+
+# Double quote only if the tags are set
+TAGS_VALUE="$(TAGS)"
 endif
 
 GO_IMAGE_TAG?='stretch'
@@ -54,7 +57,7 @@ functional-test: install-godog
 	TIMEOUT_FACTOR=${TIMEOUT_FACTOR} \
 	STACK_VERSION=${STACK_VERSION} \
 	DEVELOPER_MODE=${DEVELOPER_MODE} \
-	godog --format=${FORMAT} ${TAGS_FLAG} "${TAGS}"
+	godog --format=${FORMAT} ${TAGS_FLAG} ${TAGS_VALUE}
 
 .PHONY: lint
 lint:

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -20,6 +20,11 @@ endif
 
 # Double quote only if the tags are set
 TAGS_VALUE="$(TAGS)"
+else
+ifeq ($(SKIP_SCENARIOS),true)
+TAGS_FLAG=--tags
+TAGS_VALUE="~skip"
+endif
 endif
 
 GO_IMAGE_TAG?='stretch'


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It double-quotes the tags in Makefile only when they are set

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
There was a corner case when using Make to run all scenarios (not filtering by tag)

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

Before this change, this command failed because godog was trying to evaluate "" as a feature path. Now it runs all scenarios (no TAGS set) but those skipped.

```shell
 SUITE="fleet" DEVELOPER_MODE=false TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE make -C e2e functional-test
```

This command runs all scenarios (no TAGS set), including skipped.
```shell
 SUITE="fleet" SKIP_SCENARIOS=false DEVELOPER_MODE=false TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE make -C e2e functional-test
```

This command runs some scenarios (TAGS is set), excluding skipped.
```shell
 SUITE="fleet" TAGS="fleet_mode_agent" DEVELOPER_MODE=false TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE make -C e2e functional-test
```

This command runs some scenarios (TAGS is set), including skipped.
```shell
 SUITE="fleet" TAGS="fleet_mode_agent" SKIP_SCENARIOS=false DEVELOPER_MODE=false TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #408 


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->