### PR TITLE
fix: use official repository for elasticsearch (#753) backport for 7.11.x

### DIFF
--- a/cli/config/compose/profiles/metricbeat/docker-compose.yml
+++ b/cli/config/compose/profiles/metricbeat/docker-compose.yml
@@ -9,6 +9,6 @@ services:
       - xpack.monitoring.collection.enabled=true
       - ELASTIC_USERNAME=elastic
       - ELASTIC_PASSWORD=changeme
-    image: "docker.elastic.co/observability-ci/elasticsearch:${stackVersion:-7.11.0-SNAPSHOT}"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:${stackVersion:-7.11.0-SNAPSHOT}"
     ports:
       - "9200:9200"


### PR DESCRIPTION
Backports the following commits to 7.11.x:
 - fix: use official repository for elasticsearch (#753)