### PR TITLE
fix: update flags for the enroll command

### DIFF
--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -71,6 +71,10 @@ func (i *ElasticAgentInstaller) getElasticAgentHash(containerName string) (strin
 	return getElasticAgentHash(containerName, commitFile)
 }
 
+func buildEnrollmentFlags(token string) []string {
+	return []string{"--url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
+}
+
 func getElasticAgentHash(containerName string, commitFile string) (string, error) {
 	cmd := []string{
 		"cat", commitFile,
@@ -240,9 +244,7 @@ func newCentosInstaller(image string, tag string, version string) (ElasticAgentI
 	}
 
 	enrollFn := func(token string) error {
-		args := []string{"--url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
-
-		return runElasticAgentCommand(profile, image, service, ElasticAgentProcessName, "enroll", args)
+		return runElasticAgentCommand(profile, image, service, ElasticAgentProcessName, "enroll", buildEnrollmentFlags(token))
 	}
 
 	binDir := "/var/lib/elastic-agent/data/elastic-agent-%s/"
@@ -305,9 +307,7 @@ func newDebianInstaller(image string, tag string, version string) (ElasticAgentI
 	}
 
 	enrollFn := func(token string) error {
-		args := []string{"--url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
-
-		return runElasticAgentCommand(profile, image, service, ElasticAgentProcessName, "enroll", args)
+		return runElasticAgentCommand(profile, image, service, ElasticAgentProcessName, "enroll", buildEnrollmentFlags(token))
 	}
 
 	binDir := "/var/lib/elastic-agent/data/elastic-agent-%s/"
@@ -450,9 +450,7 @@ func newTarInstaller(image string, tag string, version string) (ElasticAgentInst
 	binDir := "/usr/bin/"
 
 	enrollFn := func(token string) error {
-		args := []string{"--url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
-
-		return runElasticAgentCommand(profile, image, service, ElasticAgentProcessName, "enroll", args)
+		return runElasticAgentCommand(profile, image, service, ElasticAgentProcessName, "enroll", buildEnrollmentFlags(token))
 	}
 
 	//

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -240,7 +240,7 @@ func newCentosInstaller(image string, tag string, version string) (ElasticAgentI
 	}
 
 	enrollFn := func(token string) error {
-		args := []string{"http://kibana:5601", token, "-f", "--insecure"}
+		args := []string{"--url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
 
 		return runElasticAgentCommand(profile, image, service, ElasticAgentProcessName, "enroll", args)
 	}
@@ -305,7 +305,7 @@ func newDebianInstaller(image string, tag string, version string) (ElasticAgentI
 	}
 
 	enrollFn := func(token string) error {
-		args := []string{"http://kibana:5601", token, "-f", "--insecure"}
+		args := []string{"--url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
 
 		return runElasticAgentCommand(profile, image, service, ElasticAgentProcessName, "enroll", args)
 	}
@@ -450,7 +450,7 @@ func newTarInstaller(image string, tag string, version string) (ElasticAgentInst
 	binDir := "/usr/bin/"
 
 	enrollFn := func(token string) error {
-		args := []string{"http://kibana:5601", token, "-f", "--insecure"}
+		args := []string{"--url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
 
 		return runElasticAgentCommand(profile, image, service, ElasticAgentProcessName, "enroll", args)
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR appends the `--url=` flag to the Kibana URL and the `--enrollment-token=` flag to the API token arguments when enrolling an agent using Fleet mode.

As it's used in three different places, we are extracting the array representing the arguments to a builder method (it requires a token), so that further updates will affect only one place.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The enrollment command changed in https://github.com/elastic/beats/pull/24155

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's checklist
<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] @michalpristas does the install command call need to be updated?
- [ ] For install command, Kibana flag uses `--kibana-url`, while for the enroll command uses `--url`. Is this inconsistency on purpose?

## How to test this PR locally

```shell
SUITE="fleet" TAGS="fleet_mode_agent && install" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true ELASTIC_APM_ACTIVE=false make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Caused by https://github.com/elastic/beats/pull/24155
- Fixes #803



<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->



<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->



<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->



<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->