### PR TITLE
chore: skip ceph tests (#635) backport for 7.10.x

### DIFF
--- a/e2e/_suites/metricbeat/features/integrations.feature
+++ b/e2e/_suites/metricbeat/features/integrations.feature
@@ -22,6 +22,7 @@ Examples: Apache
 | apache      | 2.4.20  |
 
 @ceph
+@skip
 Examples: Ceph
 | integration | version                                 |
 | ceph        | master-6373c6a-jewel-centos-7-x86_64    |


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - chore: skip ceph tests (#635)