### PR TITLE
ci: use the new flaky analyser

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -278,7 +278,7 @@ def doNotifyBuildResult(boolean slackNotify) {
   }
 
   def header = "*Test Suite*: " + testsSuites
-  notifyBuildResult(analyzeFlakey: true, flakyReportIdx: "reporter-e2e-tests-end-2-end-tests-pipeline-${env.JOB_BASE_NAME}", prComment: true, slackHeader: header, slackChannel: "${channels}", slackComment: true, slackNotify: slackNotify)
+  notifyBuildResult(analyzeFlakey: true, jobName: getFlakyJobName(withBranch: "${env.JOB_BASE_NAME}"), prComment: true, slackHeader: header, slackChannel: "${channels}", slackComment: true, slackNotify: slackNotify)
 }
 
 


### PR DESCRIPTION
## What does this PR do?

Use the new flaky analyser approach:

- elastic/apm-pipeline-library#1038

## Why is it important?

Flaky analyser has been reimplemented, let's use the new implementation
