### PR TITLE
unskip deb and rpm test (#542) backport for 7.x

### DIFF
--- a/e2e/_suites/fleet/features/fleet_mode_agent.feature
+++ b/e2e/_suites/fleet/features/fleet_mode_agent.feature
@@ -15,8 +15,7 @@ Examples:
 | centos |
 | debian |
 
-# reset the following tag when unskipping: enroll
-@skip
+@enroll
 Scenario Outline: Deploying the <os> agent with enroll and then run on rpm and deb
   Given a "<os>" agent is deployed to Fleet with "systemd" installer
   When the "elastic-agent" process is in the "started" state on the host


### PR DESCRIPTION
Backports the following commits to 7.x:
 - unskip deb and rpm test (#542)