### PR TITLE
chore: rename ELASTIC_AGENT_USE_CI_SNAPSHOTS (#566) | fix: set image version before switching to the configuration file (#565) backport for 7.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
     string(name: 'SLACK_CHANNEL', defaultValue: 'observablt-bots', description: 'The Slack channel(s) where errors will be posted. For multiple channels, use a comma-separated list of channels')
     string(name: 'ELASTIC_AGENT_DOWNLOAD_URL', defaultValue: '', description: 'If present, it will override the download URL for the Elastic agent artifact. (I.e. https://snapshots.elastic.co/7.12.0-069dfaa4/downloads/beats/elastic-agent/elastic-agent-7.12.0-SNAPSHOT-linux-x86_64.tar.gz')
     string(name: 'ELASTIC_AGENT_VERSION', defaultValue: '7.x-SNAPSHOT', description: 'SemVer version of the stand-alone elastic-agent to be used for Fleet tests. You can use here the tag of your PR to test your changes')
-    booleanParam(name: "ELASTIC_AGENT_USE_CI_SNAPSHOTS", defaultValue: false, description: "If it's needed to use the binary snapshots produced by Beats CI instead of the official releases")
+    booleanParam(name: "BEATS_USE_CI_SNAPSHOTS", defaultValue: false, description: "If it's needed to use the binary snapshots produced by Beats CI instead of the official releases")
     choice(name: 'LOG_LEVEL', choices: ['DEBUG', 'INFO'], description: 'Log level to be used')
     choice(name: 'TIMEOUT_FACTOR', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
     string(name: 'FLEET_STACK_VERSION', defaultValue: '7.x-SNAPSHOT', description: 'SemVer version of the stack to be used for Fleet tests.')
@@ -61,7 +61,7 @@ pipeline {
         SLACK_CHANNEL = "${params.SLACK_CHANNEL.trim()}"
         ELASTIC_AGENT_DOWNLOAD_URL = "${params.ELASTIC_AGENT_DOWNLOAD_URL.trim()}"
         ELASTIC_AGENT_VERSION = "${params.ELASTIC_AGENT_VERSION.trim()}"
-        ELASTIC_AGENT_USE_CI_SNAPSHOTS = "${params.ELASTIC_AGENT_USE_CI_SNAPSHOTS}"
+        BEATS_USE_CI_SNAPSHOTS = "${params.BEATS_USE_CI_SNAPSHOTS}"
         FLEET_STACK_VERSION = "${params.FLEET_STACK_VERSION.trim()}"
         METRICBEAT_VERSION = "${params.METRICBEAT_VERSION.trim()}"
         METRICBEAT_STACK_VERSION = "${params.METRICBEAT_STACK_VERSION.trim()}"

--- a/e2e/_suites/fleet/README.md
+++ b/e2e/_suites/fleet/README.md
@@ -51,7 +51,7 @@ This is an example of the optional configuration:
    export ELASTIC_AGENT_DOWNLOAD_URL="https://snapshots.elastic.co/7.12.0-069dfaa4/downloads/beats/elastic-agent/elastic-agent-7.12.0-SNAPSHOT-linux-x86_64.tar.gz"
    # (Fleet mode) This environment variable will use the snapshots produced by Beats CI. If the above variable
    # is set, this variable will take no effect
-   export ELASTIC_AGENT_USE_CI_SNAPSHOTS="true"
+   export BEATS_USE_CI_SNAPSHOTS="true"
    # (Stand-Alone mode) This environment variable will use the its value as the Docker tag produced by Beats CI (Please look up here: https://container-library.elastic.co/r/observability-ci/elastic-agent). Here you have two examples for tags:
    export ELASTIC_AGENT_VERSION="pr-20356"
    # or

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -157,7 +157,7 @@ func runElasticAgentCommand(profile string, image string, service string, proces
 // into the installer struct, to be used else where
 // If the environment variable ELASTIC_AGENT_DOWNLOAD_URL exists, then the artifact to be downloaded will
 // be defined by that value
-// Else, if the environment variable ELASTIC_AGENT_USE_CI_SNAPSHOTS is set, then the artifact
+// Else, if the environment variable BEATS_USE_CI_SNAPSHOTS is set, then the artifact
 // to be downloaded will be defined by the latest snapshot produced by the Beats CI.
 func downloadAgentBinary(artifact string, version string, OS string, arch string, extension string) (string, string, error) {
 	fileName := fmt.Sprintf("%s-%s-%s.%s", artifact, version, arch, extension)
@@ -188,7 +188,7 @@ func downloadAgentBinary(artifact string, version string, OS string, arch string
 	var downloadURL string
 	var err error
 
-	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
+	useCISnapshots, _ := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
 	if useCISnapshots {
 		log.Debug("Using CI snapshots for the Elastic Agent")
 

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/cli/services"
-	"github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
 	log "github.com/sirupsen/logrus"
 )
@@ -70,11 +69,7 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed(image string) error 
 		profileEnv["elasticAgentDockerImageSuffix"] = "-" + image
 	}
 
-	profileEnv["elasticAgentDockerNamespace"] = "beats"
-	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
-	if useCISnapshots {
-		profileEnv["elasticAgentDockerNamespace"] = "observability-ci"
-	}
+	profileEnv["elasticAgentDockerNamespace"] = e2e.GetDockerNamespaceEnvVar()
 
 	containerName := fmt.Sprintf("%s_%s_%d", FleetProfileName, ElasticAgentServiceName, 1)
 

--- a/e2e/_suites/metricbeat/README.md
+++ b/e2e/_suites/metricbeat/README.md
@@ -47,6 +47,10 @@ This is an example of the optional configuration:
    # There should be a Docker image for the runtime dependencies (elasticsearch, kibana, package registry)
    export STACK_VERSION="7.x-SNAPSHOT"
    export METRICBEAT_VERSION="7.x-SNAPSHOT"
+   # or
+   # This environment variable will use the snapshots produced by Beats CI
+   export BEATS_USE_CI_SNAPSHOTS="true"
+   export METRICBEAT_VERSION="pr-20356"
    ```
 
 3. Define the proper Docker images to be used in tests (Optional).

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -304,11 +304,7 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 		"serviceName":           mts.ServiceName,
 	}
 
-	env["metricbeatDockerNamespace"] = "beats"
-	useCISnapshots, _ := shell.GetEnvBool("ELASTIC_AGENT_USE_CI_SNAPSHOTS")
-	if useCISnapshots {
-		env["metricbeatDockerNamespace"] = "observability-ci"
-	}
+	env["metricbeatDockerNamespace"] = e2e.GetDockerNamespaceEnvVar()
 
 	err := serviceManager.AddServicesToCompose("metricbeat", []string{"metricbeat"}, env)
 	if err != nil {

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -246,13 +246,13 @@ func (mts *MetricbeatTestSuite) installedAndConfiguredForVariantModule(serviceVa
 }
 
 func (mts *MetricbeatTestSuite) installedUsingConfiguration(configuration string) error {
-	if strings.HasPrefix(metricbeatVersion, "pr-") {
-		metricbeatVersion = metricbeatVersionBase
-	}
-
 	// at this point we have everything to define the index name
 	mts.Version = metricbeatVersion
 	mts.setIndexName()
+
+	if strings.HasPrefix(metricbeatVersion, "pr-") {
+		metricbeatVersion = metricbeatVersionBase
+	}
 
 	// use master branch for snapshots
 	tag := "v" + metricbeatVersion

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Jeffail/gabs/v2"
 	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/elastic/e2e-testing/cli/docker"
+	"github.com/elastic/e2e-testing/cli/shell"
 	curl "github.com/elastic/e2e-testing/cli/shell"
 	log "github.com/sirupsen/logrus"
 )
@@ -435,6 +436,16 @@ func Sleep(seconds string) error {
 	time.Sleep(time.Duration(s) * time.Second)
 
 	return nil
+}
+
+// GetDockerNamespaceEnvVar returns the Docker namespace whether we use the CI snapshots or not.
+// If an error occurred reading the environment, wil return 'beats' as fallback
+func GetDockerNamespaceEnvVar() string {
+	useCISnapshots, _ := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
+	if useCISnapshots {
+		return "observability-ci"
+	}
+	return "beats"
 }
 
 // WaitForProcess polls a container executing "ps" command until the process is in the desired state (present or not),


### PR DESCRIPTION
Backports the following commits to 7.x:
 - chore: rename ELASTIC_AGENT_USE_CI_SNAPSHOTS (#566)
 - fix: set image version before switching to the configuration file (#565)