### PR TITLE
update-to-available-version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
     string(name: 'SLACK_CHANNEL', defaultValue: 'observablt-bots', description: 'The Slack channel(s) where errors will be posted. For multiple channels, use a comma-separated list of channels')
     string(name: 'ELASTIC_AGENT_DOWNLOAD_URL', defaultValue: '', description: 'If present, it will override the download URL for the Elastic agent artifact. (I.e. https://snapshots.elastic.co/8.0.0-59098054/downloads/beats/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz')
     string(name: 'ELASTIC_AGENT_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'SemVer version of the stand-alone elastic-agent to be used for Fleet tests. You can use here the tag of your PR to test your changes')
-    string(name: 'ELASTIC_AGENT_STALE_VERSION', defaultValue: '7.10.0', description: 'SemVer version of the stale stand-alone elastic-agent to be used for Fleet upgrade tests.')
+    string(name: 'ELASTIC_AGENT_STALE_VERSION', defaultValue: '7.10.1', description: 'SemVer version of the stale stand-alone elastic-agent to be used for Fleet upgrade tests.')
     booleanParam(name: "ELASTIC_AGENT_USE_CI_SNAPSHOTS", defaultValue: false, description: "If it's needed to use the binary snapshots produced by Beats CI instead of the official releases")
     choice(name: 'LOG_LEVEL', choices: ['DEBUG', 'INFO'], description: 'Log level to be used')
     choice(name: 'TIMEOUT_FACTOR', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')


### PR DESCRIPTION
<!-- Type of change
This is a maintenance PR - just a small one as the 7.10.0 artifact isn't in the search response used
-->

## What does this PR do?
updates minor version in string, so it can be found and that agent artifact used in test
## Why is it important?

## Screenshots

<img width="1299" alt="Screen Shot 2020-12-15 at 2 52 20 PM" src="https://user-images.githubusercontent.com/12970373/102265480-2a1e6500-3ee5-11eb-8e3d-3c269fe4b3c0.png">

need to check if the upgrade test was ever back-ported out of master, it may not have been.  also, it is disabled as of now - hence why the tests are not failing on master due to this.  a future PR could enhance the api call used to not require regular maintenance like this... but we likely won't have many 7.10 hot-fix patch releases so it matters only a little for now