### PR TITLE
chore: download installers when they are used (#810) backport for 7.x

### DIFF
--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -312,7 +312,17 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleetWithInstaller(image string, i
 }
 
 func (fts *FleetTestSuite) getInstaller() ElasticAgentInstaller {
-	return fts.Installers[fts.Image+"-"+fts.InstallerType+"-"+fts.Version]
+	// check if the agent is already cached
+	if i, exists := fts.Installers[fts.Image+"-"+fts.InstallerType+"-"+fts.Version]; exists {
+		return i
+	}
+
+	installer := GetElasticAgentInstaller(fts.Image, fts.InstallerType, fts.Version)
+
+	// cache the new installer
+	fts.Installers[fts.Image+"-"+fts.InstallerType+"-"+fts.Version] = installer
+
+	return installer
 }
 
 func (fts *FleetTestSuite) processStateChangedOnTheHost(process string, state string) error {

--- a/e2e/_suites/fleet/ingest-manager_test.go
+++ b/e2e/_suites/fleet/ingest-manager_test.go
@@ -99,14 +99,7 @@ func setUpSuite() {
 
 	imts = IngestManagerTestSuite{
 		Fleet: &FleetTestSuite{
-			Installers: map[string]ElasticAgentInstaller{
-				"centos-systemd-" + agentVersion: GetElasticAgentInstaller("centos", "systemd", agentVersion),
-				"centos-tar-" + agentVersion:     GetElasticAgentInstaller("centos", "tar", agentVersion),
-				"debian-systemd-" + agentVersion: GetElasticAgentInstaller("debian", "systemd", agentVersion),
-				"debian-tar-" + agentVersion:     GetElasticAgentInstaller("debian", "tar", agentVersion),
-				"docker-default-" + agentVersion: GetElasticAgentInstaller("docker", "default", agentVersion),
-				"docker-ubi8-" + agentVersion:    GetElasticAgentInstaller("docker", "ubi8", agentVersion),
-			},
+			Installers: map[string]ElasticAgentInstaller{}, // do not pre-initialise the map
 		},
 		StandAlone: &StandAloneTestSuite{},
 	}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - chore: download installers when they are used (#810)