### PR TITLE
fix: generate a jUnit file per test suite (#907) backport for 7.11.x

### DIFF
--- a/.ci/scripts/build-test.sh
+++ b/.ci/scripts/build-test.sh
@@ -14,8 +14,5 @@ mkdir -p $(pwd)/outputs
 
 go get -v -u gotest.tools/gotestsum
 
-# See https://pkg.go.dev/gotest.tools/gotestsum/#readme-junit-xml-output
-GOTESTSUM_JUNITFILE="$(pwd)/outputs/TEST-unit-cli.xml" make -C cli install test
-
-# See https://pkg.go.dev/gotest.tools/gotestsum/#readme-junit-xml-output
-GOTESTSUM_JUNITFILE="$(pwd)/outputs/TEST-unit-e2e.xml" make -C e2e unit-test
+make -C cli install test
+make -C e2e unit-test

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,6 +1,8 @@
 # Get current directory of a Makefile: https://stackoverflow.com/a/23324703
 ROOT_DIR:=$(CURDIR)
 
+include ../commons.mk
+
 TEST_TIMEOUT?=5m
 
 GO_IMAGE?='golang'
@@ -41,5 +43,5 @@ sync-integrations:
 	OP_LOG_LEVEL=${LOG_LEVEL} go run main.go sync integrations --delete
 
 .PHONY: test
-test:
-	gotestsum --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
+test: test-report-setup
+	gotestsum --junitfile "$(PWD)/outputs/TEST-unit-cli.xml" --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...

--- a/commons.mk
+++ b/commons.mk
@@ -1,0 +1,4 @@
+# Prepare junit build context
+.PHONY: test-report-setup
+test-report-setup:
+	mkdir -p $(PWD)/outputs

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,3 +1,5 @@
+include ../commons.mk
+
 SUITE?=metricbeat
 TAGS?=
 DEVELOPER_MODE?=false
@@ -101,9 +103,17 @@ notice:
 		-depsOut ""
 
 .PHONY: unit-test
-unit-test:
-	gotestsum --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
-	cd _suites && gotestsum --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
+unit-test: test-report-setup unit-test-e2e unit-test-suite-fleet unit-test-suite-helm unit-test-suite-metricbeat
+
+# See https://pkg.go.dev/gotest.tools/gotestsum/#readme-junit-xml-output
+.PHONY: unit-test-e2e
+unit-test-e2e:
+	gotestsum --junitfile "$(PWD)/outputs/TEST-unit-e2e.xml" --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
+
+# See https://pkg.go.dev/gotest.tools/gotestsum/#readme-junit-xml-output
+.PHONY: unit-test-suite-%
+unit-test-suite-%:
+	cd _suites/$* && gotestsum --junitfile "$(PWD)/outputs/TEST-unit-e2e-$*.xml" --format testname -- -count=1 -timeout=$(TEST_TIMEOUT) ./...
 
 ## Test examples
 


### PR DESCRIPTION
Backports the following commits to 7.11.x:
 - fix: generate a jUnit file per test suite (#907)