### PR TITLE
feat: always print agent logs in Fleet mode

### DIFF
--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -60,7 +60,7 @@ func (fts *FleetTestSuite) afterScenario() {
 		installer := fts.getInstaller()
 
 		if developerMode {
-			_ = installer.getElasticAgentLogs(fts.Hostname)
+			_ = installer.PrintLogsFn(fts.Hostname)
 		}
 
 		// only call it when the elastic-agent is present

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -35,15 +35,16 @@ const actionREMOVED = "removed"
 
 // FleetTestSuite represents the scenarios for Fleet-mode
 type FleetTestSuite struct {
-	Image          string // base image used to install the agent
-	InstallerType  string
-	Installers     map[string]ElasticAgentInstaller
-	Cleanup        bool
-	PolicyID       string // will be used to manage tokens
-	CurrentToken   string // current enrollment token
-	CurrentTokenID string // current enrollment tokenID
-	Hostname       string // the hostname of the container
-	Version        string // current elastic-agent version
+	Image               string // base image used to install the agent
+	InstallerType       string
+	Installers          map[string]ElasticAgentInstaller
+	Cleanup             bool
+	ElasticAgentStopped bool   // will be used to signal when the agent process can be called again in the tear-down stage
+	PolicyID            string // will be used to manage tokens
+	CurrentToken        string // current enrollment token
+	CurrentTokenID      string // current enrollment tokenID
+	Hostname            string // the hostname of the container
+	Version             string // current elastic-agent version
 	// integrations
 	Integration     IntegrationPackage // the installed integration
 	PolicyUpdatedAt string             // the moment the policy was updated
@@ -62,9 +63,12 @@ func (fts *FleetTestSuite) afterScenario() {
 			_ = installer.getElasticAgentLogs(fts.Hostname)
 		}
 
-		err := installer.UninstallFn()
-		if err != nil {
-			log.Warnf("Could not uninstall the agent after the scenario: %v", err)
+		// only call it when the elastic-agent is present
+		if !fts.ElasticAgentStopped {
+			err := installer.UninstallFn()
+			if err != nil {
+				log.Warnf("Could not uninstall the agent after the scenario: %v", err)
+			}
 		}
 	}
 
@@ -108,6 +112,7 @@ func (fts *FleetTestSuite) afterScenario() {
 // beforeScenario creates the state needed by a scenario
 func (fts *FleetTestSuite) beforeScenario() {
 	fts.Cleanup = false
+	fts.ElasticAgentStopped = false
 
 	fts.Version = agentVersion
 
@@ -337,7 +342,17 @@ func (fts *FleetTestSuite) processStateChangedOnTheHost(process string, state st
 	} else if state == "restarted" {
 		return systemctlRun(profile, installer.image, serviceName, "restart")
 	} else if state == "uninstalled" {
-		return installer.UninstallFn()
+		err := installer.UninstallFn()
+		if err != nil {
+			return err
+		}
+
+		// signal that the elastic-agent was uninstalled
+		if process == ElasticAgentProcessName {
+			fts.ElasticAgentStopped = true
+		}
+
+		return nil
 	} else if state != "stopped" {
 		return godog.ErrPending
 	}

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -59,9 +59,7 @@ func (fts *FleetTestSuite) afterScenario() {
 	if log.IsLevelEnabled(log.DebugLevel) {
 		installer := fts.getInstaller()
 
-		if developerMode {
-			_ = installer.PrintLogsFn(fts.Hostname)
-		}
+		_ = installer.PrintLogsFn(fts.Hostname)
 
 		// only call it when the elastic-agent is present
 		if !fts.ElasticAgentStopped {

--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/elastic/e2e-testing/cli/docker"
@@ -18,6 +19,7 @@ import (
 type InstallerPackage interface {
 	Install(containerName string, token string) error
 	InstallCerts() error
+	PrintLogs(containerName string) error
 	Postinstall() error
 	Preinstall() error
 	Uninstall() error
@@ -26,7 +28,9 @@ type InstallerPackage interface {
 // BasePackage holds references to basic state for all installers
 type BasePackage struct {
 	binaryName string
+	commitFile string
 	image      string
+	logFile    string
 	profile    string
 	service    string
 }
@@ -57,16 +61,51 @@ func (i *BasePackage) Postinstall() error {
 	return systemctlRun(i.profile, i.image, i.service, "start")
 }
 
+// PrintLogs prints logs for the agent
+func (i *BasePackage) PrintLogs(containerName string) error {
+	hash, err := getElasticAgentHash(containerName, i.commitFile)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"containerName": containerName,
+			"error":         err,
+		}).Error("Could not get agent hash in the container")
+
+		return err
+	}
+
+	if strings.Contains(i.logFile, "%s") {
+		i.logFile = fmt.Sprintf(i.logFile, hash)
+	}
+	cmd := []string{
+		"cat", i.logFile,
+	}
+
+	err = execCommandInService(i.profile, i.image, i.service, cmd, false)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"containerName": containerName,
+			"command":       cmd,
+			"error":         err,
+			"hash":          hash,
+		}).Error("Could not get agent logs in the container")
+
+		return err
+	}
+
+	return nil
+}
+
 // DEBPackage implements operations for a DEB installer
 type DEBPackage struct {
 	BasePackage
 }
 
 // NewDEBPackage creates an instance for the DEB installer
-func NewDEBPackage(binaryName string, profile string, image string, service string) *DEBPackage {
+func NewDEBPackage(binaryName string, profile string, image string, service string, commitFile string, logFile string) *DEBPackage {
 	return &DEBPackage{
 		BasePackage: BasePackage{
 			binaryName: binaryName,
+			commitFile: commitFile,
 			image:      image,
 			profile:    profile,
 			service:    service,
@@ -122,11 +161,13 @@ type DockerPackage struct {
 }
 
 // NewDockerPackage creates an instance for the Docker installer
-func NewDockerPackage(binaryName string, profile string, image string, service string, installerPath string, ubi8 bool) *DockerPackage {
+func NewDockerPackage(binaryName string, profile string, image string, service string, installerPath string, ubi8 bool, commitFile string, logFile string) *DockerPackage {
 	return &DockerPackage{
 		BasePackage: BasePackage{
 			binaryName: binaryName,
+			commitFile: commitFile,
 			image:      image,
+			logFile:    logFile,
 			profile:    profile,
 			service:    service,
 		},
@@ -208,11 +249,13 @@ type RPMPackage struct {
 }
 
 // NewRPMPackage creates an instance for the RPM installer
-func NewRPMPackage(binaryName string, profile string, image string, service string) *RPMPackage {
+func NewRPMPackage(binaryName string, profile string, image string, service string, commitFile string, logFile string) *RPMPackage {
 	return &RPMPackage{
 		BasePackage: BasePackage{
 			binaryName: binaryName,
+			commitFile: commitFile,
 			image:      image,
+			logFile:    logFile,
 			profile:    profile,
 			service:    service,
 		},
@@ -268,11 +311,13 @@ type TARPackage struct {
 }
 
 // NewTARPackage creates an instance for the RPM installer
-func NewTARPackage(binaryName string, profile string, image string, service string) *TARPackage {
+func NewTARPackage(binaryName string, profile string, image string, service string, commitFile string, logFile string) *TARPackage {
 	return &TARPackage{
 		BasePackage: BasePackage{
 			binaryName: binaryName,
+			commitFile: commitFile,
 			image:      image,
+			logFile:    logFile,
 			profile:    profile,
 			service:    service,
 		},

--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -63,30 +63,30 @@ func (i *BasePackage) Postinstall() error {
 
 // PrintLogs prints logs for the agent
 func (i *BasePackage) PrintLogs(containerName string) error {
-	hash, err := getElasticAgentHash(containerName, i.commitFile)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"containerName": containerName,
-			"error":         err,
-		}).Error("Could not get agent hash in the container")
-
-		return err
-	}
-
 	if strings.Contains(i.logFile, "%s") {
+		hash, err := getElasticAgentHash(containerName, i.commitFile)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"containerName": containerName,
+				"error":         err,
+			}).Error("Could not get agent hash in the container")
+
+			return err
+		}
+
 		i.logFile = fmt.Sprintf(i.logFile, hash)
 	}
 	cmd := []string{
 		"cat", i.logFile,
 	}
 
-	err = execCommandInService(i.profile, i.image, i.service, cmd, false)
+	err := execCommandInService(i.profile, i.image, i.service, cmd, false)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"containerName": containerName,
 			"command":       cmd,
 			"error":         err,
-			"hash":          hash,
+			"logFile":       i.logFile,
 		}).Error("Could not get agent logs in the container")
 
 		return err

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -63,46 +63,16 @@ func (i *ElasticAgentInstaller) listElasticAgentWorkingDirContent(containerName 
 	return content, nil
 }
 
-// getElasticAgentHash uses Elastic Agent's home dir to read the file with agent's build hash
-// it will return the first six characters of the hash (short hash)
-func (i *ElasticAgentInstaller) getElasticAgentHash(containerName string) (string, error) {
-	commitFile := i.homeDir + i.commitFile
-
-	return getElasticAgentHash(containerName, commitFile)
-}
-
 func buildEnrollmentFlags(token string) []string {
 	return []string{"--url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
-}
-
-func getElasticAgentHash(containerName string, commitFile string) (string, error) {
-	cmd := []string{
-		"cat", commitFile,
-	}
-
-	fullHash, err := docker.ExecCommandIntoContainer(context.Background(), containerName, "root", cmd)
-	if err != nil {
-		return "", err
-	}
-
-	runes := []rune(fullHash)
-	shortHash := string(runes[0:6])
-
-	log.WithFields(log.Fields{
-		"commitFile":    commitFile,
-		"containerName": containerName,
-		"hash":          fullHash,
-		"shortHash":     shortHash,
-	}).Debug("Agent build hash found")
-
-	return shortHash, nil
 }
 
 // getElasticAgentLogs uses elastic-agent log dir to read the entire log file
 func (i *ElasticAgentInstaller) getElasticAgentLogs(hostname string) error {
 	containerName := hostname // name of the container, which matches the hostname
+	commitFile := i.homeDir + i.commitFile
 
-	hash, err := i.getElasticAgentHash(containerName)
+	hash, err := getElasticAgentHash(containerName, commitFile)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"containerName": containerName,

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -20,7 +20,6 @@ type ElasticAgentInstaller struct {
 	artifactName      string // name of the artifact
 	artifactOS        string // OS of the artifact
 	artifactVersion   string // version of the artifact
-	binDir            string // location of the binary
 	EnrollFn          func(token string) error
 	homeDir           string // elastic agent home dir
 	image             string // docker image
@@ -195,7 +194,6 @@ func newCentosInstaller(image string, tag string, version string) (ElasticAgentI
 		artifactName:      artifact,
 		artifactOS:        os,
 		artifactVersion:   version,
-		binDir:            binDir,
 		EnrollFn:          enrollFn,
 		homeDir:           homeDir,
 		image:             image,
@@ -265,7 +263,6 @@ func newDebianInstaller(image string, tag string, version string) (ElasticAgentI
 		artifactName:      artifact,
 		artifactOS:        os,
 		artifactVersion:   version,
-		binDir:            binDir,
 		EnrollFn:          enrollFn,
 		homeDir:           homeDir,
 		image:             image,
@@ -346,7 +343,6 @@ func newDockerInstaller(ubi8 bool, version string) (ElasticAgentInstaller, error
 		artifactName:      artifact,
 		artifactOS:        os,
 		artifactVersion:   version,
-		binDir:            binDir,
 		EnrollFn:          enrollFn,
 		homeDir:           homeDir,
 		image:             image,
@@ -395,7 +391,6 @@ func newTarInstaller(image string, tag string, version string) (ElasticAgentInst
 
 	commitFileName := ".elastic-agent.active.commit"
 	homeDir := "/elastic-agent/"
-	binDir := "/usr/bin/"
 	workingDir := "/opt/Elastic/Agent/"
 
 	commitFile := homeDir + commitFileName
@@ -422,7 +417,6 @@ func newTarInstaller(image string, tag string, version string) (ElasticAgentInst
 		artifactName:      artifact,
 		artifactOS:        os,
 		artifactVersion:   version,
-		binDir:            binDir,
 		EnrollFn:          enrollFn,
 		homeDir:           homeDir,
 		image:             dockerImage,

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -21,7 +21,6 @@ type ElasticAgentInstaller struct {
 	artifactOS        string // OS of the artifact
 	artifactVersion   string // version of the artifact
 	binDir            string // location of the binary
-	commitFile        string // elastic agent commit file
 	EnrollFn          func(token string) error
 	homeDir           string // elastic agent home dir
 	image             string // docker image
@@ -199,7 +198,6 @@ func newCentosInstaller(image string, tag string, version string) (ElasticAgentI
 		artifactOS:        os,
 		artifactVersion:   version,
 		binDir:            binDir,
-		commitFile:        commitFileName,
 		EnrollFn:          enrollFn,
 		homeDir:           homeDir,
 		image:             image,
@@ -272,7 +270,6 @@ func newDebianInstaller(image string, tag string, version string) (ElasticAgentI
 		artifactOS:        os,
 		artifactVersion:   version,
 		binDir:            binDir,
-		commitFile:        commitFileName,
 		EnrollFn:          enrollFn,
 		homeDir:           homeDir,
 		image:             image,
@@ -356,7 +353,6 @@ func newDockerInstaller(ubi8 bool, version string) (ElasticAgentInstaller, error
 		artifactOS:        os,
 		artifactVersion:   version,
 		binDir:            binDir,
-		commitFile:        commitFile,
 		EnrollFn:          enrollFn,
 		homeDir:           homeDir,
 		image:             image,
@@ -435,7 +431,6 @@ func newTarInstaller(image string, tag string, version string) (ElasticAgentInst
 		artifactOS:        os,
 		artifactVersion:   version,
 		binDir:            binDir,
-		commitFile:        commitFile,
 		EnrollFn:          enrollFn,
 		homeDir:           homeDir,
 		image:             dockerImage,

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -395,8 +395,8 @@ func newTarInstaller(image string, tag string, version string) (ElasticAgentInst
 
 	commitFile := homeDir + commitFileName
 
-	logsDir := "/opt/Elastic/Agent/"
-	logFileName := "elastic-agent.log"
+	logsDir := workingDir + "/data/elastic-agent-%s/logs/"
+	logFileName := "elastic-agent-json.log"
 	logFile := logsDir + "/" + logFileName
 
 	enrollFn := func(token string) error {

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -28,7 +28,6 @@ type ElasticAgentInstaller struct {
 	InstallFn         func(containerName string, token string) error
 	InstallCertsFn    func() error
 	logFile           string // the name of the log file
-	logsDir           string // location of the logs
 	name              string // the name for the binary
 	path              string // the local path where the agent for the binary is located
 	processName       string // name of the elastic-agent process
@@ -205,7 +204,6 @@ func newCentosInstaller(image string, tag string, version string) (ElasticAgentI
 		InstallCertsFn:    installerPackage.InstallCerts,
 		installerType:     "rpm",
 		logFile:           logFileName,
-		logsDir:           logsDir,
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     installerPackage.Postinstall,
@@ -277,7 +275,6 @@ func newDebianInstaller(image string, tag string, version string) (ElasticAgentI
 		InstallCertsFn:    installerPackage.InstallCerts,
 		installerType:     "deb",
 		logFile:           logFileName,
-		logsDir:           logsDir,
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     installerPackage.Postinstall,
@@ -360,7 +357,6 @@ func newDockerInstaller(ubi8 bool, version string) (ElasticAgentInstaller, error
 		InstallCertsFn:    installerPackage.InstallCerts,
 		installerType:     "docker",
 		logFile:           logFileName,
-		logsDir:           logsDir,
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     installerPackage.Postinstall,
@@ -438,7 +434,6 @@ func newTarInstaller(image string, tag string, version string) (ElasticAgentInst
 		InstallCertsFn:    installerPackage.InstallCerts,
 		installerType:     "tar",
 		logFile:           logFileName,
-		logsDir:           logsDir,
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     installerPackage.Postinstall,

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -27,7 +27,6 @@ type ElasticAgentInstaller struct {
 	installerType     string
 	InstallFn         func(containerName string, token string) error
 	InstallCertsFn    func() error
-	logFile           string // the name of the log file
 	name              string // the name for the binary
 	path              string // the local path where the agent for the binary is located
 	processName       string // name of the elastic-agent process
@@ -203,7 +202,6 @@ func newCentosInstaller(image string, tag string, version string) (ElasticAgentI
 		InstallFn:         installerPackage.Install,
 		InstallCertsFn:    installerPackage.InstallCerts,
 		installerType:     "rpm",
-		logFile:           logFileName,
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     installerPackage.Postinstall,
@@ -274,7 +272,6 @@ func newDebianInstaller(image string, tag string, version string) (ElasticAgentI
 		InstallFn:         installerPackage.Install,
 		InstallCertsFn:    installerPackage.InstallCerts,
 		installerType:     "deb",
-		logFile:           logFileName,
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     installerPackage.Postinstall,
@@ -356,7 +353,6 @@ func newDockerInstaller(ubi8 bool, version string) (ElasticAgentInstaller, error
 		InstallFn:         installerPackage.Install,
 		InstallCertsFn:    installerPackage.InstallCerts,
 		installerType:     "docker",
-		logFile:           logFileName,
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     installerPackage.Postinstall,
@@ -433,7 +429,6 @@ func newTarInstaller(image string, tag string, version string) (ElasticAgentInst
 		InstallFn:         installerPackage.Install,
 		InstallCertsFn:    installerPackage.InstallCerts,
 		installerType:     "tar",
-		logFile:           logFileName,
 		name:              binaryName,
 		path:              binaryPath,
 		PostInstallFn:     installerPackage.Postinstall,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It prints the elastic-agent logs at the end of each test suite, and for that we did a bit of the boy scout rule:

- first, we changed the agent log for the TAR installer: instead of using the default log (`/opt/Elastic/Agent/elastic-agent.log`), we used the JSON log (`/opt/Elastic/Agent/data/elastic-agent-$HASH/logs/elastic-agent-json.log`).
- moved code around the installer Go files, so that the responsibility for printing is clear. In the process, we removed a few attributes from the struct representing the installers, mainly used to calculate the log based on the Agent hash.
- we added a `resolveLogFile` method to the package installer, so that it's able to, with the commit file and the log dir, calculate the final log file.
- we also added a flag to signal when the elastic-agent can be called again in the tear-down stage. This is needed because we saw many _error logs_ in the Jenkins logs, but not real (we log them in the tests although we do not fail on purpose, as they happen in the tearDown/cleanUp methods of the test scenarios)
- finally, we will always print the logs at the end of the test suite. This was protected by the DEVELOPER_MODE variable.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We want to know what the agent is logging on failures, and the TAR file was using a log file not including all the information. With this change we will have Jenkins logs containing agent logs.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] @michalpristas @blakerouse, is there a way to tell the agent to log to stdout/stderr instead? That feature will allow collecting container logs in one place, without having do hacks like in this PR, which is basically _catting_ the log at the end, printing it to Jenkins logs.

## How to test this PR locally

```shell
SUITE="fleet" TAGS="fleet_mode_agent && reenroll" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true ELASTIC_APM_ACTIVE=false make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #820
- Relates #742  


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
If we are able to redirect agent's logs to stdout/stderr, then container logs will include agent logs. And therefore the existing filebeat will capture all those logs storing them in the artifacts section in Jenkins UI.

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->