### PR TITLE
chore: add logs when OS certs are not installed for the upgrade scenario (#809) backport for 7.11.x

### DIFF
--- a/e2e/_suites/fleet/features/fleet_mode_agent.feature
+++ b/e2e/_suites/fleet/features/fleet_mode_agent.feature
@@ -43,7 +43,7 @@ Examples:
 @nightly
 Scenario Outline: Upgrading the installed <os> agent
   Given a "<os>" agent "stale" is deployed to Fleet with "tar" installer
-    And certs for "<os>" are installed
+    And certs are installed
     And the "elastic-agent" process is "restarted" on the host
   When agent is upgraded to version "latest"
   Then agent is in version "latest"

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -138,7 +138,7 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.ScenarioContext) {
 	s.Step(`^an attempt to enroll a new agent fails$`, fts.anAttemptToEnrollANewAgentFails)
 	s.Step(`^the "([^"]*)" process is "([^"]*)" on the host$`, fts.processStateChangedOnTheHost)
 	s.Step(`^the file system Agent folder is empty$`, fts.theFileSystemAgentFolderIsEmpty)
-	s.Step(`^certs for "([^"]*)" are installed$`, fts.installCerts)
+	s.Step(`^certs are installed$`, fts.installCerts)
 
 	// endpoint steps
 	s.Step(`^the "([^"]*)" integration is "([^"]*)" in the policy$`, fts.theIntegrationIsOperatedInThePolicy)
@@ -175,7 +175,7 @@ func (fts *FleetTestSuite) anStaleAgentIsDeployedToFleetWithInstaller(image, ver
 	return fts.anAgentIsDeployedToFleetWithInstaller(image, installerType)
 }
 
-func (fts *FleetTestSuite) installCerts(targetOS string) error {
+func (fts *FleetTestSuite) installCerts() error {
 	installer := fts.getInstaller()
 	if installer.InstallCertsFn == nil {
 		log.WithFields(log.Fields{
@@ -187,7 +187,19 @@ func (fts *FleetTestSuite) installCerts(targetOS string) error {
 		return errors.New("no installer found")
 	}
 
-	return installer.InstallCertsFn()
+	err := installer.InstallCertsFn()
+	if err != nil {
+		log.WithFields(log.Fields{
+			"agentVersion":      agentVersion,
+			"agentStaleVersion": agentStaleVersion,
+			"error":             err,
+			"installer":         installer,
+			"version":           fts.Version,
+		}).Error("Could not install the certificates")
+		return err
+	}
+
+	return nil
 }
 
 func (fts *FleetTestSuite) anAgentIsUpgraded(desiredVersion string) error {


### PR DESCRIPTION
Backports the following commits to 7.11.x:
 - chore: add logs when OS certs are not installed for the upgrade scenario (#809)