### PR TITLE
chore: follow Golang's best practices (#865) backport for 7.11.x

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
     string(name: 'SLACK_CHANNEL', defaultValue: 'observablt-bots', description: 'The Slack channel(s) where errors will be posted. For multiple channels, use a comma-separated list of channels')
     string(name: 'ELASTIC_AGENT_DOWNLOAD_URL', defaultValue: '', description: 'If present, it will override the download URL for the Elastic agent artifact. (I.e. https://snapshots.elastic.co/7.11.0-326bd5a6/downloads/beats/elastic-agent/elastic-agent-7.11.0-SNAPSHOT-linux-x86_64.tar.gz')
     string(name: 'BEAT_VERSION', defaultValue: '7.11-SNAPSHOT', description: 'SemVer version of the Beat to be used for the tests. You can use here the tag of your PR to test your changes')
-    string(name: 'ELASTIC_AGENT_STALE_VERSION', defaultValue: '7.10-SNAPSHOT', description: 'SemVer version of the stale stand-alone elastic-agent to be used for Fleet upgrade tests.')
+    string(name: 'ELASTIC_AGENT_STALE_VERSION', defaultValue: '7.11.1', description: 'SemVer version of the stale stand-alone elastic-agent to be used for Fleet upgrade tests.')
     booleanParam(name: "BEATS_USE_CI_SNAPSHOTS", defaultValue: false, description: "If it's needed to use the binary snapshots produced by Beats CI instead of the official releases")
     choice(name: 'LOG_LEVEL', choices: ['DEBUG', 'TRACE', 'INFO'], description: 'Log level to be used')
     choice(name: 'TIMEOUT_FACTOR', choices: ['5', '3', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/e2e-testing/cli/services"
 	curl "github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
+	"github.com/elastic/e2e-testing/e2e/steps"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -311,7 +312,7 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleetWithInstaller(image string, i
 	}
 
 	// get container hostname once
-	hostname, err := getContainerHostname(containerName)
+	hostname, err := steps.GetContainerHostname(containerName)
 	if err != nil {
 		return err
 	}
@@ -383,7 +384,8 @@ func (fts *FleetTestSuite) processStateChangedOnTheHost(process string, state st
 	// because it does not support returning the output of a
 	// command: it simply returns error level
 	containerName := fmt.Sprintf("%s_%s_%s_%d", profile, fts.Image+"-systemd", ElasticAgentServiceName, 1)
-	return checkProcessStateOnTheHost(containerName, process, "stopped")
+
+	return steps.CheckProcessStateOnTheHost(containerName, process, "stopped", timeoutFactor)
 }
 
 func (fts *FleetTestSuite) setup() error {

--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/e2e"
+	"github.com/elastic/e2e-testing/e2e/steps"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -37,7 +38,7 @@ type BasePackage struct {
 
 // extractPackage depends on the underlying OS, so 'cmds' must contain the specific instructions for the OS
 func (i *BasePackage) extractPackage(cmds []string) error {
-	err := execCommandInService(i.profile, i.image, i.service, cmds, false)
+	err := steps.ExecCommandInService(i.profile, i.image, i.service, cmds, profileEnv, false)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"command": cmds,
@@ -72,7 +73,7 @@ func (i *BasePackage) PrintLogs(containerName string) error {
 		"cat", i.logFile,
 	}
 
-	err = execCommandInService(i.profile, i.image, i.service, cmd, false)
+	err = steps.ExecCommandInService(i.profile, i.image, i.service, cmd, profileEnv, false)
 	if err != nil {
 		return err
 	}
@@ -128,13 +129,13 @@ func (i *DEBPackage) InstallCerts() error {
 	return installCertsForDebian(i.profile, i.image, i.service)
 }
 func installCertsForDebian(profile string, image string, service string) error {
-	if err := execCommandInService(profile, image, service, []string{"apt-get", "update"}, false); err != nil {
+	if err := steps.ExecCommandInService(profile, image, service, []string{"apt-get", "update"}, profileEnv, false); err != nil {
 		return err
 	}
-	if err := execCommandInService(profile, image, service, []string{"apt", "install", "ca-certificates", "-y"}, false); err != nil {
+	if err := steps.ExecCommandInService(profile, image, service, []string{"apt", "install", "ca-certificates", "-y"}, profileEnv, false); err != nil {
 		return err
 	}
-	if err := execCommandInService(profile, image, service, []string{"update-ca-certificates", "-f"}, false); err != nil {
+	if err := steps.ExecCommandInService(profile, image, service, []string{"update-ca-certificates", "-f"}, profileEnv, false); err != nil {
 		return err
 	}
 	return nil
@@ -276,16 +277,16 @@ func (i *RPMPackage) InstallCerts() error {
 	return installCertsForCentos(i.profile, i.image, i.service)
 }
 func installCertsForCentos(profile string, image string, service string) error {
-	if err := execCommandInService(profile, image, service, []string{"yum", "check-update"}, false); err != nil {
+	if err := steps.ExecCommandInService(profile, image, service, []string{"yum", "check-update"}, profileEnv, false); err != nil {
 		return err
 	}
-	if err := execCommandInService(profile, image, service, []string{"yum", "install", "ca-certificates", "-y"}, false); err != nil {
+	if err := steps.ExecCommandInService(profile, image, service, []string{"yum", "install", "ca-certificates", "-y"}, profileEnv, false); err != nil {
 		return err
 	}
-	if err := execCommandInService(profile, image, service, []string{"update-ca-trust", "force-enable"}, false); err != nil {
+	if err := steps.ExecCommandInService(profile, image, service, []string{"update-ca-trust", "force-enable"}, profileEnv, false); err != nil {
 		return err
 	}
-	if err := execCommandInService(profile, image, service, []string{"update-ca-trust", "extract"}, false); err != nil {
+	if err := steps.ExecCommandInService(profile, image, service, []string{"update-ca-trust", "extract"}, profileEnv, false); err != nil {
 		return err
 	}
 	return nil
@@ -378,7 +379,7 @@ func (i *TARPackage) Preinstall() error {
 		[]string{"mv", fmt.Sprintf("/%s-%s-%s-%s", i.artifact, i.version, i.OS, i.arch), "/elastic-agent"},
 	}
 	for _, cmd := range cmds {
-		err = execCommandInService(i.profile, i.image, i.service, cmd, false)
+		err = steps.ExecCommandInService(i.profile, i.image, i.service, cmd, profileEnv, false)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"command": cmd,

--- a/e2e/_suites/fleet/services.go
+++ b/e2e/_suites/fleet/services.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/e2e"
+	"github.com/elastic/e2e-testing/e2e/steps"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -66,7 +67,7 @@ func runElasticAgentCommand(profile string, image string, service string, proces
 	}
 	cmds = append(cmds, arguments...)
 
-	err := execCommandInService(profile, image, service, cmds, false)
+	err := steps.ExecCommandInService(profile, image, service, cmds, profileEnv, false)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"command": cmds,
@@ -441,7 +442,7 @@ func newTarInstaller(image string, tag string, version string) (ElasticAgentInst
 
 func systemctlRun(profile string, image string, service string, command string) error {
 	cmd := []string{"systemctl", command, ElasticAgentProcessName}
-	err := execCommandInService(profile, image, service, cmd, false)
+	err := steps.ExecCommandInService(profile, image, service, cmd, profileEnv, false)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"command": cmd,

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/e2e-testing/cli/services"
 	shell "github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
+	"github.com/elastic/e2e-testing/e2e/steps"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -109,7 +110,7 @@ func (sats *StandAloneTestSuite) aStandaloneAgentIsDeployed(image string) error 
 	}
 
 	// get container hostname once
-	hostname, err := getContainerHostname(containerName)
+	hostname, err := steps.GetContainerHostname(containerName)
 	if err != nil {
 		return err
 	}

--- a/e2e/_suites/fleet/world.go
+++ b/e2e/_suites/fleet/world.go
@@ -1,0 +1,72 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/elastic/e2e-testing/cli/services"
+	"github.com/elastic/e2e-testing/e2e/steps"
+)
+
+// developerMode tears down the backend services (ES, Kibana, Package Registry)
+// after a test suite. This is the desired behavior, but when developing, we maybe want to keep
+// them running to speed up the development cycle.
+// It can be overriden by the DEVELOPER_MODE env var
+var developerMode = false
+
+// ElasticAgentProcessName the name of the process for the Elastic Agent
+const ElasticAgentProcessName = "elastic-agent"
+
+// ElasticAgentServiceName the name of the service for the Elastic Agent
+const ElasticAgentServiceName = "elastic-agent"
+
+// FleetProfileName the name of the profile to run the runtime, backend services
+const FleetProfileName = "fleet"
+
+var agentVersionBase = "7.11-SNAPSHOT"
+
+// agentVersion is the version of the agent to use
+// It can be overriden by BEAT_VERSION env var
+var agentVersion = agentVersionBase
+
+// agentStaleVersion is the version of the agent to use as a base during upgrade
+// It can be overriden by ELASTIC_AGENT_STALE_VERSION env var. Using latest GA as a default.
+var agentStaleVersion = "7.10-SNAPSHOT"
+
+// stackVersion is the version of the stack to use
+// It can be overriden by STACK_VERSION env var
+var stackVersion = agentVersionBase
+
+// profileEnv is the environment to be applied to any execution
+// affecting the runtime dependencies (or profile)
+var profileEnv map[string]string
+
+// timeoutFactor a multiplier for the max timeout when doing backoff retries.
+// It can be overriden by TIMEOUT_FACTOR env var
+var timeoutFactor = 3
+
+// All URLs running on localhost as Kibana is expected to be exposed there
+const kibanaBaseURL = "http://localhost:5601"
+
+var kibanaClient *services.KibanaClient
+
+// IngestManagerTestSuite represents a test suite, holding references to the pieces needed to run the tests
+type IngestManagerTestSuite struct {
+	Fleet      *FleetTestSuite
+	StandAlone *StandAloneTestSuite
+}
+
+func (imts *IngestManagerTestSuite) processStateOnTheHost(process string, state string) error {
+	profile := FleetProfileName
+	serviceName := ElasticAgentServiceName
+
+	containerName := fmt.Sprintf("%s_%s_%s_%d", profile, imts.Fleet.Image+"-systemd", serviceName, 1)
+	if imts.StandAlone.Hostname != "" {
+		containerName = fmt.Sprintf("%s_%s_%d", profile, serviceName, 1)
+	}
+
+	return steps.CheckProcessStateOnTheHost(containerName, process, state, timeoutFactor)
+}

--- a/e2e/_suites/fleet/world.go
+++ b/e2e/_suites/fleet/world.go
@@ -34,7 +34,7 @@ var agentVersion = agentVersionBase
 
 // agentStaleVersion is the version of the agent to use as a base during upgrade
 // It can be overriden by ELASTIC_AGENT_STALE_VERSION env var. Using latest GA as a default.
-var agentStaleVersion = "7.10-SNAPSHOT"
+var agentStaleVersion = "7.11.1"
 
 // stackVersion is the version of the stack to use
 // It can be overriden by STACK_VERSION env var

--- a/e2e/steps/befores.go
+++ b/e2e/steps/befores.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package steps
 
 import (

--- a/e2e/steps/processes.go
+++ b/e2e/steps/processes.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package steps
+
+import (
+	"time"
+
+	"github.com/elastic/e2e-testing/e2e"
+	log "github.com/sirupsen/logrus"
+)
+
+// CheckProcessStateOnTheHost checks if a process is in the desired state in a container
+// name of the container for the service:
+// we are using the Docker client instead of docker-compose
+// because it does not support returning the output of a
+// command: it simply returns error level
+func CheckProcessStateOnTheHost(containerName string, process string, state string, timeoutFactor int) error {
+	timeout := time.Duration(timeoutFactor) * time.Minute
+
+	err := e2e.WaitForProcess(containerName, process, state, timeout)
+	if err != nil {
+		if state == "started" {
+			log.WithFields(log.Fields{
+				"container ": containerName,
+				"error":      err,
+				"timeout":    timeout,
+			}).Error("The process was not found but should be present")
+		} else {
+			log.WithFields(log.Fields{
+				"container": containerName,
+				"error":     err,
+				"timeout":   timeout,
+			}).Error("The process was found but shouldn't be present")
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/e2e/steps/services.go
+++ b/e2e/steps/services.go
@@ -1,0 +1,65 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package steps
+
+import (
+	"context"
+
+	"github.com/elastic/e2e-testing/cli/docker"
+	"github.com/elastic/e2e-testing/cli/services"
+	log "github.com/sirupsen/logrus"
+)
+
+// ExecCommandInService executes a command in a service from a profile
+func ExecCommandInService(profile string, image string, serviceName string, cmds []string, env map[string]string, detach bool) error {
+	serviceManager := services.NewServiceManager()
+
+	composes := []string{
+		profile, // profile name
+		image,   // image for the service
+	}
+	composeArgs := []string{"exec", "-T"}
+	if detach {
+		composeArgs = append(composeArgs, "-d")
+	}
+	composeArgs = append(composeArgs, serviceName)
+	composeArgs = append(composeArgs, cmds...)
+
+	err := serviceManager.RunCommand(profile, composes, composeArgs, env)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"command": cmds,
+			"error":   err,
+			"service": serviceName,
+		}).Error("Could not execute command in service container")
+
+		return err
+	}
+
+	return nil
+}
+
+// GetContainerHostname we need the container name because we use the Docker Client instead of Docker Compose
+func GetContainerHostname(containerName string) (string, error) {
+	log.WithFields(log.Fields{
+		"containerName": containerName,
+	}).Trace("Retrieving container name from the Docker client")
+
+	hostname, err := docker.ExecCommandIntoContainer(context.Background(), containerName, "root", []string{"cat", "/etc/hostname"})
+	if err != nil {
+		log.WithFields(log.Fields{
+			"containerName": containerName,
+			"error":         err,
+		}).Error("Could not retrieve container name from the Docker client")
+		return "", err
+	}
+
+	log.WithFields(log.Fields{
+		"containerName": containerName,
+		"hostname":      hostname,
+	}).Info("Hostname retrieved from the Docker client")
+
+	return hostname, nil
+}


### PR DESCRIPTION
Backports the following commits to 7.11.x:
 - chore: follow Golang's best practices (#865)