### PR TITLE
fix: do not override compose configurations when syncing from beats (#630) backport for 7.x

### DIFF
--- a/cli/cmd/_testresources/docker-compose-multiple.yml
+++ b/cli/cmd/_testresources/docker-compose-multiple.yml
@@ -1,0 +1,23 @@
+version: '2.3'
+
+services:
+  ceph:
+    image: docker.elastic.co/integrations-ci/beats-ceph:${CEPH_VERSION:-master-97985eb-nautilus-centos-7-x86_64}-2
+    build:
+      context: ./_meta
+      dockerfile: Dockerfile.${CEPH_CODENAME:-nautilus}
+      args:
+        CEPH_VERSION: ${CEPH_VERSION:-master-97985eb-nautilus-centos-7-x86_64}
+    ports:
+      - 5000
+      - 8003
+      - 8080
+  ceph-api:
+    image: docker.elastic.co/integrations-ci/beats-ceph:master-6373c6a-jewel-centos-7-x86_64-1
+    build:
+      context: ./_meta
+      dockerfile: Dockerfile.jewel
+      args:
+        CEPH_VERSION: master-6373c6a-jewel-centos-7-x86_64
+    ports:
+      - 5000

--- a/cli/cmd/_testresources/docker-compose-single.yml
+++ b/cli/cmd/_testresources/docker-compose-single.yml
@@ -1,0 +1,11 @@
+version: '2.3'
+
+services:
+  apache:
+    image: docker.elastic.co/integrations-ci/beats-apache:${APACHE_VERSION:-2.4.20}-1
+    build:
+      context: ./_meta
+      args:
+        APACHE_VERSION: ${APACHE_VERSION:-2.4.20}
+    ports:
+      - 80

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -163,7 +163,7 @@ func copyIntegrationsComposeFiles(beats git.Project, pattern string, target stri
 			"targetMeta": targetMetaDir,
 		}).Trace("Integration _meta directory copied")
 
-		err = sanitizeComposeFile(targetFile)
+		err = sanitizeComposeFile(targetFile, targetFile)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error": err,
@@ -203,7 +203,7 @@ type compose struct {
 }
 
 // removes non-needed blocks in the target compose file, such as the build context
-func sanitizeComposeFile(composeFilePath string) error {
+func sanitizeComposeFile(composeFilePath string, targetFilePath string) error {
 	bytes, err := io.ReadFile(composeFilePath)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -221,10 +221,10 @@ func sanitizeComposeFile(composeFilePath string) error {
 		return err
 	}
 
-	// we'll copy all fields but the excluded ones in this struct
-	output := make(map[string]service)
-
 	for k, srv := range c.Services {
+		// we'll copy all fields but the excluded ones in this struct
+		output := make(map[string]service)
+
 		switch i := srv.(type) {
 		case map[interface{}]interface{}:
 			log.WithFields(log.Fields{
@@ -254,7 +254,7 @@ func sanitizeComposeFile(composeFilePath string) error {
 		return err
 	}
 
-	return io.WriteFile(d, composeFilePath)
+	return io.WriteFile(d, targetFilePath)
 }
 
 // sanitizeConfigurationFile replaces 127.0.0.1 with current service name

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/Flaque/filet"
+	io "github.com/elastic/e2e-testing/cli/internal"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+const testResourcesBasePath = "_testresources/"
+const dockerComposeMultiple = "docker-compose-multiple.yml"
+const dockerComposeSingle = "docker-compose-single.yml"
+
+func TestSanitizeComposeFile_Multiple(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpDir := filet.TmpDir(t, "")
+
+	target := filepath.Join(tmpDir, dockerComposeMultiple)
+	src := filepath.Join(testResourcesBasePath, dockerComposeMultiple)
+
+	err := sanitizeComposeFile(src, target)
+	assert.Nil(t, err)
+
+	bytes, err := io.ReadFile(target)
+	assert.Nil(t, err)
+
+	c := compose{}
+	err = yaml.Unmarshal(bytes, &c)
+	assert.Nil(t, err)
+
+	assert.Equal(t, c.Version, "2.3")
+	assert.Equal(t, len(c.Services), 2)
+
+	// we know that both services have different number of ports
+	for k, srv := range c.Services {
+		switch i := srv.(type) {
+		case map[interface{}]interface{}:
+			for key, value := range i {
+				strKey := fmt.Sprintf("%v", key)
+
+				// does not contain the build context element
+				assert.NotEqual(t, strKey, "build")
+
+				// strKey == ports
+				if strKey == "ports" {
+					if k == "ceph" {
+						// ceph has 3 ports
+						assert.Equal(t, len(value.([]interface{})), 3)
+					} else if k == "ceph-api" {
+						// ceph-api has 1 port
+						assert.Equal(t, len(value.([]interface{})), 1)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestSanitizeComposeFile_Single(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpDir := filet.TmpDir(t, "")
+
+	target := filepath.Join(tmpDir, dockerComposeSingle)
+	src := filepath.Join(testResourcesBasePath, dockerComposeSingle)
+
+	err := sanitizeComposeFile(src, target)
+	assert.Nil(t, err)
+
+	bytes, err := io.ReadFile(target)
+	assert.Nil(t, err)
+
+	c := compose{}
+	err = yaml.Unmarshal(bytes, &c)
+	assert.Nil(t, err)
+
+	assert.Equal(t, c.Version, "2.3")
+	assert.Equal(t, len(c.Services), 1)
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: do not override compose configurations when syncing from beats (#630)