### PR TITLE
Fleet entrypoint to exclude the nightly tests (#793) backport for 6.8.x

### DIFF
--- a/.ci/scripts/fleet-test.sh
+++ b/.ci/scripts/fleet-test.sh
@@ -15,4 +15,9 @@ set -euxo pipefail
 STACK_VERSION=${1:-'8.0.0-SNAPSHOT'}
 SUITE='fleet'
 
-.ci/scripts/functional-test.sh "${SUITE}" "" "${STACK_VERSION}"
+# Exclude the nightly tests in the CI.
+# For further details refers to:
+#   https://github.com/elastic/e2e-testing/blob/dcc950796120fabf0c85086823cef221cf3ecbcb/.ci/Jenkinsfile#L316-L323
+TAG="~@nightly"
+
+.ci/scripts/functional-test.sh "${SUITE}" "${TAG}" "${STACK_VERSION}"


### PR DESCRIPTION
Backports the following commits to 6.8.x:
 - Fleet entrypoint to exclude the nightly tests (#793)