### PR TITLE
fix: generate a jUnit file per test suite

### DIFF
--- a/.ci/scripts/build-test.sh
+++ b/.ci/scripts/build-test.sh
@@ -14,8 +14,5 @@ mkdir -p $(pwd)/outputs
 
 go get -v -u gotest.tools/gotestsum
 
-# See https://pkg.go.dev/gotest.tools/gotestsum/#readme-junit-xml-output
-GOTESTSUM_JUNITFILE="$(pwd)/outputs/TEST-unit-cli.xml" make -C cli install test
-
-# See https://pkg.go.dev/gotest.tools/gotestsum/#readme-junit-xml-output
-GOTESTSUM_JUNITFILE="$(pwd)/outputs/TEST-unit-e2e.xml" make -C e2e unit-test
+make -C cli install test
+make -C e2e unit-test

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,6 +1,8 @@
 # Get current directory of a Makefile: https://stackoverflow.com/a/23324703
 ROOT_DIR:=$(CURDIR)
 
+include ../commons.mk
+
 TEST_TIMEOUT?=5m
 
 GO_IMAGE?='golang'
@@ -39,11 +41,6 @@ notice:
 .PHONY: sync-integrations
 sync-integrations:
 	OP_LOG_LEVEL=${LOG_LEVEL} go run main.go sync integrations --delete
-
-# Prepare junit build context
-.PHONY: test-report-setup
-test-report-setup:
-	mkdir -p $(PWD)/outputs
 
 .PHONY: test
 test: test-report-setup

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -40,6 +40,11 @@ notice:
 sync-integrations:
 	OP_LOG_LEVEL=${LOG_LEVEL} go run main.go sync integrations --delete
 
+# Prepare junit build context
+.PHONY: test-report-setup
+test-report-setup:
+	mkdir -p $(PWD)/outputs
+
 .PHONY: test
-test:
-	gotestsum --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
+test: test-report-setup
+	gotestsum --junitfile "$(PWD)/outputs/TEST-unit-cli.xml" --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...

--- a/commons.mk
+++ b/commons.mk
@@ -1,0 +1,4 @@
+# Prepare junit build context
+.PHONY: test-report-setup
+test-report-setup:
+	mkdir -p $(PWD)/outputs

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,3 +1,5 @@
+include ../commons.mk
+
 SUITE?=metricbeat
 TAGS?=
 DEVELOPER_MODE?=false
@@ -101,12 +103,7 @@ notice:
 		-depsOut ""
 
 .PHONY: unit-test
-unit-test: unit-test-report-setup unit-test-e2e unit-test-suite-fleet unit-test-suite-helm unit-test-suite-metricbeat
-
-# Prepare junit build context
-.PHONY: unit-test-report-setup
-unit-test-report-setup:
-	mkdir -p $(PWD)/outputs
+unit-test: test-report-setup unit-test-e2e unit-test-suite-fleet unit-test-suite-helm unit-test-suite-metricbeat
 
 # See https://pkg.go.dev/gotest.tools/gotestsum/#readme-junit-xml-output
 .PHONY: unit-test-e2e

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -101,9 +101,22 @@ notice:
 		-depsOut ""
 
 .PHONY: unit-test
-unit-test:
-	gotestsum --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
-	cd _suites && gotestsum --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
+unit-test: unit-test-report-setup unit-test-e2e unit-test-suite-fleet unit-test-suite-helm unit-test-suite-metricbeat
+
+# Prepare junit build context
+.PHONY: unit-test-report-setup
+unit-test-report-setup:
+	mkdir -p $(PWD)/outputs
+
+# See https://pkg.go.dev/gotest.tools/gotestsum/#readme-junit-xml-output
+.PHONY: unit-test-e2e
+unit-test-e2e:
+	gotestsum --junitfile "$(PWD)/outputs/TEST-unit-e2e.xml" --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
+
+# See https://pkg.go.dev/gotest.tools/gotestsum/#readme-junit-xml-output
+.PHONY: unit-test-suite-%
+unit-test-suite-%:
+	cd _suites/$* && gotestsum --junitfile "$(PWD)/outputs/TEST-unit-e2e-$*.xml" --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
 
 ## Test examples
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It creates a Make goal per test suite, so that each of them is able to generate its own jUnit report file. It uses gotestsum's `--junitfile` flag to generate the test report, using test suite name as report file name. Therefore, we are removing the `GOTESTSUM_JUNITFILE` environment variable from the script used by Jenkins.

Because Jenkins will archive all files under `outputs/TEST-unit-*.xml`, there is no need to update the Jenkinsfile.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The `GOTESTSUM_JUNITFILE` environment variable used in the CI script was the culprit of overriding the report file for multiple test suites, then the last unit test execution was the winner, overriding previous report files. With this PR, we are allowing the devveloper to have both formats: jUnit file and terminal output in the same execution of `gotestsum`.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the Unit tests for the E2E, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

**Run as CI**:
```shell
./.ci/scripts/build-test.sh
```

**Run as Developer**:
```shell
make -C cli test
make -C e2e unit-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #906


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots
The jUnit files are generated in the filesystem:
<img width="1103" alt="Screenshot 2021-03-17 at 10 24 19" src="https://user-images.githubusercontent.com/951580/111444732-f97be080-870a-11eb-8826-b40598656f0b.png">

The test report includes the tests:
<img width="1402" alt="Screenshot 2021-03-17 at 10 26 25" src="https://user-images.githubusercontent.com/951580/111445257-858e0800-870b-11eb-981b-c8e4b88503a6.png">


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->