### PR TITLE
invalid option (#792) backport for 7.10.x

### DIFF
--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -85,7 +85,7 @@ func (i *DEBPackage) InstallCerts() error {
 	if err := execCommandInService(i.profile, i.image, i.service, []string{"apt", "install", "ca-certificates", "-y"}, false); err != nil {
 		return err
 	}
-	if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-certificates", "f"}, false); err != nil {
+	if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-certificates", "-f"}, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Backports the following commits to 7.10.x:
 - invalid option (#792)