### PR TITLE
fix: support selecting the platform in docker-compose (#751) backport for 7.11.x

### DIFF
--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -221,6 +221,9 @@ func sanitizeComposeFile(composeFilePath string, targetFilePath string) error {
 		return err
 	}
 
+	// sets version to 2.4 for testing purpose
+	c.Version = "2.4"
+
 	for k, srv := range c.Services {
 		// we'll copy all fields but the excluded ones in this struct
 		output := make(map[string]service)

--- a/cli/cmd/sync_test.go
+++ b/cli/cmd/sync_test.go
@@ -32,7 +32,7 @@ func TestSanitizeComposeFile_Multiple(t *testing.T) {
 	err = yaml.Unmarshal(bytes, &c)
 	assert.Nil(t, err)
 
-	assert.Equal(t, c.Version, "2.3")
+	assert.Equal(t, c.Version, "2.4")
 	assert.Equal(t, len(c.Services), 2)
 
 	// we know that both services have different number of ports
@@ -77,6 +77,6 @@ func TestSanitizeComposeFile_Single(t *testing.T) {
 	err = yaml.Unmarshal(bytes, &c)
 	assert.Nil(t, err)
 
-	assert.Equal(t, c.Version, "2.3")
+	assert.Equal(t, c.Version, "2.4")
 	assert.Equal(t, len(c.Services), 1)
 }

--- a/cli/config/compose/profiles/fleet/docker-compose.yml
+++ b/cli/config/compose/profiles/fleet/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   elasticsearch:
     healthcheck:

--- a/cli/config/compose/profiles/metricbeat/docker-compose.yml
+++ b/cli/config/compose/profiles/metricbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   elasticsearch:
     environment:

--- a/cli/config/compose/services/apm-server/docker-compose.yml
+++ b/cli/config/compose/services/apm-server/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   apm-server:
     environment:

--- a/cli/config/compose/services/centos-systemd/docker-compose.yml
+++ b/cli/config/compose/services/centos-systemd/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   centos-systemd:
     image: centos/systemd:${centos_systemdTag:-latest} 

--- a/cli/config/compose/services/centos/docker-compose.yml
+++ b/cli/config/compose/services/centos/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   centos:
     image: centos:${centosTag:-7}

--- a/cli/config/compose/services/debian-systemd/docker-compose.yml
+++ b/cli/config/compose/services/debian-systemd/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   debian-systemd:
     image: alehaa/debian-systemd:${debian_systemdTag:-stretch}

--- a/cli/config/compose/services/debian/docker-compose.yml
+++ b/cli/config/compose/services/debian/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   debian:
     image: debian:${debianTag:-9}

--- a/cli/config/compose/services/elastic-agent/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   elastic-agent:
     image: docker.elastic.co/${elasticAgentDockerNamespace:-beats}/elastic-agent${elasticAgentDockerImageSuffix}:${elasticAgentTag:-7.11.0-SNAPSHOT}
@@ -10,5 +10,6 @@ services:
         condition: service_healthy
     environment:
       - "KIBANA_HOST=http://${kibanaHost:-kibana}:${kibanaPort:-5601}"
+    platform: ${elasticAgentPlatform:-linux/amd64}
     volumes:
       - "${elasticAgentConfigFile}:/usr/share/elastic-agent/elastic-agent.yml"

--- a/cli/config/compose/services/elasticsearch/docker-compose.yml
+++ b/cli/config/compose/services/elasticsearch/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   elasticsearch:
     environment:

--- a/cli/config/compose/services/kibana/docker-compose.yml
+++ b/cli/config/compose/services/kibana/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   kibana:
     environment:

--- a/cli/config/compose/services/metricbeat/docker-compose.yml
+++ b/cli/config/compose/services/metricbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   metricbeat:
     command: [
@@ -17,5 +17,6 @@ services:
     image: "docker.elastic.co/${metricbeatDockerNamespace:-beats}/metricbeat:${metricbeatTag:-7.11.0-SNAPSHOT}"
     labels:
       co.elastic.logs/module: "${serviceName}"
+    platform: ${metricbeatPlatform:-linux/amd64}
     volumes:
       - "${metricbeatConfigFile}:/usr/share/metricbeat/metricbeat.yml"

--- a/cli/config/compose/services/opbeans-go/docker-compose.yml
+++ b/cli/config/compose/services/opbeans-go/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   opbeans-go:
     environment:

--- a/cli/config/compose/services/opbeans-java/docker-compose.yml
+++ b/cli/config/compose/services/opbeans-java/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   opbeans-java:
     environment:

--- a/cli/config/compose/services/vsphere/docker-compose.yml
+++ b/cli/config/compose/services/vsphere/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   vsphere:
     image: "nimmis/vcsim:${VSPHERE_VERSION}"

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -95,6 +95,7 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed(image string) error 
 
 	profileEnv["elasticAgentContainerName"] = containerName
 	profileEnv["elasticAgentConfigFile"] = sats.AgentConfigFilePath
+	profileEnv["elasticAgentPlatform"] = "linux/amd64"
 	profileEnv["elasticAgentTag"] = agentVersion
 
 	err = serviceManager.AddServicesToCompose(FleetProfileName, []string{ElasticAgentServiceName}, profileEnv)

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -359,6 +359,7 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 	}
 
 	env["metricbeatDockerNamespace"] = e2e.GetDockerNamespaceEnvVar()
+	env["metricbeatPlatform"] = "linux/amd64"
 
 	err := serviceManager.AddServicesToCompose("metricbeat", []string{"metricbeat"}, env)
 	if err != nil {


### PR DESCRIPTION
Backports the following commits to 7.11.x:
 - fix: support selecting the platform in docker-compose (#751)