### PR TITLE
chore: rename ELASTIC_AGENT_USE_CI_SNAPSHOTS

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -36,8 +36,7 @@ pipeline {
     string(name: 'ELASTIC_AGENT_DOWNLOAD_URL', defaultValue: '', description: 'If present, it will override the download URL for the Elastic agent artifact. (I.e. https://snapshots.elastic.co/8.0.0-59098054/downloads/beats/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz')
     string(name: 'ELASTIC_AGENT_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'SemVer version of the stand-alone elastic-agent to be used for Fleet tests. You can use here the tag of your PR to test your changes')
     string(name: 'ELASTIC_AGENT_STALE_VERSION', defaultValue: '7.10.1', description: 'SemVer version of the stale stand-alone elastic-agent to be used for Fleet upgrade tests.')
-    booleanParam(name: "USE_CI_SNAPSHOTS", defaultValue: false, description: "If it's needed to use the binary snapshots produced by Beats CI instead of the official releases")
-    booleanParam(name: "ELASTIC_AGENT_USE_CI_SNAPSHOTS", defaultValue: false, description: "If it's needed to use the binary snapshots produced by Beats CI instead of the official releases")
+    booleanParam(name: "BEATS_USE_CI_SNAPSHOTS", defaultValue: false, description: "If it's needed to use the binary snapshots produced by Beats CI instead of the official releases")
     choice(name: 'LOG_LEVEL', choices: ['DEBUG', 'INFO'], description: 'Log level to be used')
     choice(name: 'TIMEOUT_FACTOR', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
     string(name: 'FLEET_STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'SemVer version of the stack to be used for Fleet tests.')
@@ -63,7 +62,7 @@ pipeline {
         SLACK_CHANNEL = "${params.SLACK_CHANNEL.trim()}"
         ELASTIC_AGENT_DOWNLOAD_URL = "${params.ELASTIC_AGENT_DOWNLOAD_URL.trim()}"
         ELASTIC_AGENT_VERSION = "${params.ELASTIC_AGENT_VERSION.trim()}"
-        USE_CI_SNAPSHOTS = "${params.ELASTIC_AGENT_USE_CI_SNAPSHOTS}"
+        BEATS_USE_CI_SNAPSHOTS = "${params.BEATS_USE_CI_SNAPSHOTS}"
         FLEET_STACK_VERSION = "${params.FLEET_STACK_VERSION.trim()}"
         METRICBEAT_VERSION = "${params.METRICBEAT_VERSION.trim()}"
         METRICBEAT_STACK_VERSION = "${params.METRICBEAT_STACK_VERSION.trim()}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
     string(name: 'ELASTIC_AGENT_DOWNLOAD_URL', defaultValue: '', description: 'If present, it will override the download URL for the Elastic agent artifact. (I.e. https://snapshots.elastic.co/8.0.0-59098054/downloads/beats/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz')
     string(name: 'ELASTIC_AGENT_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'SemVer version of the stand-alone elastic-agent to be used for Fleet tests. You can use here the tag of your PR to test your changes')
     string(name: 'ELASTIC_AGENT_STALE_VERSION', defaultValue: '7.10.1', description: 'SemVer version of the stale stand-alone elastic-agent to be used for Fleet upgrade tests.')
+    booleanParam(name: "USE_CI_SNAPSHOTS", defaultValue: false, description: "If it's needed to use the binary snapshots produced by Beats CI instead of the official releases")
     booleanParam(name: "ELASTIC_AGENT_USE_CI_SNAPSHOTS", defaultValue: false, description: "If it's needed to use the binary snapshots produced by Beats CI instead of the official releases")
     choice(name: 'LOG_LEVEL', choices: ['DEBUG', 'INFO'], description: 'Log level to be used')
     choice(name: 'TIMEOUT_FACTOR', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
@@ -62,7 +63,7 @@ pipeline {
         SLACK_CHANNEL = "${params.SLACK_CHANNEL.trim()}"
         ELASTIC_AGENT_DOWNLOAD_URL = "${params.ELASTIC_AGENT_DOWNLOAD_URL.trim()}"
         ELASTIC_AGENT_VERSION = "${params.ELASTIC_AGENT_VERSION.trim()}"
-        ELASTIC_AGENT_USE_CI_SNAPSHOTS = "${params.ELASTIC_AGENT_USE_CI_SNAPSHOTS}"
+        USE_CI_SNAPSHOTS = "${params.ELASTIC_AGENT_USE_CI_SNAPSHOTS}"
         FLEET_STACK_VERSION = "${params.FLEET_STACK_VERSION.trim()}"
         METRICBEAT_VERSION = "${params.METRICBEAT_VERSION.trim()}"
         METRICBEAT_STACK_VERSION = "${params.METRICBEAT_STACK_VERSION.trim()}"

--- a/e2e/_suites/fleet/README.md
+++ b/e2e/_suites/fleet/README.md
@@ -51,7 +51,7 @@ This is an example of the optional configuration:
    export ELASTIC_AGENT_DOWNLOAD_URL="https://snapshots.elastic.co/8.0.0-59098054/downloads/beats/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz"
    # (Fleet mode) This environment variable will use the snapshots produced by Beats CI. If the above variable
    # is set, this variable will take no effect
-   export ELASTIC_AGENT_USE_CI_SNAPSHOTS="true"
+   export USE_CI_SNAPSHOTS="true"
    # (Stand-Alone mode) This environment variable will use the its value as the Docker tag produced by Beats CI (Please look up here: https://container-library.elastic.co/r/observability-ci/elastic-agent). Here you have two examples for tags:
    export ELASTIC_AGENT_VERSION="pr-20356"
    # or

--- a/e2e/_suites/fleet/README.md
+++ b/e2e/_suites/fleet/README.md
@@ -51,7 +51,7 @@ This is an example of the optional configuration:
    export ELASTIC_AGENT_DOWNLOAD_URL="https://snapshots.elastic.co/8.0.0-59098054/downloads/beats/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz"
    # (Fleet mode) This environment variable will use the snapshots produced by Beats CI. If the above variable
    # is set, this variable will take no effect
-   export USE_CI_SNAPSHOTS="true"
+   export BEATS_USE_CI_SNAPSHOTS="true"
    # (Stand-Alone mode) This environment variable will use the its value as the Docker tag produced by Beats CI (Please look up here: https://container-library.elastic.co/r/observability-ci/elastic-agent). Here you have two examples for tags:
    export ELASTIC_AGENT_VERSION="pr-20356"
    # or

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -161,7 +161,7 @@ func runElasticAgentCommand(profile string, image string, service string, proces
 // into the installer struct, to be used else where
 // If the environment variable ELASTIC_AGENT_DOWNLOAD_URL exists, then the artifact to be downloaded will
 // be defined by that value
-// Else, if the environment variable ELASTIC_AGENT_USE_CI_SNAPSHOTS is set, then the artifact
+// Else, if the environment variable USE_CI_SNAPSHOTS is set, then the artifact
 // to be downloaded will be defined by the latest snapshot produced by the Beats CI.
 func downloadAgentBinary(artifact string, version string, OS string, arch string, extension string) (string, string, error) {
 	fileName := fmt.Sprintf("%s-%s-%s.%s", artifact, version, arch, extension)
@@ -192,7 +192,7 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 	var downloadURL string
 	var err error
 
-	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
+	useCISnapshots, _ := shell.GetEnvBool("USE_CI_SNAPSHOTS")
 	if useCISnapshots {
 		log.Debug("Using CI snapshots for the Elastic Agent")
 

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -161,7 +161,7 @@ func runElasticAgentCommand(profile string, image string, service string, proces
 // into the installer struct, to be used else where
 // If the environment variable ELASTIC_AGENT_DOWNLOAD_URL exists, then the artifact to be downloaded will
 // be defined by that value
-// Else, if the environment variable USE_CI_SNAPSHOTS is set, then the artifact
+// Else, if the environment variable BEATS_USE_CI_SNAPSHOTS is set, then the artifact
 // to be downloaded will be defined by the latest snapshot produced by the Beats CI.
 func downloadAgentBinary(artifact string, version string, OS string, arch string, extension string) (string, string, error) {
 	fileName := fmt.Sprintf("%s-%s-%s.%s", artifact, version, arch, extension)
@@ -192,7 +192,7 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 	var downloadURL string
 	var err error
 
-	useCISnapshots, _ := shell.GetEnvBool("USE_CI_SNAPSHOTS")
+	useCISnapshots, _ := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
 	if useCISnapshots {
 		log.Debug("Using CI snapshots for the Elastic Agent")
 

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/cli/services"
-	"github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
 	log "github.com/sirupsen/logrus"
 )
@@ -70,11 +69,7 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed(image string) error 
 		profileEnv["elasticAgentDockerImageSuffix"] = "-" + image
 	}
 
-	profileEnv["elasticAgentDockerNamespace"] = "beats"
-	useCISnapshots, _ := shell.GetEnvBool("USE_CI_SNAPSHOTS")
-	if useCISnapshots {
-		profileEnv["elasticAgentDockerNamespace"] = "observability-ci"
-	}
+	profileEnv["elasticAgentDockerNamespace"] = e2e.GetDockerNamespaceEnvVar()
 
 	containerName := fmt.Sprintf("%s_%s_%d", FleetProfileName, ElasticAgentServiceName, 1)
 

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -71,7 +71,7 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed(image string) error 
 	}
 
 	profileEnv["elasticAgentDockerNamespace"] = "beats"
-	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
+	useCISnapshots, _ := shell.GetEnvBool("USE_CI_SNAPSHOTS")
 	if useCISnapshots {
 		profileEnv["elasticAgentDockerNamespace"] = "observability-ci"
 	}

--- a/e2e/_suites/metricbeat/README.md
+++ b/e2e/_suites/metricbeat/README.md
@@ -49,7 +49,7 @@ This is an example of the optional configuration:
    export METRICBEAT_VERSION="8.0.0-SNAPSHOT"
    # or
    # This environment variable will use the snapshots produced by Beats CI
-   export USE_CI_SNAPSHOTS="true"
+   export BEATS_USE_CI_SNAPSHOTS="true"
    export METRICBEAT_VERSION="pr-20356"
    ```
 

--- a/e2e/_suites/metricbeat/README.md
+++ b/e2e/_suites/metricbeat/README.md
@@ -47,6 +47,10 @@ This is an example of the optional configuration:
    # There should be a Docker image for the runtime dependencies (elasticsearch, kibana, package registry)
    export STACK_VERSION="8.0.0-SNAPSHOT"
    export METRICBEAT_VERSION="8.0.0-SNAPSHOT"
+   # or
+   # This environment variable will use the snapshots produced by Beats CI
+   export USE_CI_SNAPSHOTS="true"
+   export METRICBEAT_VERSION="pr-20356"
    ```
 
 3. Define the proper Docker images to be used in tests (Optional).

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -305,7 +305,7 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 	}
 
 	env["metricbeatDockerNamespace"] = "beats"
-	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
+	useCISnapshots, _ := shell.GetEnvBool("USE_CI_SNAPSHOTS")
 	if useCISnapshots {
 		env["metricbeatDockerNamespace"] = "observability-ci"
 	}

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -304,11 +304,7 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 		"serviceName":           mts.ServiceName,
 	}
 
-	env["metricbeatDockerNamespace"] = "beats"
-	useCISnapshots, _ := shell.GetEnvBool("USE_CI_SNAPSHOTS")
-	if useCISnapshots {
-		env["metricbeatDockerNamespace"] = "observability-ci"
-	}
+	env["metricbeatDockerNamespace"] = e2e.GetDockerNamespaceEnvVar()
 
 	err := serviceManager.AddServicesToCompose("metricbeat", []string{"metricbeat"}, env)
 	if err != nil {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Jeffail/gabs/v2"
 	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/elastic/e2e-testing/cli/docker"
+	"github.com/elastic/e2e-testing/cli/shell"
 	curl "github.com/elastic/e2e-testing/cli/shell"
 	log "github.com/sirupsen/logrus"
 )
@@ -435,6 +436,16 @@ func Sleep(seconds string) error {
 	time.Sleep(time.Duration(s) * time.Second)
 
 	return nil
+}
+
+// GetDockerNamespaceEnvVar returns the Docker namespace whether we use the CI snapshots or not.
+// If an error occurred reading the environment, wil return 'beats' as fallback
+func GetDockerNamespaceEnvVar() string {
+	useCISnapshots, _ := shell.GetEnvBool("USE_CI_SNAPSHOTS")
+	if useCISnapshots {
+		return "observability-ci"
+	}
+	return "beats"
 }
 
 // WaitForProcess polls a container executing "ps" command until the process is in the desired state (present or not),

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -441,7 +441,7 @@ func Sleep(seconds string) error {
 // GetDockerNamespaceEnvVar returns the Docker namespace whether we use the CI snapshots or not.
 // If an error occurred reading the environment, wil return 'beats' as fallback
 func GetDockerNamespaceEnvVar() string {
-	useCISnapshots, _ := shell.GetEnvBool("USE_CI_SNAPSHOTS")
+	useCISnapshots, _ := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
 	if useCISnapshots {
 		return "observability-ci"
 	}


### PR DESCRIPTION
## ⚠️THIS IS A BREAKING CHANGE⚠️

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It renames the ELASTIC_AGENT_USE_CI_SNAPSHOTS to USE_CI_SNAPSHOTS, which makes its scope wider, and easier to reuse across different test suites.

It also includes a small refactor in the logic to get the Docker namespace: if we use CI snapshots, let's use `observability-ci`, otherwise use `beats`.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We consume that variable in both metricbeat and elastic-agent test suites, so we prefer clarity when using it.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this?

```shell
SUITE="metricbeat" METRICBEAT_VERSION="pr-23142" \
    USE_CI_SNAPSHOTS=true TAGS="metricbeat" DEVELOPER_MODE=true \
    TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE \
    make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Blocks elastic/beats#23382


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
We must merge a PR in Beats with the update, as I could not find a simple way of not breaking the downstream project (Beats) after this change

Needs backport to 7.x and 7.10.x

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->