### PR TITLE
chore: rename slack channel for Fleet's nightly build (#899) backport for 7.12.x

### DIFF
--- a/.ci/e2eTestingFleetDaily.groovy
+++ b/.ci/e2eTestingFleetDaily.groovy
@@ -47,7 +47,7 @@ pipeline {
             booleanParam(name: 'notifyOnGreenBuilds', value: true),
             booleanParam(name: 'NIGHTLY_SCENARIOS', value: true),
             string(name: 'runTestsSuites', value: 'fleet'),
-            string(name: 'SLACK_CHANNEL', value: "fleet"),
+            string(name: 'SLACK_CHANNEL', value: "elastic-agent"),
           ],
           propagate: false,
           wait: false


### PR DESCRIPTION
Backports the following commits to 7.12.x:
 - chore: rename slack channel for Fleet's nightly build (#899)