### PR TITLE
chore: refactor Fleet upgrade tests (#671) backport for 7.x

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -91,3 +91,25 @@ sync-integrations:
 unit-test:
 	gotestsum --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
 	cd _suites && gotestsum --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
+
+## Test examples
+
+.PHONY: fleet-fleet
+fleet-fleet:
+	SUITE="fleet" TAGS="fleet_mode_agent" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true $(MAKE) functional-test
+
+.PHONY: fleet-fleet-ci-snapshots
+fleet-fleet-ci-snapshots:
+	SUITE="fleet" TAGS="fleet_mode_agent" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEATS_USE_CI_SNAPSHOTS=true DEVELOPER_MODE=true GITHUB_CHECK_SHA1=a1962c8864016010adcde9f35bd8378debb4fbf7 $(MAKE) functional-test
+
+.PHONY: fleet-fleet-pr-ci-snapshots
+fleet-fleet-pr-ci-snapshots:
+	SUITE="fleet" TAGS="fleet_mode_agent" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEATS_USE_CI_SNAPSHOTS=true DEVELOPER_MODE=true ELASTIC_AGENT_VERSION=pr-14954 $(MAKE) functional-test
+
+.PHONY: fleet-nightly
+fleet-nightly:
+	SUITE="fleet" TAGS="fleet_mode_agent && nightly" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true $(MAKE) functional-test
+
+.PHONY: fleet-nightly-ci-snapshots
+fleet-nightly-ci-snapshots:
+	SUITE="fleet" TAGS="fleet_mode_agent && nightly" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEATS_USE_CI_SNAPSHOTS=true DEVELOPER_MODE=true GITHUB_CHECK_SHA1=a1962c8864016010adcde9f35bd8378debb4fbf7 $(MAKE) functional-test

--- a/e2e/_suites/fleet/features/fleet_mode_agent.feature
+++ b/e2e/_suites/fleet/features/fleet_mode_agent.feature
@@ -40,7 +40,7 @@ Examples:
 | debian |
 
 # @upgrade-agent
-@skip
+@nightly
 Scenario Outline: Upgrading the installed <os> agent
   Given a "<os>" agent "stale" is deployed to Fleet with "tar" installer
     And certs for "<os>" are installed

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -42,6 +42,7 @@ type FleetTestSuite struct {
 	CurrentToken   string // current enrollment token
 	CurrentTokenID string // current enrollment tokenID
 	Hostname       string // the hostname of the container
+	Version        string // current elastic-agent version
 	// integrations
 	Integration     IntegrationPackage // the installed integration
 	PolicyUpdatedAt string             // the moment the policy was updated
@@ -107,6 +108,8 @@ func (fts *FleetTestSuite) afterScenario() {
 func (fts *FleetTestSuite) beforeScenario() {
 	fts.Cleanup = false
 
+	fts.Version = agentVersion
+
 	// create policy with system monitoring enabled
 	defaultPolicy, err := getAgentDefaultPolicy()
 	if err != nil {
@@ -148,8 +151,8 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.ScenarioContext) {
 }
 
 func (fts *FleetTestSuite) anStaleAgentIsDeployedToFleetWithInstaller(image, version, installerType string) error {
-	agentVersionBackup := agentVersion
-	defer func() { agentVersion = agentVersionBackup }()
+	agentVersionBackup := fts.Version
+	defer func() { fts.Version = agentVersionBackup }()
 
 	switch version {
 	case "stale":
@@ -160,13 +163,12 @@ func (fts *FleetTestSuite) anStaleAgentIsDeployedToFleetWithInstaller(image, ver
 		version = agentStaleVersion
 	}
 
-	agentVersion = version
+	fts.Version = version
 
 	// prepare installer for stale version
-	if agentVersion != agentVersionBackup {
-		i := GetElasticAgentInstaller(image, installerType)
-		installerType = fmt.Sprintf("%s-%s", installerType, version)
-		fts.Installers[fmt.Sprintf("%s-%s", image, installerType)] = i
+	if fts.Version != agentVersionBackup {
+		i := GetElasticAgentInstaller(image, installerType, fts.Version, true)
+		fts.Installers[fmt.Sprintf("%s-%s-%s", image, installerType, version)] = i
 	}
 
 	return fts.anAgentIsDeployedToFleetWithInstaller(image, installerType)
@@ -175,6 +177,12 @@ func (fts *FleetTestSuite) anStaleAgentIsDeployedToFleetWithInstaller(image, ver
 func (fts *FleetTestSuite) installCerts(targetOS string) error {
 	installer := fts.getInstaller()
 	if installer.InstallCertsFn == nil {
+		log.WithFields(log.Fields{
+			"installer":         installer,
+			"version":           fts.Version,
+			"agentVersion":      agentVersion,
+			"agentStaleVersion": agentStaleVersion,
+		}).Error("No installer found")
 		return errors.New("no installer found")
 	}
 
@@ -291,7 +299,7 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleetWithInstaller(image string, i
 }
 
 func (fts *FleetTestSuite) getInstaller() ElasticAgentInstaller {
-	return fts.Installers[fts.Image+"-"+fts.InstallerType]
+	return fts.Installers[fts.Image+"-"+fts.InstallerType+"-"+fts.Version]
 }
 
 func (fts *FleetTestSuite) processStateChangedOnTheHost(process string, state string) error {

--- a/e2e/_suites/fleet/ingest-manager_test.go
+++ b/e2e/_suites/fleet/ingest-manager_test.go
@@ -45,7 +45,7 @@ var agentVersion = agentVersionBase
 
 // agentStaleVersion is the version of the agent to use as a base during upgrade
 // It can be overriden by ELASTIC_AGENT_STALE_VERSION env var. Using latest GA as a default.
-var agentStaleVersion = "7.10.0"
+var agentStaleVersion = "7.10.2"
 
 // stackVersion is the version of the stack to use
 // It can be overriden by STACK_VERSION env var
@@ -81,6 +81,11 @@ func setUpSuite() {
 
 	timeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", timeoutFactor)
 
+	useCISnapshots := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
+	if useCISnapshots && !strings.HasSuffix(agentStaleVersion, "-SNAPSHOT") {
+		agentStaleVersion += "-SNAPSHOT"
+	}
+
 	// check if version is an alias
 	agentVersion = e2e.GetElasticArtifactVersion(agentVersion)
 	agentStaleVersion = shell.GetEnv("ELASTIC_AGENT_STALE_VERSION", agentStaleVersion)
@@ -89,10 +94,10 @@ func setUpSuite() {
 	imts = IngestManagerTestSuite{
 		Fleet: &FleetTestSuite{
 			Installers: map[string]ElasticAgentInstaller{
-				"centos-systemd": GetElasticAgentInstaller("centos", "systemd"),
-				"centos-tar":     GetElasticAgentInstaller("centos", "tar"),
-				"debian-systemd": GetElasticAgentInstaller("debian", "systemd"),
-				"debian-tar":     GetElasticAgentInstaller("debian", "tar"),
+				"centos-systemd-" + agentVersion: GetElasticAgentInstaller("centos", "systemd", agentVersion, false),
+				"centos-tar-" + agentVersion:     GetElasticAgentInstaller("centos", "tar", agentVersion, false),
+				"debian-systemd-" + agentVersion: GetElasticAgentInstaller("debian", "systemd", agentVersion, false),
+				"debian-tar-" + agentVersion:     GetElasticAgentInstaller("debian", "tar", agentVersion, false),
 			},
 		},
 		StandAlone: &StandAloneTestSuite{},

--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -157,6 +157,7 @@ type TARPackage struct {
 	arch     string
 	artifact string
 	OS       string
+	stale    bool
 	version  string
 }
 
@@ -214,23 +215,38 @@ func (i *TARPackage) Preinstall() error {
 		return err
 	}
 
-	version := checkElasticAgentVersion(i.version)
+	version := i.version
+	if !i.stale {
+		version = checkElasticAgentVersion(i.version)
+	}
 
 	// simplify layout
-	cmds := []string{"mv", fmt.Sprintf("/%s-%s-%s-%s", i.artifact, version, i.OS, i.arch), "/elastic-agent"}
-	err = execCommandInService(i.profile, i.image, i.service, cmds, false)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"command": cmds,
-			"error":   err,
-			"image":   i.image,
-			"service": i.service,
-		}).Error("Could not extract agent package in the box")
+	cmds := [][]string{
+		[]string{"rm", "-fr", "/elastic-agent"},
+		[]string{"mv", fmt.Sprintf("/%s-%s-%s-%s", i.artifact, version, i.OS, i.arch), "/elastic-agent"},
+	}
+	for _, cmd := range cmds {
+		err = execCommandInService(i.profile, i.image, i.service, cmd, false)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"command": cmd,
+				"error":   err,
+				"image":   i.image,
+				"service": i.service,
+				"version": version,
+			}).Error("Could not extract agent package in the box")
 
-		return err
+			return err
+		}
 	}
 
 	return nil
+}
+
+// Stale sets the stale state
+func (i *TARPackage) Stale(stale bool) *TARPackage {
+	i.stale = stale
+	return i
 }
 
 // Uninstall uninstalls a TAR package

--- a/e2e/_suites/fleet/services_test.go
+++ b/e2e/_suites/fleet/services_test.go
@@ -84,11 +84,25 @@ func TestGetGCPBucketCoordinates_Commits(t *testing.T) {
 		extension := "rpm"
 		fileName := "elastic-agent-" + testVersion + "-x86_64.rpm"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "commits/0123456789")
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-x86_64.rpm")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-x86_64.rpm")
+	})
+	t.Run("Fetching commits bucket for stale RPM package in the snapshots folder", func(t *testing.T) {
+		defer os.Unsetenv("GITHUB_CHECK_SHA1")
+		os.Setenv("GITHUB_CHECK_SHA1", "0123456789")
+
+		arch := "x86_64"
+		extension := "rpm"
+		fileName := "elastic-agent-" + testVersion + "-x86_64.rpm"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-x86_64.rpm")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-x86_64.rpm")
 	})
 
 	t.Run("Fetching commits bucket for DEB package", func(t *testing.T) {
@@ -99,11 +113,25 @@ func TestGetGCPBucketCoordinates_Commits(t *testing.T) {
 		extension := "deb"
 		fileName := "elastic-agent-" + testVersion + "-amd64.deb"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "commits/0123456789")
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-amd64.deb")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-amd64.deb")
+	})
+	t.Run("Fetching commits bucket for stale DEB package in the snapshots folder", func(t *testing.T) {
+		defer os.Unsetenv("GITHUB_CHECK_SHA1")
+		os.Setenv("GITHUB_CHECK_SHA1", "0123456789")
+
+		arch := "amd64"
+		extension := "deb"
+		fileName := "elastic-agent-" + testVersion + "-amd64.deb"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-amd64.deb")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-amd64.deb")
 	})
 
 	t.Run("Fetching commits bucket for TAR package adds OS to fileName and object", func(t *testing.T) {
@@ -114,11 +142,25 @@ func TestGetGCPBucketCoordinates_Commits(t *testing.T) {
 		extension := "tar.gz"
 		fileName := "elastic-agent-" + testVersion + "-linux-x86_64.tar.gz"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "commits/0123456789")
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
+	})
+	t.Run("Fetching commits bucket for stale TAR package adds OS to fileName and object in the snapshots folder", func(t *testing.T) {
+		defer os.Unsetenv("GITHUB_CHECK_SHA1")
+		os.Setenv("GITHUB_CHECK_SHA1", "0123456789")
+
+		arch := "x86_64"
+		extension := "tar.gz"
+		fileName := "elastic-agent-" + testVersion + "-linux-x86_64.tar.gz"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
 	})
 }
 
@@ -135,11 +177,25 @@ func TestGetGCPBucketCoordinates_CommitsForAPullRequest(t *testing.T) {
 		extension := "rpm"
 		fileName := "elastic-agent-" + testVersion + "-x86_64.rpm"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "pull-requests/pr-23456")
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-x86_64.rpm")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-x86_64.rpm")
+	})
+	t.Run("Fetching commits bucket for stale RPM package in the snapshots folder", func(t *testing.T) {
+		defer os.Unsetenv("GITHUB_CHECK_SHA1")
+		os.Setenv("GITHUB_CHECK_SHA1", "0123456789")
+
+		arch := "x86_64"
+		extension := "rpm"
+		fileName := "elastic-agent-" + testVersion + "-x86_64.rpm"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-x86_64.rpm")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-x86_64.rpm")
 	})
 
 	t.Run("Fetching commits bucket for DEB package", func(t *testing.T) {
@@ -150,11 +206,25 @@ func TestGetGCPBucketCoordinates_CommitsForAPullRequest(t *testing.T) {
 		extension := "deb"
 		fileName := "elastic-agent-" + testVersion + "-amd64.deb"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "pull-requests/pr-23456")
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-amd64.deb")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-amd64.deb")
+	})
+	t.Run("Fetching commits bucket for stale DEB package in the snapshots folder", func(t *testing.T) {
+		defer os.Unsetenv("GITHUB_CHECK_SHA1")
+		os.Setenv("GITHUB_CHECK_SHA1", "0123456789")
+
+		arch := "amd64"
+		extension := "deb"
+		fileName := "elastic-agent-" + testVersion + "-amd64.deb"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-amd64.deb")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-amd64.deb")
 	})
 
 	t.Run("Fetching commits bucket for TAR package adds OS to fileName and object", func(t *testing.T) {
@@ -165,11 +235,25 @@ func TestGetGCPBucketCoordinates_CommitsForAPullRequest(t *testing.T) {
 		extension := "tar.gz"
 		fileName := "elastic-agent-" + testVersion + "-linux-x86_64.tar.gz"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "pull-requests/pr-23456")
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
+	})
+	t.Run("Fetching commits bucket for stale TAR package adds OS to fileName and object in the snapshots folder", func(t *testing.T) {
+		defer os.Unsetenv("GITHUB_CHECK_SHA1")
+		os.Setenv("GITHUB_CHECK_SHA1", "0123456789")
+
+		arch := "x86_64"
+		extension := "tar.gz"
+		fileName := "elastic-agent-" + testVersion + "-linux-x86_64.tar.gz"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
 	})
 }
 
@@ -183,11 +267,22 @@ func TestGetGCPBucketCoordinates_PullRequests(t *testing.T) {
 		extension := "rpm"
 		fileName := "elastic-agent-" + testVersion + "-x86_64.rpm"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-x86_64.rpm")
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "pull-requests/pr-23456")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-x86_64.rpm")
+	})
+	t.Run("Fetching commits bucket for stale RPM package in the snapshots folder", func(t *testing.T) {
+		arch := "x86_64"
+		extension := "rpm"
+		fileName := "elastic-agent-" + testVersion + "-x86_64.rpm"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-x86_64.rpm")
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-x86_64.rpm")
 	})
 
 	t.Run("Fetching commits bucket for DEB package", func(t *testing.T) {
@@ -195,11 +290,22 @@ func TestGetGCPBucketCoordinates_PullRequests(t *testing.T) {
 		extension := "deb"
 		fileName := "elastic-agent-" + testVersion + "-amd64.deb"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-amd64.deb")
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "pull-requests/pr-23456")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-amd64.deb")
+	})
+	t.Run("Fetching commits bucket for stale DEB package in the snapshots folder", func(t *testing.T) {
+		arch := "amd64"
+		extension := "deb"
+		fileName := "elastic-agent-" + testVersion + "-amd64.deb"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-amd64.deb")
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-amd64.deb")
 	})
 
 	t.Run("Fetching commits bucket for TAR package adds OS to fileName and object", func(t *testing.T) {
@@ -207,11 +313,22 @@ func TestGetGCPBucketCoordinates_PullRequests(t *testing.T) {
 		extension := "tar.gz"
 		fileName := "elastic-agent-" + testVersion + "-linux-x86_64.tar.gz"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "pull-requests/pr-23456")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
+	})
+	t.Run("Fetching commits bucket for stale TAR package adds OS to fileName and object in the snapshots folder", func(t *testing.T) {
+		arch := "x86_64"
+		extension := "tar.gz"
+		fileName := "elastic-agent-" + testVersion + "-linux-x86_64.tar.gz"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
 	})
 }
 
@@ -225,7 +342,18 @@ func TestGetGCPBucketCoordinates_Snapshots(t *testing.T) {
 		extension := "rpm"
 		fileName := "elastic-agent-" + testVersion + "-x86_64.rpm"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-x86_64.rpm")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-x86_64.rpm")
+	})
+	t.Run("Fetching commits bucket for stale RPM package", func(t *testing.T) {
+		arch := "x86_64"
+		extension := "rpm"
+		fileName := "elastic-agent-" + testVersion + "-x86_64.rpm"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "snapshots/elastic-agent")
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-x86_64.rpm")
@@ -237,7 +365,18 @@ func TestGetGCPBucketCoordinates_Snapshots(t *testing.T) {
 		extension := "deb"
 		fileName := "elastic-agent-" + testVersion + "-amd64.deb"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-amd64.deb")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-amd64.deb")
+	})
+	t.Run("Fetching commits bucket for stale DEB package", func(t *testing.T) {
+		arch := "amd64"
+		extension := "deb"
+		fileName := "elastic-agent-" + testVersion + "-amd64.deb"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "snapshots/elastic-agent")
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-amd64.deb")
@@ -249,7 +388,18 @@ func TestGetGCPBucketCoordinates_Snapshots(t *testing.T) {
 		extension := "tar.gz"
 		fileName := "elastic-agent-" + testVersion + "-linux-x86_64.tar.gz"
 
-		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension)
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, false)
+		assert.Equal(t, bucket, "beats-ci-artifacts")
+		assert.Equal(t, prefix, "snapshots/elastic-agent")
+		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
+		assert.Equal(t, object, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
+	})
+	t.Run("Fetching commits bucket for stale TAR package adds OS to fileName and object", func(t *testing.T) {
+		arch := "x86_64"
+		extension := "tar.gz"
+		fileName := "elastic-agent-" + testVersion + "-linux-x86_64.tar.gz"
+
+		newFileName, bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, OS, arch, extension, true)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "snapshots/elastic-agent")
 		assert.Equal(t, newFileName, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")

--- a/e2e/_suites/fleet/services_test.go
+++ b/e2e/_suites/fleet/services_test.go
@@ -24,7 +24,7 @@ func TestDownloadAgentBinary(t *testing.T) {
 		arch := "foo_arch"
 		extension := "foo_ext"
 
-		_, _, err := downloadAgentBinary(artifact, version, OS, arch, extension)
+		_, _, err := downloadAgentBinary(artifact, version, OS, arch, extension, false)
 		assert.NotNil(t, err)
 	})
 
@@ -36,7 +36,7 @@ func TestDownloadAgentBinary(t *testing.T) {
 		extension := "rpm"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm"
 
-		newFileName, downloadedFilePath, err := downloadAgentBinary(artifact, version, OS, arch, extension)
+		newFileName, downloadedFilePath, err := downloadAgentBinary(artifact, version, OS, arch, extension, false)
 		assert.Nil(t, err)
 		assert.Equal(t, newFileName, expectedFileName)
 		assert.Equal(t, downloadedFilePath, path.Join(distributionsDir, expectedFileName))
@@ -50,7 +50,7 @@ func TestDownloadAgentBinary(t *testing.T) {
 		extension := "deb"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-amd64.deb"
 
-		newFileName, downloadedFilePath, err := downloadAgentBinary(artifact, version, OS, arch, extension)
+		newFileName, downloadedFilePath, err := downloadAgentBinary(artifact, version, OS, arch, extension, false)
 		assert.Nil(t, err)
 		assert.Equal(t, newFileName, expectedFileName)
 		assert.Equal(t, downloadedFilePath, path.Join(distributionsDir, expectedFileName))
@@ -64,7 +64,7 @@ func TestDownloadAgentBinary(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-amd64.tar.gz"
 
-		newFileName, downloadedFilePath, err := downloadAgentBinary(artifact, version, OS, arch, extension)
+		newFileName, downloadedFilePath, err := downloadAgentBinary(artifact, version, OS, arch, extension, false)
 		assert.Nil(t, err)
 		assert.Equal(t, newFileName, expectedFileName)
 		assert.Equal(t, downloadedFilePath, path.Join(distributionsDir, expectedFileName))


### PR DESCRIPTION
Backports the following commits to 7.x:
 - chore: refactor Fleet upgrade tests (#671)