### PR TITLE
fix: do not override compose configurations when syncing from beats

### DIFF
--- a/cli/cmd/_testresources/docker-compose-multiple.yml
+++ b/cli/cmd/_testresources/docker-compose-multiple.yml
@@ -1,0 +1,23 @@
+version: '2.3'
+
+services:
+  ceph:
+    image: docker.elastic.co/integrations-ci/beats-ceph:${CEPH_VERSION:-master-97985eb-nautilus-centos-7-x86_64}-2
+    build:
+      context: ./_meta
+      dockerfile: Dockerfile.${CEPH_CODENAME:-nautilus}
+      args:
+        CEPH_VERSION: ${CEPH_VERSION:-master-97985eb-nautilus-centos-7-x86_64}
+    ports:
+      - 5000
+      - 8003
+      - 8080
+  ceph-api:
+    image: docker.elastic.co/integrations-ci/beats-ceph:master-6373c6a-jewel-centos-7-x86_64-1
+    build:
+      context: ./_meta
+      dockerfile: Dockerfile.jewel
+      args:
+        CEPH_VERSION: master-6373c6a-jewel-centos-7-x86_64
+    ports:
+      - 5000

--- a/cli/cmd/_testresources/docker-compose-single.yml
+++ b/cli/cmd/_testresources/docker-compose-single.yml
@@ -1,0 +1,11 @@
+version: '2.3'
+
+services:
+  apache:
+    image: docker.elastic.co/integrations-ci/beats-apache:${APACHE_VERSION:-2.4.20}-1
+    build:
+      context: ./_meta
+      args:
+        APACHE_VERSION: ${APACHE_VERSION:-2.4.20}
+    ports:
+      - 80

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -163,7 +163,7 @@ func copyIntegrationsComposeFiles(beats git.Project, pattern string, target stri
 			"targetMeta": targetMetaDir,
 		}).Trace("Integration _meta directory copied")
 
-		err = sanitizeComposeFile(targetFile)
+		err = sanitizeComposeFile(targetFile, targetFile)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error": err,
@@ -203,7 +203,7 @@ type compose struct {
 }
 
 // removes non-needed blocks in the target compose file, such as the build context
-func sanitizeComposeFile(composeFilePath string) error {
+func sanitizeComposeFile(composeFilePath string, targetFilePath string) error {
 	bytes, err := io.ReadFile(composeFilePath)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -254,7 +254,7 @@ func sanitizeComposeFile(composeFilePath string) error {
 		return err
 	}
 
-	return io.WriteFile(d, composeFilePath)
+	return io.WriteFile(d, targetFilePath)
 }
 
 // sanitizeConfigurationFile replaces 127.0.0.1 with current service name

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -221,10 +221,10 @@ func sanitizeComposeFile(composeFilePath string) error {
 		return err
 	}
 
-	// we'll copy all fields but the excluded ones in this struct
-	output := make(map[string]service)
-
 	for k, srv := range c.Services {
+		// we'll copy all fields but the excluded ones in this struct
+		output := make(map[string]service)
+
 		switch i := srv.(type) {
 		case map[interface{}]interface{}:
 			log.WithFields(log.Fields{

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Flaque/filet"
+	io "github.com/elastic/e2e-testing/cli/internal"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+const testResourcesBasePath = "_testresources/"
+const dockerComposeMultiple = "docker-compose-multiple.yml"
+const dockerComposeSingle = "docker-compose-single.yml"
+
+func TestSanitizeComposeFile_Multiple(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpDir := filet.TmpDir(t, "")
+
+	target := filepath.Join(tmpDir, dockerComposeMultiple)
+	src := filepath.Join(testResourcesBasePath, dockerComposeMultiple)
+
+	err := sanitizeComposeFile(src, target)
+	assert.Nil(t, err)
+
+	bytes, err := io.ReadFile(target)
+	assert.Nil(t, err)
+
+	c := compose{}
+	err = yaml.Unmarshal(bytes, &c)
+	assert.Nil(t, err)
+
+	assert.Equal(t, c.Version, "2.3")
+	assert.Equal(t, len(c.Services), 2)
+}
+
+func TestSanitizeComposeFile_Single(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpDir := filet.TmpDir(t, "")
+
+	target := filepath.Join(tmpDir, dockerComposeSingle)
+	src := filepath.Join(testResourcesBasePath, dockerComposeSingle)
+
+	err := sanitizeComposeFile(src, target)
+	assert.Nil(t, err)
+
+	bytes, err := io.ReadFile(target)
+	assert.Nil(t, err)
+
+	c := compose{}
+	err = yaml.Unmarshal(bytes, &c)
+	assert.Nil(t, err)
+
+	assert.Equal(t, c.Version, "2.3")
+	assert.Equal(t, len(c.Services), 1)
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It moves the variable holding the references to a single service into the loop-for that is responsible of creating the service.

In the process, we added unit tests to the sanitize compose file feature, and for that we had to change method signature to support writing to a different file in the test side (adding testability).

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We noticed that ceph was not receiving all the ports declared in its docker-compose file:

```yaml
version: '2.3'

services:
  ceph:
    image: docker.elastic.co/integrations-ci/beats-ceph:${CEPH_VERSION:-master-97985eb-nautilus-centos-7-x86_64}-2
    build:
      context: ./_meta
      dockerfile: Dockerfile.${CEPH_CODENAME:-nautilus}
      args:
        CEPH_VERSION: ${CEPH_VERSION:-master-97985eb-nautilus-centos-7-x86_64}
    ports:
      - 5000
      - 8003
      - 8080
  ceph-api:
    image: docker.elastic.co/integrations-ci/beats-ceph:master-6373c6a-jewel-centos-7-x86_64-1
    build:
      context: ./_meta
      dockerfile: Dockerfile.jewel
      args:
        CEPH_VERSION: master-6373c6a-jewel-centos-7-x86_64
    ports:
      - 5000
```

In the contrary it was overriden by the second service in the compose, ceph-api:

```yaml 
version: "2.3"
services:
  ceph:
    image: docker.elastic.co/integrations-ci/beats-ceph:${CEPH_VERSION:-master-97985eb-nautilus-centos-7-x86_64}-2
    ports:
    - 5000
  ceph-api:
    image: docker.elastic.co/integrations-ci/beats-ceph:master-6373c6a-jewel-centos-7-x86_64-1
    ports:
    - 5000
```

And this could lead to unexpected errors.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Verified ceph is having multiple ports

## How to test this PR locally

```shell 
$ make -C cli test
...
PASS cmd.TestSanitizeComposeFile_Multiple (0.00s)
PASS cmd.TestSanitizeComposeFile_Single (0.00s)
PASS cmd
...
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #618


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
We should check https://github.com/elastic/beats/blob/master/metricbeat/module/ceph/docker-compose.yml#L5-L16, as it seems there is a hardcoded value for the image in ceph-api.

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->