### PR TITLE
fix: use proper flags (#868) backport for 6.8.x

### DIFF
--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -333,7 +333,7 @@ func NewTARPackage(binaryName string, profile string, image string, service stri
 func (i *TARPackage) Install(containerName string, token string) error {
 	// install the elastic-agent to /usr/bin/elastic-agent using command
 	binary := fmt.Sprintf("/elastic-agent/%s", i.artifact)
-	args := []string{"--force", "--insecure", "--enrollment-token", token, "--kibana-url", "http://kibana:5601"}
+	args := []string{"--force", "--insecure", "--enrollment-token=" + token, "--kibana-url", "http://kibana:5601"}
 
 	err := runElasticAgentCommand(i.profile, i.image, i.service, binary, "install", args)
 	if err != nil {

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -60,7 +60,7 @@ func (i *ElasticAgentInstaller) listElasticAgentWorkingDirContent(containerName 
 }
 
 func buildEnrollmentFlags(token string) []string {
-	return []string{"--url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
+	return []string{"--kibana-url=http://kibana:5601", "--enrollment-token=" + token, "-f", "--insecure"}
 }
 
 // runElasticAgentCommand runs a command for the elastic-agent


### PR DESCRIPTION
Backports the following commits to 6.8.x:
 - fix: use proper flags (#868)