### PR TITLE
fix: let godog handle the creation of the junit test file (#629) backport for 7.x

### DIFF
--- a/.ci/scripts/functional-test.sh
+++ b/.ci/scripts/functional-test.sh
@@ -28,12 +28,4 @@ mkdir -p outputs
 
 REPORT="$(pwd)/outputs/TEST-${SUITE}"
 
-## Generate test report even if make failed.
-set +e
-exit_status=0
-if ! SUITE=${SUITE} TAGS="${TAGS}" FORMAT=junit:${REPORT}.xml STACK_VERSION=${STACK_VERSION} METRICBEAT_VERSION=${METRICBEAT_VERSION} make --no-print-directory -C e2e functional-test ; then
-  echo 'ERROR: functional-test failed'
-  exit_status=1
-fi
-
-exit $exit_status
+SUITE=${SUITE} TAGS="${TAGS}" FORMAT=junit:${REPORT}.xml STACK_VERSION=${STACK_VERSION} METRICBEAT_VERSION=${METRICBEAT_VERSION} make --no-print-directory -C e2e functional-test


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: let godog handle the creation of the junit test file (#629)