### PR TITLE
chore: append "-amd64" label for Docker images (#787) backport for 7.11.x

### DIFF
--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/e2e"
@@ -152,11 +153,14 @@ func (i *DockerPackage) Preinstall() error {
 		return err
 	}
 
+	// wait for tagging to ensure the loaded image is present
+	e2e.Sleep(3 * time.Second)
+
 	// we need to tag the loaded image because its tag relates to the target branch,
 	// and we want it to use the 'pr-12345' format.
 	return docker.TagImage(
 		"docker.elastic.co/beats/"+i.artifact+":"+agentVersionBase,
-		"docker.elastic.co/observability-ci/"+i.artifact+":"+i.originalVersion,
+		"docker.elastic.co/observability-ci/"+i.artifact+":"+i.originalVersion+"-amd64",
 	)
 }
 

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -355,6 +355,7 @@ func newDockerInstaller(ubi8 bool, version string) (ElasticAgentInstaller, error
 	artifactName := artifact
 	if ubi8 {
 		artifactName = "elastic-agent-ubi8"
+		image = "elastic-agent-ubi8"
 	}
 
 	os := "linux"
@@ -383,9 +384,9 @@ func newDockerInstaller(ubi8 bool, version string) (ElasticAgentInstaller, error
 		return nil
 	}
 
-	installerPackage := NewDockerPackage(binaryName, profile, image, service, binaryPath, ubi8).
+	installerPackage := NewDockerPackage(binaryName, profile, artifactName, service, binaryPath, ubi8).
 		WithArch(arch).
-		WithArtifact(artifact).
+		WithArtifact(artifactName).
 		WithOS(os).
 		WithVersion(version)
 

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -63,6 +63,8 @@ func (sats *StandAloneTestSuite) contributeSteps(s *godog.ScenarioContext) {
 func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed(image string) error {
 	log.Trace("Deploying an agent to Fleet")
 
+	dockerImageTag := agentVersion
+
 	useCISnapshots := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
 	beatsLocalPath := shell.GetEnv("BEATS_LOCAL_PATH", "")
 	if useCISnapshots || beatsLocalPath != "" {
@@ -72,6 +74,8 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed(image string) error 
 		dockerInstaller := GetElasticAgentInstaller("docker", image, agentVersion)
 
 		dockerInstaller.PreInstallFn()
+
+		dockerImageTag += "-amd64"
 	}
 
 	serviceManager := services.NewServiceManager()
@@ -96,7 +100,7 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed(image string) error 
 	profileEnv["elasticAgentContainerName"] = containerName
 	profileEnv["elasticAgentConfigFile"] = sats.AgentConfigFilePath
 	profileEnv["elasticAgentPlatform"] = "linux/amd64"
-	profileEnv["elasticAgentTag"] = agentVersion
+	profileEnv["elasticAgentTag"] = dockerImageTag
 
 	err = serviceManager.AddServicesToCompose(context.Background(), FleetProfileName, []string{ElasticAgentServiceName}, profileEnv)
 	if err != nil {

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -408,7 +408,7 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 
 		err = docker.TagImage(
 			"docker.elastic.co/beats/metricbeat:"+metricbeatVersionBase,
-			"docker.elastic.co/observability-ci/metricbeat:"+mts.Version,
+			"docker.elastic.co/observability-ci/metricbeat:"+mts.Version+"-amd64",
 		)
 	}
 
@@ -436,7 +436,7 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 		"metricbeatConfigFile":  mts.configurationFile,
 		"metricbeatTag":         mts.Version,
 		"stackVersion":          stackVersion,
-		mts.ServiceName + "Tag": mts.ServiceVersion,
+		mts.ServiceName + "Tag": mts.ServiceVersion + "-amd64",
 		"serviceName":           mts.ServiceName,
 	}
 


### PR DESCRIPTION
Backports the following commits to 7.11.x:
 - chore: append "-amd64" label for Docker images (#787)