### PR TITLE
fix: use proper flags

### DIFF
--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -333,7 +333,7 @@ func NewTARPackage(binaryName string, profile string, image string, service stri
 func (i *TARPackage) Install(containerName string, token string) error {
 	// install the elastic-agent to /usr/bin/elastic-agent using command
 	binary := fmt.Sprintf("/elastic-agent/%s", i.artifact)
-	args := []string{"--force", "--insecure", "--enrollment-token", token, "--kibana-url", "http://kibana:5601"}
+	args := []string{"--force", "--insecure", "--enrollment-token=" + token, "--kibana-url", "http://kibana:5601"}
 
 	err := runElasticAgentCommand(i.profile, i.image, i.service, binary, "install", args)
 	if err != nil {

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -60,7 +60,7 @@ func (i *ElasticAgentInstaller) listElasticAgentWorkingDirContent(containerName 
 }
 
 func buildEnrollmentFlags(token string) []string {
-	return []string{"--url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
+	return []string{"--kibana-url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
 }
 
 // runElasticAgentCommand runs a command for the elastic-agent


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It changes two things in how the enrollment flags are created:

1. uses `--enrollment-token=TOKEN` instead of `--enrollment-token TOKEN` for TAR installer when using the **install** command.
1. uses `--kibana-url=KIBANA_URL` flag name instead of `--url=KIBANA_URL` for RPM, DEB and TAR installers when using the **enroll** command.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We started to see consistent failures for the uninstall scenario. For some reason, and this is something @michalpristas @blakerouse @ericdavisx should confirm, I was able to reproduce the following unexpected behavior:

1. install the agent with old flags (i.e. `./elastic-agent install -f --kibana-url=http://kibana:5601 --enrollment-token TOKEN --insecure`)
1. the agent appears as enrolled in the UI, but there were no logs for the agent
1. uninstall the agent using the `uninstall -f` command
1. the agent gets to the `enrolling` status, but it never disappeared from the UI

After the changes in this PR, using the proper flags, the expected behaviour is satisfied.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] @michalpristas @blakerouse please confirm the flags are correct

## How to test this PR locally

```shell
SUITE="fleet" TAGS="fleet_mode_agent && uninstall-host" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #867


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
Backport to 7.x, 7.12.x and 6.8.x
<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->