### PR TITLE
chore: increase timeout for Ceph

### DIFF
--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -315,6 +315,12 @@ func (mts *MetricbeatTestSuite) installedUsingConfiguration(configuration string
 func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 	// this is needed because, in general, the target service (apache, mysql, redis) does not have a healthcheck
 	waitForService := time.Duration(timeoutFactor) * 10 * time.Second
+	if mts.ServiceName == "ceph" {
+		// see https://github.com/elastic/beats/blob/ef6274d0d1e36308a333cbed69846a1bd63528ae/metricbeat/module/ceph/mgr_osd_tree/mgr_osd_tree_integration_test.go#L35
+		// Ceph service needs more time to start up
+		waitForService = waitForService * 4
+	}
+
 	e2e.Sleep(waitForService)
 
 	serviceManager := services.NewServiceManager()

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -314,8 +314,8 @@ func (mts *MetricbeatTestSuite) installedUsingConfiguration(configuration string
 // runMetricbeatService runs a metricbeat service entity for a service to monitor it
 func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 	// this is needed because, in general, the target service (apache, mysql, redis) does not have a healthcheck
-	waitForService := time.Duration(timeoutFactor) * 10
-	e2e.Sleep(fmt.Sprintf("%d", waitForService))
+	waitForService := time.Duration(timeoutFactor) * 10 * time.Second
+	e2e.Sleep(waitForService)
 
 	serviceManager := services.NewServiceManager()
 

--- a/e2e/elasticsearch.go
+++ b/e2e/elasticsearch.go
@@ -123,7 +123,7 @@ func RetrySearch(indexName string, esQuery map[string]interface{}, maxAttempts i
 				"retryAttempts": maxAttempts,
 				"retryTimeout":  retryTimeout,
 			}).Tracef("Waiting %d seconds for the index to be ready", retryTimeout)
-			time.Sleep(time.Duration(retryTimeout) * time.Second)
+			Sleep(time.Duration(retryTimeout) * time.Second)
 		}
 	}
 

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -444,20 +443,14 @@ func RandomString(length int) string {
 	return randomStringWithCharset(length, charset)
 }
 
-// Sleep sleeps a number of seconds, including logs
-func Sleep(seconds string) error {
+// Sleep sleeps a duration, including logs
+func Sleep(duration time.Duration) error {
 	fields := log.Fields{
-		"seconds": seconds,
+		"duration": duration,
 	}
 
-	s, err := strconv.Atoi(seconds)
-	if err != nil {
-		log.WithFields(fields).Errorf("Cannot convert %s to seconds", seconds)
-		return err
-	}
-
-	log.WithFields(fields).Tracef("Waiting %s seconds", seconds)
-	time.Sleep(time.Duration(s) * time.Second)
+	log.WithFields(fields).Tracef("Waiting %v", duration)
+	time.Sleep(duration)
 
 	return nil
 }


### PR DESCRIPTION
## What does this PR do?
We are increasing the timeout when waiting for the Ceph integration to be up-and-running, as the Beats team already do in https://github.com/elastic/beats/blob/ef6274d0d1e36308a333cbed69846a1bd63528ae/metricbeat/module/ceph/mgr_osd_tree/mgr_osd_tree_integration_test.go#L35. Because testcontainers is not supporting (yet) a `waitFor` strategy (it's about to be merged), we have to sleep the thread. And we are increasing the timeout to 2 minutes only for Ceph, the rest of the services stay at 30 seconds.

In between, we refactored the Sleep method to simplify its usage, using time.Duration instead of string as input parameter.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
As a result of this PR, we expect to **reduce the flakiness** detected by the E2E for Cep, causing noise in Beats PRs, which needed to be re-triggered.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

```shell
SUITE="metricbeat" TAGS="integrations && ceph"  TIMEOUT_FACTOR=3 DEVELOPER_MODE=true LOG_LEVEL=TRACE make -C e2e functional-test
```
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #607


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
Once testcontainers adds the functionality to wait for compose services, we will be able to consume it in a nicer way, instead of blocking the thread by 2 minutes. See https://github.com/testcontainers/testcontainers-go/pull/261

An example of how it would be:
```golang
compose.WithExposedService(
    "nginx_1", 80,
    wait.NewHTTPStrategy("/").
        WithPort("80/tcp").
        WithStartupTimeout(10*time.Second))
```

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->