### PR TITLE
Update missing instruction for functional-test

### DIFF
--- a/e2e/_suites/fleet/README.md
+++ b/e2e/_suites/fleet/README.md
@@ -65,6 +65,7 @@ This is an example of the optional configuration:
 4. Install dependencies.
 
    - Install Go: `https://golang.org/doc/install` _(The CI uses [GVM](https://github.com/andrewkroh/gvm))_
+   - Install integrations `make -C e2e sync-integrations`
    - Install godog (from project's root directory): `make -C e2e install-godog`
 
 5. Run the tests.


### PR DESCRIPTION
For local development/testing we were missing a documented step that needed to
sync the integrations. Added this to the install dependencies section.

Signed-off-by: Adam Stokes <51892+adam-stokes@users.noreply.github.com>

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

This updates our documentation for developers who wish to run the test suites on their local machines

## Why is it important?

The document was missing an important step for allowing the test suites to run without issue.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

To verify, please follow the `Install Dependencies` section from the top down and then running:

 `SUITE=metricbeat TAGS="apache" make --no-print-directory -C e2e functional-test`