### PR TITLE
Fleet entrypoint to exclude the nightly tests

### DIFF
--- a/.ci/scripts/fleet-test.sh
+++ b/.ci/scripts/fleet-test.sh
@@ -15,4 +15,9 @@ set -euxo pipefail
 STACK_VERSION=${1:-'8.0.0-SNAPSHOT'}
 SUITE='fleet'
 
-.ci/scripts/functional-test.sh "${SUITE}" "" "${STACK_VERSION}"
+# Exclude the nightly tests in the CI.
+# For further details refers to:
+#   https://github.com/elastic/e2e-testing/blob/dcc950796120fabf0c85086823cef221cf3ecbcb/.ci/Jenkinsfile#L316-L323
+TAG="~@nightly"
+
+.ci/scripts/functional-test.sh "${SUITE}" "${TAG}" "${STACK_VERSION}"


### PR DESCRIPTION
## What does this PR do?

exclude the nightly tests

## Why is it important?

Nightly tests are running only on `nightly` basis, let's use the same logic in the script, similar to the one defined in the pipeline -> https://github.com/elastic/e2e-testing/blob/dcc950796120fabf0c85086823cef221cf3ecbcb/.ci/Jenkinsfile#L316-L323

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

## How to test this PR locally

Run the script itself
