### PR TITLE
fix: cover fallback cases for shell.GetEnv (#723) backport for 7.10.x

### DIFF
--- a/cli/shell/shell.go
+++ b/cli/shell/shell.go
@@ -69,7 +69,8 @@ func Execute(workspace string, command string, args ...string) (string, error) {
 
 // GetEnv returns an environment variable as string
 func GetEnv(envVar string, defaultValue string) string {
-	if value, exists := os.LookupEnv(envVar); exists {
+	value, exists := os.LookupEnv(envVar)
+	if exists && value != "" {
 		return value
 	}
 

--- a/cli/shell/shell_test.go
+++ b/cli/shell/shell_test.go
@@ -11,6 +11,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGetEnv(t *testing.T) {
+	t.Run("Empty value should return fallback", func(t *testing.T) {
+		defer os.Unsetenv("test.key")
+		os.Setenv("test.key", "")
+
+		val := GetEnv("test.key", "fallback")
+		assert.Equal(t, "fallback", val)
+	})
+
+	t.Run("Non existing key should return fallback", func(t *testing.T) {
+		val := GetEnv("test.key", "fallback")
+		assert.Equal(t, "fallback", val)
+	})
+
+	t.Run("Value should return value", func(t *testing.T) {
+		defer os.Unsetenv("test.key")
+		os.Setenv("test.key", "value")
+
+		val := GetEnv("test.key", "fallback")
+		assert.Equal(t, "value", val)
+	})
+}
+
 func TestGetEnvBool(t *testing.T) {
 	type test struct {
 		key   string


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - fix: cover fallback cases for shell.GetEnv (#723)