### PR TITLE
chore: simplify synchronising the integrations (#761) | chore: go version cannot be overriden (#762) backport for 7.x

### DIFF
--- a/.ci/scripts/functional-test.sh
+++ b/.ci/scripts/functional-test.sh
@@ -20,8 +20,6 @@ SUITE=${1:-''}
 TAGS=${2:-''}
 STACK_VERSION=${3:-'7.x-SNAPSHOT'}
 METRICBEAT_VERSION=${4:-'7.x-SNAPSHOT'}
-TARGET_OS=${GOOS:-linux}
-TARGET_ARCH=${GOARCH:-amd64}
 
 ## Install the required dependencies for the given SUITE
 .ci/scripts/install-test-dependencies.sh "${SUITE}"

--- a/.ci/scripts/install-metricbeat-test-dependencies.sh
+++ b/.ci/scripts/install-metricbeat-test-dependencies.sh
@@ -6,18 +6,9 @@
 
 set -euxo pipefail
 #
-# Install the dependencies using the install and test make goals.
+# Install the dependencies using the sync-integrations make goal.
 #
-# Parameters:
-#   - GOOS - that's the name of the O.S. used to build the binary
-#   - GOARCH - that's the name of the architecture of the O.S. used to build the binary.
 #
-
-TARGET_OS=${GOOS:-linux}
-TARGET_ARCH=${GOARCH:-amd64}
-
-# Build OP Binary
-GOOS=${TARGET_OS} GOARCH=${TARGET_ARCH} make -C e2e fetch-binary
 
 # Sync integrations
-make -C e2e sync-integrations
+make -C cli sync-integrations

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -4,7 +4,7 @@ ROOT_DIR:=$(CURDIR)
 TEST_TIMEOUT?=5m
 
 GO_IMAGE?='golang'
-GO_VERSION?='$(shell cat ../.go-version )'
+GO_VERSION='$(shell cat ../.go-version )'
 GO_IMAGE_TAG?='stretch'
 GOOS?='linux'
 GOARCH?='amd64'

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -8,6 +8,7 @@ GO_VERSION?='$(shell cat ../.go-version )'
 GO_IMAGE_TAG?='stretch'
 GOOS?='linux'
 GOARCH?='amd64'
+LOG_LEVEL?=INFO
 
 .PHONY: build
 build:
@@ -34,6 +35,10 @@ notice:
 		-noticeTemplate ../notice/NOTICE.txt.tmpl \
 		-noticeOut NOTICE.txt \
 		-depsOut ""
+
+.PHONY: sync-integrations
+sync-integrations:
+	OP_LOG_LEVEL=${LOG_LEVEL} go run main.go sync integrations --delete
 
 .PHONY: test
 test:

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -41,12 +41,6 @@ build-docs:
 	mv docs/.\\/index.html docs/index.html
 	rm -fr docs/.\\
 
-.PHONY: fetch-binary
-fetch-binary:
-	@$(MAKE) -C ../cli build
-	cp ../cli/.github/releases/download/$(VERSION_VALUE)/$(GOOS)$(subst amd,,$(GOARCH))-op ./op
-	chmod +x ./op
-
 .PHONY: install
 install:
 	go get -v -t ./...
@@ -82,10 +76,6 @@ notice:
 		-noticeTemplate ../notice/NOTICE.txt.tmpl \
 		-noticeOut NOTICE.txt \
 		-depsOut ""
-
-.PHONY: sync-integrations
-sync-integrations:
-	OP_LOG_LEVEL=${LOG_LEVEL} ./op sync integrations --delete
 
 .PHONY: unit-test
 unit-test:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - chore: simplify synchronising the integrations (#761)
 - chore: go version cannot be overriden (#762)