### PR TITLE
chore: add logs when OS certs are not installed for the upgrade scenario

### DIFF
--- a/e2e/_suites/fleet/features/fleet_mode_agent.feature
+++ b/e2e/_suites/fleet/features/fleet_mode_agent.feature
@@ -43,7 +43,7 @@ Examples:
 @nightly
 Scenario Outline: Upgrading the installed <os> agent
   Given a "<os>" agent "stale" is deployed to Fleet with "tar" installer
-    And certs for "<os>" are installed
+    And certs are installed
     And the "elastic-agent" process is "restarted" on the host
   When agent is upgraded to version "latest"
   Then agent is in version "latest"

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -187,7 +187,20 @@ func (fts *FleetTestSuite) installCerts(targetOS string) error {
 		return errors.New("no installer found")
 	}
 
-	return installer.InstallCertsFn()
+	err := installer.InstallCertsFn()
+	if err != nil {
+		log.WithFields(log.Fields{
+			"agentVersion":      agentVersion,
+			"agentStaleVersion": agentStaleVersion,
+			"error":             err,
+			"installer":         installer,
+			"targetOS":          targetOS,
+			"version":           fts.Version,
+		}).Error("Could not install the certificates")
+		return err
+	}
+
+	return nil
 }
 
 func (fts *FleetTestSuite) anAgentIsUpgraded(desiredVersion string) error {

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -138,7 +138,7 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.ScenarioContext) {
 	s.Step(`^an attempt to enroll a new agent fails$`, fts.anAttemptToEnrollANewAgentFails)
 	s.Step(`^the "([^"]*)" process is "([^"]*)" on the host$`, fts.processStateChangedOnTheHost)
 	s.Step(`^the file system Agent folder is empty$`, fts.theFileSystemAgentFolderIsEmpty)
-	s.Step(`^certs for "([^"]*)" are installed$`, fts.installCerts)
+	s.Step(`^certs are installed$`, fts.installCerts)
 
 	// endpoint steps
 	s.Step(`^the "([^"]*)" integration is "([^"]*)" in the policy$`, fts.theIntegrationIsOperatedInThePolicy)
@@ -175,7 +175,7 @@ func (fts *FleetTestSuite) anStaleAgentIsDeployedToFleetWithInstaller(image, ver
 	return fts.anAgentIsDeployedToFleetWithInstaller(image, installerType)
 }
 
-func (fts *FleetTestSuite) installCerts(targetOS string) error {
+func (fts *FleetTestSuite) installCerts() error {
 	installer := fts.getInstaller()
 	if installer.InstallCertsFn == nil {
 		log.WithFields(log.Fields{
@@ -194,7 +194,6 @@ func (fts *FleetTestSuite) installCerts(targetOS string) error {
 			"agentStaleVersion": agentStaleVersion,
 			"error":             err,
 			"installer":         installer,
-			"targetOS":          targetOS,
 			"version":           fts.Version,
 		}).Error("Could not install the certificates")
 		return err

--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -255,10 +255,11 @@ func (i *RPMPackage) Uninstall() error {
 type TARPackage struct {
 	BasePackage
 	// optional fields
-	arch     string
-	artifact string
-	OS       string
-	version  string
+	arch      string
+	artifact  string
+	OS        string
+	OSFlavour string // at this moment, centos or debian
+	version   string
 }
 
 // NewTARPackage creates an instance for the RPM installer
@@ -360,6 +361,12 @@ func (i *TARPackage) WithArtifact(artifact string) *TARPackage {
 // WithOS sets the OS
 func (i *TARPackage) WithOS(OS string) *TARPackage {
 	i.OS = OS
+	return i
+}
+
+// WithOSFlavour sets the OS flavour, at this moment centos or debian
+func (i *TARPackage) WithOSFlavour(OSFlavour string) *TARPackage {
+	i.OSFlavour = OSFlavour
 	return i
 }
 

--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -288,16 +288,31 @@ func (i *TARPackage) Install(containerName string, token string) error {
 	return nil
 }
 
-// InstallCerts installs the certificates for a TAR package
+// InstallCerts installs the certificates for a TAR package, using the right OS package manager
 func (i *TARPackage) InstallCerts() error {
-	if err := execCommandInService(i.profile, i.image, i.service, []string{"apt-get", "update"}, false); err != nil {
-		return err
-	}
-	if err := execCommandInService(i.profile, i.image, i.service, []string{"apt", "install", "ca-certificates", "-y"}, false); err != nil {
-		return err
-	}
-	if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-certificates", "-f"}, false); err != nil {
-		return err
+	if i.OSFlavour == "centos" {
+		if err := execCommandInService(i.profile, i.image, i.service, []string{"yum", "check-update"}, false); err != nil {
+			return err
+		}
+		if err := execCommandInService(i.profile, i.image, i.service, []string{"yum", "install", "ca-certificates", "-y"}, false); err != nil {
+			return err
+		}
+		if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-trust", "force-enable"}, false); err != nil {
+			return err
+		}
+		if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-trust", "extract"}, false); err != nil {
+			return err
+		}
+	} else if i.OSFlavour == "debian" {
+		if err := execCommandInService(i.profile, i.image, i.service, []string{"apt-get", "update"}, false); err != nil {
+			return err
+		}
+		if err := execCommandInService(i.profile, i.image, i.service, []string{"apt", "install", "ca-certificates", "-y"}, false); err != nil {
+			return err
+		}
+		if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-certificates", "-f"}, false); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -300,6 +300,12 @@ func (i *TARPackage) InstallCerts() error {
 		return installCertsForDebian(i.profile, i.image, i.service)
 	}
 
+	log.WithFields(log.Fields{
+		"arch":      i.arch,
+		"OS":        i.OS,
+		"OSFlavour": i.OSFlavour,
+	}).Debug("Installation of certificates was skipped because of unknown OS flavour")
+
 	return nil
 }
 

--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -80,16 +80,18 @@ func (i *DEBPackage) Install(containerName string, token string) error {
 
 // InstallCerts installs the certificates for a DEB package
 func (i *DEBPackage) InstallCerts() error {
-	if err := execCommandInService(i.profile, i.image, i.service, []string{"apt-get", "update"}, false); err != nil {
+	return installCertsForDebian(i.profile, i.image, i.service)
+}
+func installCertsForDebian(profile string, image string, service string) error {
+	if err := execCommandInService(profile, image, service, []string{"apt-get", "update"}, false); err != nil {
 		return err
 	}
-	if err := execCommandInService(i.profile, i.image, i.service, []string{"apt", "install", "ca-certificates", "-y"}, false); err != nil {
+	if err := execCommandInService(profile, image, service, []string{"apt", "install", "ca-certificates", "-y"}, false); err != nil {
 		return err
 	}
-	if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-certificates", "-f"}, false); err != nil {
+	if err := execCommandInService(profile, image, service, []string{"update-ca-certificates", "-f"}, false); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -223,19 +225,21 @@ func (i *RPMPackage) Install(containerName string, token string) error {
 
 // InstallCerts installs the certificates for a RPM package
 func (i *RPMPackage) InstallCerts() error {
-	if err := execCommandInService(i.profile, i.image, i.service, []string{"yum", "check-update"}, false); err != nil {
+	return installCertsForCentos(i.profile, i.image, i.service)
+}
+func installCertsForCentos(profile string, image string, service string) error {
+	if err := execCommandInService(profile, image, service, []string{"yum", "check-update"}, false); err != nil {
 		return err
 	}
-	if err := execCommandInService(i.profile, i.image, i.service, []string{"yum", "install", "ca-certificates", "-y"}, false); err != nil {
+	if err := execCommandInService(profile, image, service, []string{"yum", "install", "ca-certificates", "-y"}, false); err != nil {
 		return err
 	}
-	if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-trust", "force-enable"}, false); err != nil {
+	if err := execCommandInService(profile, image, service, []string{"update-ca-trust", "force-enable"}, false); err != nil {
 		return err
 	}
-	if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-trust", "extract"}, false); err != nil {
+	if err := execCommandInService(profile, image, service, []string{"update-ca-trust", "extract"}, false); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -291,28 +295,9 @@ func (i *TARPackage) Install(containerName string, token string) error {
 // InstallCerts installs the certificates for a TAR package, using the right OS package manager
 func (i *TARPackage) InstallCerts() error {
 	if i.OSFlavour == "centos" {
-		if err := execCommandInService(i.profile, i.image, i.service, []string{"yum", "check-update"}, false); err != nil {
-			return err
-		}
-		if err := execCommandInService(i.profile, i.image, i.service, []string{"yum", "install", "ca-certificates", "-y"}, false); err != nil {
-			return err
-		}
-		if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-trust", "force-enable"}, false); err != nil {
-			return err
-		}
-		if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-trust", "extract"}, false); err != nil {
-			return err
-		}
+		return installCertsForCentos(i.profile, i.image, i.service)
 	} else if i.OSFlavour == "debian" {
-		if err := execCommandInService(i.profile, i.image, i.service, []string{"apt-get", "update"}, false); err != nil {
-			return err
-		}
-		if err := execCommandInService(i.profile, i.image, i.service, []string{"apt", "install", "ca-certificates", "-y"}, false); err != nil {
-			return err
-		}
-		if err := execCommandInService(i.profile, i.image, i.service, []string{"update-ca-certificates", "-f"}, false); err != nil {
-			return err
-		}
+		return installCertsForDebian(i.profile, i.image, i.service)
 	}
 
 	return nil

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -421,8 +421,8 @@ func newDockerInstaller(ubi8 bool, version string) (ElasticAgentInstaller, error
 
 // newTarInstaller returns an instance of the Debian installer for a specific version
 func newTarInstaller(image string, tag string, version string) (ElasticAgentInstaller, error) {
-	image = image + "-systemd" // we want to consume systemd boxes
-	service := image
+	dockerImage := image + "-systemd" // we want to consume systemd boxes
+	service := dockerImage
 	profile := FleetProfileName
 
 	// extract the agent in the box, as it's mounted as a volume
@@ -452,14 +452,15 @@ func newTarInstaller(image string, tag string, version string) (ElasticAgentInst
 	enrollFn := func(token string) error {
 		args := []string{"http://kibana:5601", token, "-f", "--insecure"}
 
-		return runElasticAgentCommand(profile, image, service, ElasticAgentProcessName, "enroll", args)
+		return runElasticAgentCommand(profile, dockerImage, service, ElasticAgentProcessName, "enroll", args)
 	}
 
 	//
-	installerPackage := NewTARPackage(binaryName, profile, image, service).
+	installerPackage := NewTARPackage(binaryName, profile, dockerImage, service).
 		WithArch(arch).
 		WithArtifact(artifact).
 		WithOS(os).
+		WithOSFlavour(image).
 		WithVersion(e2e.CheckPRVersion(version, agentVersionBase)) // sanitize version
 
 	return ElasticAgentInstaller{
@@ -472,7 +473,7 @@ func newTarInstaller(image string, tag string, version string) (ElasticAgentInst
 		commitFile:        commitFile,
 		EnrollFn:          enrollFn,
 		homeDir:           homeDir,
-		image:             image,
+		image:             dockerImage,
 		InstallFn:         installerPackage.Install,
 		InstallCertsFn:    installerPackage.InstallCerts,
 		installerType:     "tar",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR logs the error happened when the install certificates code fails. Adding this log, we noticed that the test scenario for the installation of the certificates was using an input parameter (`os`) that was not used, so we are removing it in consequence.

After that removal, we noticed that the TAR installer was not complete in the sense that the certs installation function was coupled to Debian only. This is working for the current implementation but could be misleading for future scenarios that would want to upgrade a Centos-based agent. For that reason, in this PR we are supporting the TAR installer package to know about the OS flavour that will be used to install the agent (centos or debian), and with that value, the install certs function will be able to call the proper package manager (`yum` or `apt`).

In this last refactor, we extracted that code to be reusable, as it was used in two different places.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We have seen a few times errors on CI about the certificates not being installed, and want to add visibility on those errors (before this change, the error was simply thrown without logs).

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

```shell
SUITE="fleet" TAGS="fleet_mode_agent && reenroll" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true ELASTIC_APM_ACTIVE=false make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->




<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->



<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->



<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->



<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->