### PR TITLE
fix: set image version before switching to the configuration file

### DIFF
--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -246,13 +246,13 @@ func (mts *MetricbeatTestSuite) installedAndConfiguredForVariantModule(serviceVa
 }
 
 func (mts *MetricbeatTestSuite) installedUsingConfiguration(configuration string) error {
-	if strings.HasPrefix(metricbeatVersion, "pr-") {
-		metricbeatVersion = metricbeatVersionBase
-	}
-
 	// at this point we have everything to define the index name
 	mts.Version = metricbeatVersion
 	mts.setIndexName()
+
+	if strings.HasPrefix(metricbeatVersion, "pr-") {
+		metricbeatVersion = metricbeatVersionBase
+	}
 
 	// use master branch for snapshots
 	tag := "v" + metricbeatVersion


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It switches the order of two operations: 1) setting the version for Metricbeat's docker image, and 2) defining which branch/tag will be used to download the configuration file.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It causes a bug in the tests for metricbeat configuration in the case it's triggered by a PR from Beats: it will use the CI snapshots but the version, as it starts with `pr-`, was replaced with the base version for the maintenance branch, when we still want to use the version of the PR (in the form of its Docker image, downloaded from `observability-ci` registry)


<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

```shell
SUITE="metricbeat" METRICBEAT_VERSION="pr-23142" \
    ELASTIC_AGENT_USE_CI_SNAPSHOTS=true TAGS="metricbeat" DEVELOPER_MODE=true \
    TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE \
    make -C e2e functional-test
```
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #564
- Discovered while testing #560



<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->



<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->



<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
We still need to download the proper config file from the PR, but we do not have access to the commit SHA at this moment, unless other modifications are in place, like reading the SHA from Jenkins.

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->