### PR TITLE
fix: monitor PRs and tags too (#571) | fix: restore initial state (#570) backport for 7.10.x

### DIFF
--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -9,6 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
+          head-filter-regex: '(master|PR-.*|v\d\.d\.d|7\.x|7\.11\.x|7\.10\.x)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -246,6 +246,10 @@ func (mts *MetricbeatTestSuite) installedAndConfiguredForVariantModule(serviceVa
 }
 
 func (mts *MetricbeatTestSuite) installedUsingConfiguration(configuration string) error {
+	// restore initial state
+	metricbeatVersionBackup := metricbeatVersion
+	defer func() { metricbeatVersion = metricbeatVersionBackup }()
+
 	// at this point we have everything to define the index name
 	mts.Version = metricbeatVersion
 	mts.setIndexName()


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - fix: monitor PRs and tags too (#571)
 - fix: restore initial state (#570)