### PR TITLE
fix: make docker namespace configurable

### DIFF
--- a/cli/config/compose/services/elastic-agent/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   elastic-agent:
-    image: docker.elastic.co/observability-ci/elastic-agent${elasticAgentDockerImageSuffix}:${elasticAgentTag:-8.0.0-SNAPSHOT}
+    image: docker.elastic.co/${elasticAgentDockerNamespace:-beats}/elastic-agent${elasticAgentDockerImageSuffix}:${elasticAgentTag:-8.0.0-SNAPSHOT}
     container_name: ${elasticAgentContainerName}
     depends_on:
       elasticsearch:

--- a/cli/config/compose/services/metricbeat/docker-compose.yml
+++ b/cli/config/compose/services/metricbeat/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ]
     environment:
       - BEAT_STRICT_PERMS=${beatStricPerms:-false}
-    image: "docker.elastic.co/observability-ci/metricbeat:${metricbeatTag:-8.0.0-SNAPSHOT}"
+    image: "docker.elastic.co/${metricbeatDockerNamespace:-beats}/metricbeat:${metricbeatTag:-8.0.0-SNAPSHOT}"
     labels:
       co.elastic.logs/module: "${serviceName}"
     volumes:

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/cli/services"
+	"github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
 	log "github.com/sirupsen/logrus"
 )
@@ -67,6 +68,12 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed(image string) error 
 	profileEnv["elasticAgentDockerImageSuffix"] = ""
 	if image != "default" {
 		profileEnv["elasticAgentDockerImageSuffix"] = "-" + image
+	}
+
+	profileEnv["elasticAgentDockerNamespace"] = "beats"
+	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
+	if useCISnapshots {
+		profileEnv["elasticAgentDockerNamespace"] = "observability-ci"
 	}
 
 	containerName := fmt.Sprintf("%s_%s_%d", FleetProfileName, ElasticAgentServiceName, 1)

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -304,10 +304,10 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 		"serviceName":           mts.ServiceName,
 	}
 
-	profileEnv["metricbeatDockerNamespace"] = "beats"
+	env["metricbeatDockerNamespace"] = "beats"
 	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
 	if useCISnapshots {
-		profileEnv["metricbeatDockerNamespace"] = "observability-ci"
+		env["metricbeatDockerNamespace"] = "observability-ci"
 	}
 
 	err := serviceManager.AddServicesToCompose("metricbeat", []string{"metricbeat"}, env)

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -304,6 +304,12 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 		"serviceName":           mts.ServiceName,
 	}
 
+	profileEnv["metricbeatDockerNamespace"] = "beats"
+	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
+	if useCISnapshots {
+		profileEnv["metricbeatDockerNamespace"] = "observability-ci"
+	}
+
 	err := serviceManager.AddServicesToCompose("metricbeat", []string{"metricbeat"}, env)
 	if err != nil {
 		log.WithFields(log.Fields{


### PR DESCRIPTION
If the developer targets a CI snapshot, then it will use observavbility-ci,
otherwise beats will be the default


<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It makes the namespace of the docker image for the elastic-agent configurable, being it possible to set `beats` and `observability-ci`. The second one will be used for CI snapshots, setting the `ELASTIC_AGENT_USE_CI_SNAPSHOTS` env var.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
For Beats PRs targetting a maintenance branch (7.x, 7.10.x) the namespace in the E2E is `beats`, always, which is wrong, as the snapshots are published under the `observvability-ci` namespace. With this changes, the image will be located properly. 

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)



<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


## How to test this PR locally

```shell
git checkout 7.x
SUITE="fleet" ELASTIC_AGENT_VERSION="pr-23142" \
    ELASTIC_AGENT_USE_CI_SNAPSHOTS=true TAGS="stand_alone_agent" DEVELOPER_MODE=true \ 
    TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE \
    make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Discovered while testing elastic/beats#23142


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

>[2021-01-05T17:03:03.052Z] Pulling elastic-agent (docker.elastic.co/beats/elastic-agent:pr-23142)...
[2021-01-05T17:03:03.052Z] manifest for docker.elastic.co/beats/elastic-agent:pr-23142 not found: manifest unknown: manifest unknown
[2021-01-05T17:03:03.052Z] time="2021-01-05T17:03:02Z" level=error msg="Could not deploy the elastic-agent"

>[2021-01-05T17:01:59.923Z] Pulling metricbeat (docker.elastic.co/beats/metricbeat:pr-23142)...
[2021-01-05T17:01:59.923Z] manifest for docker.elastic.co/beats/metricbeat:pr-23142 not found: manifest unknown: manifest unknown

## Follow-ups
Backport to 7.x and 7.10.x

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->