### PR TITLE
fix: typo in precommit docs (#623) | chore: increase timeout in CI (#624) backport for 6.8.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
     string(name: 'ELASTIC_AGENT_STALE_VERSION', defaultValue: '7.10.1', description: 'SemVer version of the stale stand-alone elastic-agent to be used for Fleet upgrade tests.')
     booleanParam(name: "BEATS_USE_CI_SNAPSHOTS", defaultValue: false, description: "If it's needed to use the binary snapshots produced by Beats CI instead of the official releases")
     choice(name: 'LOG_LEVEL', choices: ['DEBUG', 'INFO'], description: 'Log level to be used')
-    choice(name: 'TIMEOUT_FACTOR', choices: ['3', '5', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
+    choice(name: 'TIMEOUT_FACTOR', choices: ['5', '3', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
     string(name: 'FLEET_STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'SemVer version of the stack to be used for Fleet tests.')
     string(name: 'METRICBEAT_STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'SemVer version of the stack to be used for Metricbeat tests.')
     string(name: 'METRICBEAT_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'SemVer version of the metricbeat to be used.')

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ $ pre-commit install
 pre-commit installed at .git/hooks/pre-commit
 ```
 
-To understand more about the hooks we use, please take a look at pre-commit's [configuration file](./.pre-commit-confifg.yml).
+To understand more about the hooks we use, please take a look at pre-commit's [configuration file](./.pre-commit-config.yml).

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -44,13 +44,13 @@ For this test framework, we have chosen Godog over any other test framework beca
 
 All the Gherkin (Cucumber) specifications are written in `.feature` files.
 
-A good example could be [this one](./_suites/metricbeat/features/mysql.feature).
+A good example could be [this one](./_suites/metricbeat/features/metricbeat.feature).
 
 ## Test Implementation
 
 We are using Godog + Cucumber to implement the tests, where we create connections to the `Given`, `When`, `Then`, `And`, etc. in a well-known file structure.
 
-As an example, the Golang implementation of the `./_suites/metricbeat/features/mysql.feature` is located under the [metricbeat_test.go](./_suites/metricbeat/metricbeat_test.go) file.
+As an example, the Golang implementation of the `./_suites/metricbeat/features/metricbeat.feature` is located under the [metricbeat_test.go](./_suites/metricbeat/metricbeat_test.go) file.
 
 Each module will define its own file for specificacions, adding specific feature context functions that will allow filtering the execution, if needed. 
 


### PR DESCRIPTION
Backports the following commits to 6.8.x:
 - fix: typo in precommit docs (#623)
 - chore: increase timeout in CI (#624)