### PR TITLE
disable upgrade tests

### DIFF
--- a/e2e/_suites/fleet/features/fleet_mode_agent.feature
+++ b/e2e/_suites/fleet/features/fleet_mode_agent.feature
@@ -40,6 +40,17 @@ Examples:
 | centos |
 | debian |
 
+# @upgrade-agent
+@skip
+Scenario Outline: Upgrading the installed <os> agent
+  Given a "<os>" agent "stale" is deployed to Fleet with "tar" installer
+    And certs for "<os>" are installed
+  When agent is upgraded to version "latest"
+  Then agent is in version "latest"
+Examples:
+| os     | 
+| debian | 
+
 @restart-agent
 Scenario Outline: Restarting the installed <os> agent
   Given a "<os>" agent is deployed to Fleet with "tar" installer

--- a/e2e/_suites/fleet/features/fleet_mode_agent.feature
+++ b/e2e/_suites/fleet/features/fleet_mode_agent.feature
@@ -40,16 +40,6 @@ Examples:
 | centos |
 | debian |
 
-@upgrade-agent
-Scenario Outline: Upgrading the installed <os> agent
-  Given a "<os>" agent "stale" is deployed to Fleet with "tar" installer
-    And certs for "<os>" are installed
-  When agent is upgraded to version "latest"
-  Then agent is in version "latest"
-Examples:
-| os     | 
-| debian | 
-
 @restart-agent
 Scenario Outline: Restarting the installed <os> agent
   Given a "<os>" agent is deployed to Fleet with "tar" installer


### PR DESCRIPTION
## What does this PR do?

Disables upgrade tests 

## Why is it important?

Upgrade test fails on PR on 
```
[2020-12-10T17:53:01.565Z] time="2020-12-10T17:53:00Z" level=error msg="Could not download the binary for the agent" arch=x86_64 artifact=elastic-agent error="Reached the end of the pages and the snapshots/elastic-agent-7.10.0-x86_64.tar.gz object was not found for the beats-ci-artifacts bucket" extension=tar.gz os=linux version=7.10.0

[2020-12-10T17:53:01.565Z] time="2020-12-10T17:53:00Z" level=fatal msg="Sorry, we could not download the installer" error="Reached the end of the pages and the snapshots/elastic-agent-7.10.0-x86_64.tar.gz object was not found for the beats-ci-artifacts bucket" image=debian installer=tar

```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)
