### PR TITLE
fix: pass platform version to metricbeat, not to the integration

### DIFF
--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -406,10 +406,15 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 			return err
 		}
 
+		mts.Version = mts.Version + "-amd64"
+
 		err = docker.TagImage(
 			"docker.elastic.co/beats/metricbeat:"+metricbeatVersionBase,
-			"docker.elastic.co/observability-ci/metricbeat:"+mts.Version+"-amd64",
+			"docker.elastic.co/observability-ci/metricbeat:"+mts.Version,
 		)
+		if err != nil {
+			return err
+		}
 	}
 
 	// this is needed because, in general, the target service (apache, mysql, redis) does not have a healthcheck
@@ -436,7 +441,7 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 		"metricbeatConfigFile":  mts.configurationFile,
 		"metricbeatTag":         mts.Version,
 		"stackVersion":          stackVersion,
-		mts.ServiceName + "Tag": mts.ServiceVersion + "-amd64",
+		mts.ServiceName + "Tag": mts.ServiceVersion,
 		"serviceName":           mts.ServiceName,
 	}
 

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -408,6 +408,9 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 
 		mts.Version = mts.Version + "-amd64"
 
+		// wait for tagging to ensure the loaded image is present
+		e2e.Sleep(3 * time.Second)
+
 		err = docker.TagImage(
 			"docker.elastic.co/beats/metricbeat:"+metricbeatVersionBase,
 			"docker.elastic.co/observability-ci/metricbeat:"+mts.Version,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It passes the platform version (amd64/arm64) to the metricbeat service, not to the integration service

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It was causing failures for Beats PRs, as they downloaded the metricbeat Docker image from a GCP bucket, then it was loaded into the Docker engine and tagged. Because of this bug, the image for the platform was not correctly tagged, causing the build to fail because the Docker image was not found.

It was not discovered on master because the functionality is covered by the `BEATS_USE_CI_SNAPSHOTS` or the `BEATS_LOCAL_PATH`, and only the first one is executed on CI, for PRs.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

In master:
```shell
SUITE="metricbeat" TAGS="integrations && apache" GITHUB_CHECK_SHA1="179917e2d3aa7263dd1e316b92ff87f83af4d38d" BEATS_USE_CI_SNAPSHOTS=false TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true make -C e2e functional-test
```

For a PR in 7.x:
```shell
git checkout 7.x
echo "You need to cherrypick commits in this PR"
SUITE="metricbeat" TAGS="integrations && apache" GITHUB_CHECK_SHA1="179917e2d3aa7263dd1e316b92ff87f83af4d38d" BEATS_USE_CI_SNAPSHOTS=true TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Caused by 6b9528b14d545c58680cd4d7d3711f2f14843b24 (#787)
- Closes #932


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
Backport to all maintenance branches
<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->