### PR TITLE
Metricbeat goal

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -325,11 +325,6 @@ def generateFunctionalTestStep(Map args = [:]){
           if(isInstalled(tool: 'docker', flag: '--version')) {
             dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
           }
-          retry(3){
-            dir("${BASE_DIR}"){
-              sh script: """.ci/scripts/install-test-dependencies.sh "${suite}" """, label: "Install test dependencies for ${suite}:${tags}"
-            }
-          }
           filebeat(output: "docker_logs_${suite}_${tags}.log", workdir: "${env.WORKSPACE}"){
             dir("${BASE_DIR}"){
               sh script: """.ci/scripts/functional-test.sh "${suite}" "${tags}" "${stackVersion}" "${METRICBEAT_VERSION}" """, label: "Run functional tests for ${suite}:${tags}"

--- a/.ci/functionalTests.groovy
+++ b/.ci/functionalTests.groovy
@@ -107,11 +107,6 @@ pipeline {
       steps {
         deleteDir()
         unstash 'source'
-        retry(3){
-          dir("${BASE_DIR}"){
-            sh script: """.ci/scripts/install-test-dependencies.sh "${GO_VERSION}" """, label: "Install test dependencies for ${params.FEATURE}"
-          }
-        }
         dir(BASE_DIR){
           sh script: """.ci/scripts/functional-test.sh "${GO_VERSION}" "${params.FEATURE}" """, label: 'Run functional tests'
         }

--- a/.ci/scripts/functional-test.sh
+++ b/.ci/scripts/functional-test.sh
@@ -23,6 +23,9 @@ METRICBEAT_VERSION=${4:-'8.0.0-SNAPSHOT'}
 TARGET_OS=${GOOS:-linux}
 TARGET_ARCH=${GOARCH:-amd64}
 
+## Install the required dependencies for the given SUITE
+.ci/scripts/install-test-dependencies.sh "${SUITE}"
+
 rm -rf outputs || true
 mkdir -p outputs
 

--- a/.ci/scripts/install-test-dependencies.sh
+++ b/.ci/scripts/install-test-dependencies.sh
@@ -17,7 +17,15 @@ SUITE=${1:?SUITE is not set}
 # execute specific test dependencies if it exists
 if [ -f .ci/scripts/install-${SUITE}-test-dependencies.sh ]
 then
-    source .ci/scripts/install-${SUITE}-test-dependencies.sh
+    ## Install the required dependencies with some retry
+    CI_UTILS=/usr/local/bin/bash_standard_lib.sh
+    if [ -e "${CI_UTILS}" ] ; then
+        # shellcheck disable=SC1090
+        source "${CI_UTILS}"
+        retry 3 source .ci/scripts/install-${SUITE}-test-dependencies.sh
+    else
+        source .ci/scripts/install-${SUITE}-test-dependencies.sh
+    fi
 else
     echo "Not installing test dependencies for ${SUITE}"
 fi

--- a/.ci/scripts/metricbeat-test.sh
+++ b/.ci/scripts/metricbeat-test.sh
@@ -15,5 +15,16 @@ set -euxo pipefail
 
 STACK_VERSION=${1:-'8.0.0-SNAPSHOT'}
 METRICBEAT_VERSION=${2:-'8.0.0-SNAPSHOT'}
+SUITE='metricbeat'
 
-.ci/scripts/functional-test.sh "metricbeat" "" "${STACK_VERSION}" "${METRICBEAT_VERSION}"
+## Install the required dependencies with some retry
+CI_UTILS=/usr/local/bin/bash_standard_lib.sh
+if [ -e "${CI_UTILS}" ] ; then
+    # shellcheck disable=SC1090
+    source "${CI_UTILS}"
+    retry 3 .ci/scripts/install-test-dependencies.sh "${SUITE}"
+else
+    .ci/scripts/install-test-dependencies.sh "${SUITE}"
+fi
+
+.ci/scripts/functional-test.sh "${SUITE}" "" "${STACK_VERSION}" "${METRICBEAT_VERSION}"

--- a/.ci/scripts/metricbeat-test.sh
+++ b/.ci/scripts/metricbeat-test.sh
@@ -17,14 +17,4 @@ STACK_VERSION=${1:-'8.0.0-SNAPSHOT'}
 METRICBEAT_VERSION=${2:-'8.0.0-SNAPSHOT'}
 SUITE='metricbeat'
 
-## Install the required dependencies with some retry
-CI_UTILS=/usr/local/bin/bash_standard_lib.sh
-if [ -e "${CI_UTILS}" ] ; then
-    # shellcheck disable=SC1090
-    source "${CI_UTILS}"
-    retry 3 .ci/scripts/install-test-dependencies.sh "${SUITE}"
-else
-    .ci/scripts/install-test-dependencies.sh "${SUITE}"
-fi
-
 .ci/scripts/functional-test.sh "${SUITE}" "" "${STACK_VERSION}" "${METRICBEAT_VERSION}"

--- a/.ci/scripts/metricbeat-test.sh
+++ b/.ci/scripts/metricbeat-test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+## Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+## or more contributor license agreements. Licensed under the Elastic License;
+## you may not use this file except in compliance with the Elastic License.
+
+set -euxo pipefail
+#
+# Run the functional tests for metricbeat using the functional-test wrapper
+#
+# Parameters:
+#   - STACK_VERSION - that's the version of the stack to be tested. Default '8.0.0-SNAPSHOT'.
+#   - METRICBEAT_VERSION - that's the version of the metricbeat to be tested. Default '8.0.0-SNAPSHOT'.
+#
+
+STACK_VERSION=${1:-'8.0.0-SNAPSHOT'}
+METRICBEAT_VERSION=${2:-'8.0.0-SNAPSHOT'}
+
+.ci/scripts/functional-test.sh "metricbeat" "" "${STACK_VERSION}" "${METRICBEAT_VERSION}"


### PR DESCRIPTION
## What does this PR do?

Enable metricbeat script to delegate all the logic to this repo then the consumer only need to call the script

## Why is it important?

Simplify the consumer calls

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have run the Unit tests for the CLI, and they are passing locally~~
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- ~~[ ] I have noticed new Go dependencies (run `make notice` in the proper directory)~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Run the script `.ci/scripts/metricbeat-test.sh`

## Related issues

Relates https://github.com/elastic/beats/pull/23854/

