### PR TITLE
fix: use x-pack dir for metricbeat binaries (#718) backport for 7.x

### DIFF
--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -317,7 +317,7 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 	if useCISnapshots || beatsLocalPath != "" {
 		artifactName := e2e.BuildArtifactName("metricbeat", mts.Version, metricbeatVersionBase, "linux", "amd64", "tar.gz", true)
 
-		imagePath, err := e2e.FetchBeatsBinary(artifactName, "metricbeat", mts.Version, metricbeatVersionBase, timeoutFactor, false)
+		imagePath, err := e2e.FetchBeatsBinary(artifactName, "metricbeat", mts.Version, metricbeatVersionBase, timeoutFactor, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: use x-pack dir for metricbeat binaries (#718)