### PR TITLE
fix: make docker namespace configurable (#560) backport for 7.x

### DIFF
--- a/cli/config/compose/services/elastic-agent/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   elastic-agent:
-    image: docker.elastic.co/beats/elastic-agent${elasticAgentDockerImageSuffix}:${elasticAgentTag:-7.x-SNAPSHOT}
+    image: docker.elastic.co/${elasticAgentDockerNamespace:-beats}/elastic-agent${elasticAgentDockerImageSuffix}:${elasticAgentTag:-7.x-SNAPSHOT}
     container_name: ${elasticAgentContainerName}
     depends_on:
       elasticsearch:

--- a/cli/config/compose/services/metricbeat/docker-compose.yml
+++ b/cli/config/compose/services/metricbeat/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ]
     environment:
       - BEAT_STRICT_PERMS=${beatStricPerms:-false}
-    image: "docker.elastic.co/beats/metricbeat:${metricbeatTag:-7.x-SNAPSHOT}"
+    image: "docker.elastic.co/${metricbeatDockerNamespace:-beats}/metricbeat:${metricbeatTag:-7.x-SNAPSHOT}"
     labels:
       co.elastic.logs/module: "${serviceName}"
     volumes:

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/cli/services"
+	"github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
 	log "github.com/sirupsen/logrus"
 )
@@ -67,6 +68,12 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed(image string) error 
 	profileEnv["elasticAgentDockerImageSuffix"] = ""
 	if image != "default" {
 		profileEnv["elasticAgentDockerImageSuffix"] = "-" + image
+	}
+
+	profileEnv["elasticAgentDockerNamespace"] = "beats"
+	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
+	if useCISnapshots {
+		profileEnv["elasticAgentDockerNamespace"] = "observability-ci"
 	}
 
 	containerName := fmt.Sprintf("%s_%s_%d", FleetProfileName, ElasticAgentServiceName, 1)

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -304,6 +304,12 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 		"serviceName":           mts.ServiceName,
 	}
 
+	env["metricbeatDockerNamespace"] = "beats"
+	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
+	if useCISnapshots {
+		env["metricbeatDockerNamespace"] = "observability-ci"
+	}
+
 	err := serviceManager.AddServicesToCompose("metricbeat", []string{"metricbeat"}, env)
 	if err != nil {
 		log.WithFields(log.Fields{


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: make docker namespace configurable (#560)