### PR TITLE
docs: document how to trigger the tests for Beats PR

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -187,6 +187,24 @@ To do so:
 Here you have a video reproducing the same steps:
 ![](./regression-testing.gif)
 
+### Running tests for a Beats pull request
+Because we trigger the E2E tests for each Beats PR that is packaged, it's possible to manually trigger it using CI user interface. To achieve it we must navigate to Jenkins and run the tests in the specific branch the original Beats PR is targeting.
+
+>For further information about packaging Beats, please read [Beat's CI docs](https://github.com/elastic/beats/blob/1de27eed058dd074b58c71094c7678b3536251cb/README.md#ci).
+
+To do so:
+
+1. Navigate to Jenkins: https://beats-ci.elastic.co/job/e2e-tests/job/e2e-testing-mbp/
+1. Login as a user
+1. Select the base branch for the test code: 7.10.x, 7.11.x, 7.x or master.
+1. In the left menu, click on `Buid with Parameters`.
+1. In the input parameters form, set the Beat version **for Fleet and Metricbeat** with the ID of your pull request, using `pr-` as prefix. I.e. `pr-23456`. 
+1. In the input parameters form, keep the stack version (for Fleet and Metricbeat) as is, to use each branch' default version.
+1. In the input parameters form, set the `GITHUB_CHECK_NAME` to `E2E Tests`. This value will appear as the label for the Github check for the E2E tests.
+1. In the input parameters form, set the `GITHUB_CHECK_REPO` to `beats`.
+1. In the input parameters form, set the `GITHUB_CHECK_SHA1` to the `SHA1` of the last commit in your pull request. This value will allow us to modify the mergeable status of that commit with the Github check.
+1. Click the `Build` button at the bottom of the parameters form.
+
 ## Noticing the test framework
 
 To generate the notice files for this project:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -199,7 +199,7 @@ To do so:
 1. Select the base branch for the test code: 7.10.x, 7.11.x, 7.x or master.
 1. In the left menu, click on `Buid with Parameters`.
 1. In the input parameters form, set the Beat version **for Fleet and Metricbeat** with the ID of your pull request, using `pr-` as prefix. I.e. `pr-23456`. 
-1. In the input parameters form, keep the stack version (for Fleet and Metricbeat) as is, to use each branch' default version.
+1. In the input parameters form, keep the stack version (for Fleet and Metricbeat) as is, to use each branch's default version.
 1. In the input parameters form, set the `GITHUB_CHECK_NAME` to `E2E Tests`. This value will appear as the label for the Github check for the E2E tests.
 1. In the input parameters form, set the `GITHUB_CHECK_REPO` to `beats`.
 1. In the input parameters form, set the `GITHUB_CHECK_SHA1` to the `SHA1` of the last commit in your pull request. This value will allow us to modify the mergeable status of that commit with the Github check.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It provides a list of steps to trigger the tests for a Beats PR, including default values.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
When the test fail on a Beats PR, we'd like the developer to manually retrigger the E2E using Jenkins UI.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #582

## Use cases

```gherkin
Given a Beats PR
When the E2E needs to be retriggered
Then the PR author knows how to trigger it manually 
``` 

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
We could add a `/run-e2e` command in Beats pipeline to retrigger them only if the package job was already in triggered.

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->