### PR TITLE
chore: tag docker image after loading it from a file (#772) backport for 7.11.x

### DIFF
--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -206,6 +206,27 @@ func LoadImage(imagePath string) error {
 	return nil
 }
 
+// TagImage tags an existing src image into a target one
+func TagImage(src string, target string) error {
+	dockerClient := getDockerClient()
+
+	err := dockerClient.ImageTag(context.Background(), src, target)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":  err,
+			"src":    src,
+			"target": target,
+		}).Error("Could not tag the Docker image.")
+		return err
+	}
+
+	log.WithFields(log.Fields{
+		"src":    src,
+		"target": target,
+	}).Debug("Docker image tagged successfully")
+	return nil
+}
+
 // RemoveDevNetwork removes the developer network
 func RemoveDevNetwork() error {
 	dockerClient := getDockerClient()

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -387,7 +387,7 @@ func newDockerInstaller(ubi8 bool, version string) (ElasticAgentInstaller, error
 		WithArch(arch).
 		WithArtifact(artifact).
 		WithOS(os).
-		WithVersion(e2e.CheckPRVersion(version, agentVersionBase)) // sanitize version
+		WithVersion(version)
 
 	return ElasticAgentInstaller{
 		artifactArch:      arch,

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -405,6 +405,11 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 		if err != nil {
 			return err
 		}
+
+		err = docker.TagImage(
+			"docker.elastic.co/beats/metricbeat:"+metricbeatVersionBase,
+			"docker.elastic.co/observability-ci/metricbeat:"+mts.Version,
+		)
 	}
 
 	// this is needed because, in general, the target service (apache, mysql, redis) does not have a healthcheck


### PR DESCRIPTION
Backports the following commits to 7.11.x:
 - chore: tag docker image after loading it from a file (#772)