### PR TITLE
feat: run most frequent flavours in the PR stage

### DIFF
--- a/.ci/.e2e-tests.yaml
+++ b/.ci/.e2e-tests.yaml
@@ -18,6 +18,7 @@ SUITES:
         pullRequestFilter: " && ~debian"
         tags: "fleet_mode_agent"
       - name: "Endpoint Integration"
+        pullRequestFilter: " && ~debian"
         tags: "agent_endpoint_integration"
       - name: "Stand-alone"
         pullRequestFilter: " && ~ubi8"

--- a/.ci/.e2e-tests.yaml
+++ b/.ci/.e2e-tests.yaml
@@ -48,6 +48,7 @@ SUITES:
       - name: "Metricbeat"
         tags: "metricbeat"
       - name: "MySQL"
+        pullRequestFilter: " && ~old_versions"
         tags: "integrations && mysql"
       - name: "Oracle"
         tags: "integrations && oracle"

--- a/.ci/.e2e-tests.yaml
+++ b/.ci/.e2e-tests.yaml
@@ -15,15 +15,15 @@ SUITES:
       - "ubuntu-18.04"
     scenarios:
       - name: "Fleet"
-        pullRequestFilter: "&& centos"
+        pullRequestFilter: "&& ~debian"
         tags: "fleet_mode_agent"
       - name: "Endpoint Integration"
         tags: "agent_endpoint_integration"
       - name: "Stand-alone"
-        pullRequestFilter: "&& default"
+        pullRequestFilter: "&& ~ubi8"
         tags: "stand_alone_agent"
       - name: "Backend Processes"
-        pullRequestFilter: "&& centos"
+        pullRequestFilter: "&& ~debian"
         tags: "backend_processes"
   - suite: "metricbeat"
     platforms:

--- a/.ci/.e2e-tests.yaml
+++ b/.ci/.e2e-tests.yaml
@@ -15,12 +15,14 @@ SUITES:
       - "ubuntu-18.04"
     scenarios:
       - name: "Fleet"
+        pullRequestFilter: "&& centos"
         tags: "fleet_mode_agent"
       - name: "Endpoint Integration"
         tags: "agent_endpoint_integration"
       - name: "Stand-alone"
         tags: "stand_alone_agent"
       - name: "Backend Processes"
+        pullRequestFilter: "&& centos"
         tags: "backend_processes"
   - suite: "metricbeat"
     platforms:

--- a/.ci/.e2e-tests.yaml
+++ b/.ci/.e2e-tests.yaml
@@ -20,6 +20,7 @@ SUITES:
       - name: "Endpoint Integration"
         tags: "agent_endpoint_integration"
       - name: "Stand-alone"
+        pullRequestFilter: "&& default"
         tags: "stand_alone_agent"
       - name: "Backend Processes"
         pullRequestFilter: "&& centos"

--- a/.ci/.e2e-tests.yaml
+++ b/.ci/.e2e-tests.yaml
@@ -15,15 +15,15 @@ SUITES:
       - "ubuntu-18.04"
     scenarios:
       - name: "Fleet"
-        pullRequestFilter: "&& ~debian"
+        pullRequestFilter: " && ~debian"
         tags: "fleet_mode_agent"
       - name: "Endpoint Integration"
         tags: "agent_endpoint_integration"
       - name: "Stand-alone"
-        pullRequestFilter: "&& ~ubi8"
+        pullRequestFilter: " && ~ubi8"
         tags: "stand_alone_agent"
       - name: "Backend Processes"
-        pullRequestFilter: "&& ~debian"
+        pullRequestFilter: " && ~debian"
         tags: "backend_processes"
   - suite: "metricbeat"
     platforms:

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -250,7 +250,7 @@ def checkTestSuite(Map parallelTasks = [:], Map item = [:]) {
   def suite = item.suite
   def platforms = item.platforms
   item.scenarios.each { scenario ->
-    def pullRequestFilter = scenario.pullRequestFilter
+    def pullRequestFilter = scenario.containsKey('pullRequestFilter') ? scenario.pullRequestFilter : ''
     def tags = scenario.tags
     def regexps = [ "^e2e/_suites/${suite}/.*", "^.ci/.*", "^cli/.*", "^e2e/.*\\.go" ]
     if ("${FORCE_SKIP_GIT_CHECKS}" == "true" || isGitRegionMatch(patterns: regexps, shouldMatchAll: false)) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -256,7 +256,7 @@ def checkTestSuite(Map parallelTasks = [:], Map item = [:]) {
     if ("${FORCE_SKIP_GIT_CHECKS}" == "true" || isGitRegionMatch(patterns: regexps, shouldMatchAll: false)) {
       platforms.each { platform ->
         log(level: 'INFO', text: "Adding ${platform}:${suite}:${tags} test suite to the build execution")
-        parallelTasks["${platform}_${suite}_${tags}"] = generateFunctionalTestStep(platform: "${platform}", suite: "${suite}", tags: "${tags}", pullRequestFilter: ${pullRequestFilter})
+        parallelTasks["${platform}_${suite}_${tags}"] = generateFunctionalTestStep(platform: "${platform}", suite: "${suite}", tags: "${tags}", pullRequestFilter: "${pullRequestFilter}")
       }
     } else {
       log(level: 'WARN', text: "The ${suite}:${tags} test suite won't be executed because there are no modified files")

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -250,12 +250,13 @@ def checkTestSuite(Map parallelTasks = [:], Map item = [:]) {
   def suite = item.suite
   def platforms = item.platforms
   item.scenarios.each { scenario ->
+    def pullRequestFilter = scenario.pullRequestFilter
     def tags = scenario.tags
     def regexps = [ "^e2e/_suites/${suite}/.*", "^.ci/.*", "^cli/.*", "^e2e/.*\\.go" ]
     if ("${FORCE_SKIP_GIT_CHECKS}" == "true" || isGitRegionMatch(patterns: regexps, shouldMatchAll: false)) {
       platforms.each { platform ->
         log(level: 'INFO', text: "Adding ${platform}:${suite}:${tags} test suite to the build execution")
-        parallelTasks["${platform}_${suite}_${tags}"] = generateFunctionalTestStep(platform: "${platform}", suite: "${suite}", tags: "${tags}")
+        parallelTasks["${platform}_${suite}_${tags}"] = generateFunctionalTestStep(platform: "${platform}", suite: "${suite}", tags: "${tags}", pullRequestFilter: ${pullRequestFilter})
       }
     } else {
       log(level: 'WARN', text: "The ${suite}:${tags} test suite won't be executed because there are no modified files")
@@ -307,6 +308,7 @@ def generateFunctionalTestStep(Map args = [:]){
   def platform = args.get('platform')
   def suite = args.get('suite')
   def tags = args.get('tags')
+  def pullRequestFilter = args.get('pullRequestFilter')?.trim() ? args.get('pullRequestFilter') : ''
 
   // We will decide whether to include the nightly tests in the execution at CI time, only.
   // On the other hand, the developers can use the TAGS environment variable locally.
@@ -316,6 +318,10 @@ def generateFunctionalTestStep(Map args = [:]){
     excludeNightlyTag = ""
   }
   tags += excludeNightlyTag
+
+  if (isPR()) {
+    tags += pullRequestFilter
+  }
 
   return {
     node("${platform} && immutable && docker") {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -319,7 +319,7 @@ def generateFunctionalTestStep(Map args = [:]){
   }
   tags += excludeNightlyTag
 
-  if (isPR()) {
+  if (isPR() || isUpstreamTrigger('PR-')) {
     tags += pullRequestFilter
   }
 

--- a/e2e/_suites/fleet/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/fleet/features/agent_endpoint_integration.feature
@@ -57,7 +57,6 @@ Scenario Outline: Un-enrolling Elastic Agent stops Elastic Endpoint
   When the agent is un-enrolled
   Then the agent is listed in Fleet as "inactive"
     And the host name is not shown in the Administration view in the Security App
-    And the "elastic-endpoint" process is in the "stopped" state on the host
 
 @centos
 Examples: Centos
@@ -75,7 +74,6 @@ Scenario Outline: Removing Endpoint from Agent policy stops the connected Endpoi
   When the "Endpoint Security" integration is "removed" in the policy
   Then the agent is listed in Fleet as "online"
     But the host name is not shown in the Administration view in the Security App
-    And the "elastic-endpoint" process is in the "stopped" state on the host
 
 @centos
 Examples: Centos

--- a/e2e/_suites/fleet/features/agent_endpoint_integration.feature
+++ b/e2e/_suites/fleet/features/agent_endpoint_integration.feature
@@ -3,36 +3,86 @@ Feature: Agent Endpoint Integration
   Scenarios for Agent to deploy Endpoint and sending data to Fleet and Elasticsearch.
 
 @deploy-endpoint-with-agent
-Scenario: Adding the Endpoint Integration to an Agent makes the host to show in Security App
-  Given a "centos" agent is deployed to Fleet with "tar" installer
+Scenario Outline: Adding the Endpoint Integration to an Agent makes the host to show in Security App
+  Given a "<os>" agent is deployed to Fleet with "tar" installer
     And the agent is listed in Fleet as "online"
   When the "Endpoint Security" integration is "added" in the policy
   Then the "Endpoint Security" datasource is shown in the policy as added
     And the host name is shown in the Administration view in the Security App as "online"
 
+@centos
+Examples: Centos
+| os     |
+| centos |
+
+@debian
+Examples: Debian
+| os     |
+| debian |
+
 @endpoint-policy-check
-Scenario: Deploying an Endpoint makes policies to appear in the Security App
-  When an Endpoint is successfully deployed with a "centos" Agent using "tar" installer
+Scenario Outline: Deploying an Endpoint makes policies to appear in the Security App
+  When an Endpoint is successfully deployed with a "<os>" Agent using "tar" installer
   Then the policy response will be shown in the Security App
 
+@centos
+Examples: Centos
+| os     |
+| centos |
+
+@debian
+Examples: Debian
+| os     |
+| debian |
+
 @set-policy-and-check-changes
-Scenario: Changing an Agent policy is reflected in the Security App
-  Given an Endpoint is successfully deployed with a "centos" Agent using "tar" installer
+Scenario Outline: Changing an Agent policy is reflected in the Security App
+  Given an Endpoint is successfully deployed with a "<os>" Agent using "tar" installer
   When the policy is updated to have "malware" in "detect" mode
   Then the policy will reflect the change in the Security App
 
+@centos
+Examples: Centos
+| os     |
+| centos |
+
+@debian
+Examples: Debian
+| os     |
+| debian |
+
 @deploy-endpoint-then-unenroll-agent
-Scenario: Un-enrolling Elastic Agent stops Elastic Endpoint
-  Given an Endpoint is successfully deployed with a "centos" Agent using "tar" installer
+Scenario Outline: Un-enrolling Elastic Agent stops Elastic Endpoint
+  Given an Endpoint is successfully deployed with a "<os>" Agent using "tar" installer
   When the agent is un-enrolled
   Then the agent is listed in Fleet as "inactive"
     And the host name is not shown in the Administration view in the Security App
     And the "elastic-endpoint" process is in the "stopped" state on the host
 
+@centos
+Examples: Centos
+| os     |
+| centos |
+
+@debian
+Examples: Debian
+| os     |
+| debian |
+
 @deploy-endpoint-then-remove-it-from-policy
-Scenario: Removing Endpoint from Agent policy stops the connected Endpoint
-  Given an Endpoint is successfully deployed with a "centos" Agent using "tar" installer
+Scenario Outline: Removing Endpoint from Agent policy stops the connected Endpoint
+  Given an Endpoint is successfully deployed with a "<os>" Agent using "tar" installer
   When the "Endpoint Security" integration is "removed" in the policy
   Then the agent is listed in Fleet as "online"
     But the host name is not shown in the Administration view in the Security App
     And the "elastic-endpoint" process is in the "stopped" state on the host
+
+@centos
+Examples: Centos
+| os     |
+| centos |
+
+@debian
+Examples: Debian
+| os     |
+| debian |

--- a/e2e/_suites/fleet/features/backend_processes.feature
+++ b/e2e/_suites/fleet/features/backend_processes.feature
@@ -8,9 +8,15 @@ Scenario Outline: Deploying the <os> agent
   When the "elastic-agent" process is in the "started" state on the host
   Then the "filebeat" process is in the "started" state on the host
     And the "metricbeat" process is in the "started" state on the host
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @enroll
@@ -19,9 +25,15 @@ Scenario Outline: Deploying the <os> agent with enroll and then run on rpm and d
   When the "elastic-agent" process is in the "started" state on the host
   Then the "filebeat" process is in the "started" state on the host
     And the "metricbeat" process is in the "started" state on the host
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @stop-agent
@@ -30,9 +42,15 @@ Scenario Outline: Stopping the <os> agent stops backend processes
   When the "elastic-agent" process is "stopped" on the host
   Then the "filebeat" process is in the "stopped" state on the host
     And the "metricbeat" process is in the "stopped" state on the host
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @restart-agent
@@ -41,9 +59,15 @@ Scenario Outline: Restarting the installed <os> agent
   When the "elastic-agent" process is "restarted" on the host
   Then the "filebeat" process is in the "started" state on the host
     And the "metricbeat" process is in the "started" state on the host
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @restart-host
@@ -53,9 +77,15 @@ Scenario Outline: Restarting the <os> host with persistent agent restarts backen
   Then the "elastic-agent" process is in the "started" state on the host
     And the "filebeat" process is in the "started" state on the host
     And the "metricbeat" process is in the "started" state on the host
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @unenroll
@@ -65,9 +95,15 @@ Scenario Outline: Un-enrolling the <os> agent stops backend processes
   Then the "elastic-agent" process is in the "started" state on the host
     And the "filebeat" process is in the "stopped" state on the host
     And the "metricbeat" process is in the "stopped" state on the host
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @reenroll
@@ -77,9 +113,15 @@ Scenario Outline: Re-enrolling the <os> agent starts the elastic-agent process
     And the "elastic-agent" process is "stopped" on the host
   When the agent is re-enrolled on the host
   Then the "elastic-agent" process is "started" on the host
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @uninstall-host
@@ -89,7 +131,13 @@ Scenario Outline: Un-installing the installed <os> agent
   Then the "elastic-agent" process is in the "stopped" state on the host
     And the "filebeat" process is in the "stopped" state on the host
     And the "metricbeat" process is in the "stopped" state on the host
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |

--- a/e2e/_suites/fleet/features/backend_processes.feature
+++ b/e2e/_suites/fleet/features/backend_processes.feature
@@ -141,3 +141,35 @@ Examples: Centos
 Examples: Debian
 | os     |
 | debian |
+
+@deploy-endpoint-then-unenroll-agent
+Scenario Outline: Un-enrolling Elastic Agent stops Elastic Endpoint
+  Given an Endpoint is successfully deployed with a "<os>" Agent using "tar" installer
+  When the agent is un-enrolled
+  Then the "elastic-endpoint" process is in the "stopped" state on the host
+
+@centos
+Examples: Centos
+| os     |
+| centos |
+
+@debian
+Examples: Debian
+| os     |
+| debian |
+
+@deploy-endpoint-then-remove-it-from-policy
+Scenario Outline: Removing Endpoint from Agent policy stops the connected Endpoint
+  Given an Endpoint is successfully deployed with a "<os>" Agent using "tar" installer
+  When the "Endpoint Security" integration is "removed" in the policy
+  Then the "elastic-endpoint" process is in the "stopped" state on the host
+
+@centos
+Examples: Centos
+| os     |
+| centos |
+
+@debian
+Examples: Debian
+| os     |
+| debian |

--- a/e2e/_suites/fleet/features/fleet_mode_agent.feature
+++ b/e2e/_suites/fleet/features/fleet_mode_agent.feature
@@ -8,9 +8,15 @@ Scenario Outline: Deploying the <os> agent
   When the "elastic-agent" process is in the "started" state on the host
   Then the agent is listed in Fleet as "online"
     And system package dashboards are listed in Fleet
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @enroll
@@ -19,9 +25,15 @@ Scenario Outline: Deploying the <os> agent with enroll and then run on rpm and d
   When the "elastic-agent" process is in the "started" state on the host
   Then the agent is listed in Fleet as "online"
     And system package dashboards are listed in Fleet
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 # @upgrade-agent
@@ -32,18 +44,26 @@ Scenario Outline: Upgrading the installed <os> agent
     And the "elastic-agent" process is "restarted" on the host
   When agent is upgraded to version "latest"
   Then agent is in version "latest"
-Examples:
-| os     | 
-| debian | 
+
+@debian
+Examples: Debian
+| os     |
+| debian |
 
 @restart-agent
 Scenario Outline: Restarting the installed <os> agent
   Given a "<os>" agent is deployed to Fleet with "tar" installer
   When the "elastic-agent" process is "restarted" on the host
   Then the agent is listed in Fleet as "online"
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @unenroll
@@ -51,9 +71,15 @@ Scenario Outline: Un-enrolling the <os> agent deactivates the agent
   Given a "<os>" agent is deployed to Fleet with "tar" installer
   When the agent is un-enrolled
   Then the agent is listed in Fleet as "inactive"
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @reenroll
@@ -64,9 +90,15 @@ Scenario Outline: Re-enrolling the <os> agent activates the agent in Fleet
     And the agent is re-enrolled on the host
   When the "elastic-agent" process is "started" on the host
   Then the agent is listed in Fleet as "online"
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @revoke-token
@@ -74,9 +106,15 @@ Scenario Outline: Revoking the enrollment token for the <os> agent
   Given a "<os>" agent is deployed to Fleet with "tar" installer
   When the enrollment token is revoked
   Then an attempt to enroll a new agent fails
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |
 
 @uninstall-host
@@ -85,7 +123,13 @@ Scenario Outline: Un-installing the installed <os> agent
   When the "elastic-agent" process is "uninstalled" on the host
   Then the file system Agent folder is empty
     And the agent is listed in Fleet as "offline"
-Examples:
+
+@centos
+Examples: Centos
 | os     |
 | centos |
+
+@debian
+Examples: Debian
+| os     |
 | debian |

--- a/e2e/_suites/fleet/features/stand_alone_agent.feature
+++ b/e2e/_suites/fleet/features/stand_alone_agent.feature
@@ -9,18 +9,30 @@ Scenario Outline: Starting the <image> agent starts backend processes
   When a "<image>" stand-alone agent is deployed
   Then the "filebeat" process is in the "started" state on the host
     And the "metricbeat" process is in the "started" state on the host
-Examples:
+
+@default
+Examples: default
 | image   |
 | default |
+
+@ubi8
+Examples: Ubi8
+| image   |
 | ubi8    |
 
 @deploy-stand-alone
 Scenario Outline: Deploying a <image> stand-alone agent
   When a "<image>" stand-alone agent is deployed
   Then there is new data in the index from agent
-Examples:
+
+@default
+Examples: default
 | image   |
 | default |
+
+@ubi8
+Examples: Ubi8
+| image   |
 | ubi8    |
 
 @stop-agent
@@ -28,7 +40,13 @@ Scenario Outline: Stopping the <image> agent container stops data going into ES
   Given a "<image>" stand-alone agent is deployed
   When the "elastic-agent" docker container is stopped
   Then there is no new data in the index after agent shuts down
-Examples:
+
+@default
+Examples: default
 | image   |
 | default |
+
+@ubi8
+Examples: Ubi8
+| image   |
 | ubi8    |

--- a/e2e/_suites/metricbeat/features/integrations.feature
+++ b/e2e/_suites/metricbeat/features/integrations.feature
@@ -105,7 +105,6 @@ Examples: MySQL (latest versions)
 | mysql       | MariaDB | 10.4.4   |
 | mysql       | MySQL   | 8.0.13   |
 | mysql       | MySQL   | 5.7.12   |
-| mysql       | Percona | 8.0.13-4 |
 
 @old_versions
 Examples: MySQL (old versions)
@@ -113,3 +112,4 @@ Examples: MySQL (old versions)
 | mysql       | MariaDB | 10.2.23  |
 | mysql       | MariaDB | 10.3.14  |
 | mysql       | Percona | 5.7.24   |
+| mysql       | Percona | 8.0.13-4 |

--- a/e2e/_suites/metricbeat/features/integrations.feature
+++ b/e2e/_suites/metricbeat/features/integrations.feature
@@ -92,20 +92,23 @@ Examples: vSphere
 | integration | version |
 | vsphere     | latest  |
 
-@variants
+@mysql
 Scenario Outline: <integration>-<variant>-<version> sends metrics to Elasticsearch without errors
   Given "<variant>" v<version>, variant of "<integration>", is running for metricbeat
   When metricbeat is installed and configured for "<variant>", variant of the "<integration>" module
   Then there are "<variant>" events in the index
     And there are no errors in the index
 
-@mysql
-Examples: MySQL
+Examples: MySQL (latest versions)
+| integration | variant | version  |
+| mysql       | MariaDB | 10.4.4   |
+| mysql       | MySQL   | 8.0.13   |
+| mysql       | Percona | 8.0.13-4 |
+
+@nightly
+Examples: MySQL (old versions)
 | integration | variant | version  |
 | mysql       | MariaDB | 10.2.23  |
 | mysql       | MariaDB | 10.3.14  |
-| mysql       | MariaDB | 10.4.4   |
 | mysql       | MySQL   | 5.7.12   |
-| mysql       | MySQL   | 8.0.13   |
 | mysql       | Percona | 5.7.24   |
-| mysql       | Percona | 8.0.13-4 |

--- a/e2e/_suites/metricbeat/features/integrations.feature
+++ b/e2e/_suites/metricbeat/features/integrations.feature
@@ -99,13 +99,14 @@ Scenario Outline: <integration>-<variant>-<version> sends metrics to Elasticsear
   Then there are "<variant>" events in the index
     And there are no errors in the index
 
+@latest_versions
 Examples: MySQL (latest versions)
 | integration | variant | version  |
 | mysql       | MariaDB | 10.4.4   |
 | mysql       | MySQL   | 8.0.13   |
 | mysql       | Percona | 8.0.13-4 |
 
-@nightly
+@old_versions
 Examples: MySQL (old versions)
 | integration | variant | version  |
 | mysql       | MariaDB | 10.2.23  |

--- a/e2e/_suites/metricbeat/features/integrations.feature
+++ b/e2e/_suites/metricbeat/features/integrations.feature
@@ -104,6 +104,7 @@ Examples: MySQL (latest versions)
 | integration | variant | version  |
 | mysql       | MariaDB | 10.4.4   |
 | mysql       | MySQL   | 8.0.13   |
+| mysql       | MySQL   | 5.7.12   |
 | mysql       | Percona | 8.0.13-4 |
 
 @old_versions
@@ -111,5 +112,4 @@ Examples: MySQL (old versions)
 | integration | variant | version  |
 | mysql       | MariaDB | 10.2.23  |
 | mysql       | MariaDB | 10.3.14  |
-| mysql       | MySQL   | 5.7.12   |
 | mysql       | Percona | 5.7.24   |


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR refactors how the BDD feature files are structured, separating the existing examples for a scenario into multiple `Examples` block, annotated with the example type.

I.e., instead of:

```gherkin
Examples:
| image   |
| default |
| ubi8    |
```

we will have:

```gherkin
@default
Examples: default
| image   |
| default |

@ubi8
Examples: Ubi8
| image   |
| ubi8    |
```

To instruct the CI we are adding a new `pullRequestFilter` key in the E2E YAML descriptor for CI, which is read by the pipeline to configure the build, including the Gherkin tags to be appended for a PR. Therefore, the CI will append the `pullRequestFilter` tags to the tags to be added to the current execution, only for PRs.

For Fleet's endpoint integration, the PR filter will add ` ~debian`, indicating that debian scenarios will be skipped.
> we added both OSs (centos and debian) to the execution, as it only used centos for the tests. WIth this strategy, now it's possible to run both in the nightly builds, but centos in the PR stage.

> another improvement is that we moved/copied the scenarios affecting processes for endpoint, to the feature file for processes.

For Fleet's fleet mode, the PR filter will add ` ~debian`, indicating that debian scenarios will be skipped.
For Fleet's Standalone mode, the PR filter will add ` ~ubi8`, indicating that UBI8 scenarios will be skipped.

If the key is empty, the pipeline will add an empty string, which means keeping old behaviour.

We are using same approach for metricbeat's MySQL versions: moving most used versions to the PR phase (latest MariaDB, and MySQL 8 and 5.7) and the rest (old versions and Percona) to the nightly.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We will be able to instruct the CI to add the selected tag/annotation to be run for PRs, speeding up the PR build (actually halfing it). On the other hand, nightly builds should include those skipped scenarios.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's checklist
<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Select `Centos` or `Debian` as the OS to be skipped in the PR phase for the Fleet mode tests
- [ ] Select `UBI8` or the `default` one as the flavour to be skipped in the PR phase for the Standalone tests

@michalpristas @EricDavisX could you please help me out to choose the platform?

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #869

## Use cases

For fleet mode:
```gherkin
Given the Fleet-mode features are executed
When a PR is executed
Then debian scenarios are skipped

Given the Fleet-mode features are executed
When a branch is executed
Then debian scenarios are included

Given the Fleet-mode features are executed
When a nightly build is executed
Then debian scenarios are included
```

For stand-alone mode:
```gherkin
Given the Standalone-mode features are executed
When a PR is executed
Then ubi8 scenarios are skipped

Given the Standalone-mode features are executed
When a branch is executed
Then ubi8 scenarios are included

Given the Standalone-mode features are executed
When a nightly build is executed
Then ubi8 scenarios are included
```

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-up
Document the connection between Gherkin tags and the I descriptor

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->