### PR TITLE
chore: add back traces when extracting the files from the box

### DIFF
--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -17,7 +17,7 @@ import (
 var deployToProfile string
 
 func init() {
-	config.InitConfig()
+	config.Init()
 
 	for k := range config.AvailableServices() {
 		// deploy command

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -19,7 +19,7 @@ var servicesToRun string
 var versionToRun string
 
 func init() {
-	config.InitConfig()
+	config.Init()
 
 	rootCmd.AddCommand(runCmd)
 

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -17,7 +17,7 @@ import (
 var versionToStop string
 
 func init() {
-	config.InitConfig()
+	config.Init()
 
 	rootCmd.AddCommand(stopCmd)
 

--- a/cli/cmd/sync.go
+++ b/cli/cmd/sync.go
@@ -27,7 +27,7 @@ var excludedBlocks = []string{"build"}
 var remote = "elastic:master"
 
 func init() {
-	config.InitConfig()
+	config.Init()
 
 	syncIntegrationsCmd.Flags().BoolVarP(&deleteRepository, "delete", "d", false, "Will delete the existing Beats repository before cloning it again (default false)")
 	syncIntegrationsCmd.Flags().StringVarP(&remote, "remote", "r", "elastic:master", "Sets the remote for Beats, using 'user:branch' as format (i.e. elastic:master)")

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -314,6 +314,12 @@ func extractProfileServiceConfig(op *OpConfig, box *packr.Box) error {
 				return err
 			}
 		}
+
+		log.WithFields(log.Fields{
+			"file": p,
+			"dir":  dir,
+		}).Trace("Extracting boxed file")
+
 		return ioutil.WriteFile(p, []byte(file.String()), 0644)
 	}
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -118,6 +118,10 @@ func GetServiceConfig(service string) (Service, bool) {
 
 // Init creates this tool workspace under user's home, in a hidden directory named ".op"
 func Init() {
+	if Op != nil {
+		return
+	}
+
 	configureLogger()
 
 	binaries := []string{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds back the log traces when a file was extracted from the box. While adding them, and testing it locally, I found that the initialisation order provided by Go init() method is not deterministic, because of that I checked that the logger init was not called at the right time. With change we ensure that the Init is:
1. called first
2. exiting if the config was already populated

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It adds verbose messages about what files are bundled in the tool.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

```shell
GO111MODULE=on OP_LOG_LEVEL=TRACE go run main.go run profile fleet
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->



<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

>TRAC[0037] 'op' workdirs created.                        profilesPath=/Users/mdelapenya/.op/compose/profiles servicesPath=/Users/mdelapenya/.op/compose/services
TRAC[0043] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/profiles/fleet/configurations file=/Users/mdelapenya/.op/compose/profiles/fleet/configurations/kibana.config.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/profiles/fleet file=/Users/mdelapenya/.op/compose/profiles/fleet/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/profiles/helm file=/Users/mdelapenya/.op/compose/profiles/helm/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/profiles/metricbeat file=/Users/mdelapenya/.op/compose/profiles/metricbeat/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/apm-server file=/Users/mdelapenya/.op/compose/services/apm-server/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/centos-systemd file=/Users/mdelapenya/.op/compose/services/centos-systemd/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/centos file=/Users/mdelapenya/.op/compose/services/centos/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/debian-systemd file=/Users/mdelapenya/.op/compose/services/debian-systemd/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/debian file=/Users/mdelapenya/.op/compose/services/debian/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/elastic-agent file=/Users/mdelapenya/.op/compose/services/elastic-agent/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/elasticsearch file=/Users/mdelapenya/.op/compose/services/elasticsearch/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/kibana file=/Users/mdelapenya/.op/compose/services/kibana/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/metricbeat file=/Users/mdelapenya/.op/compose/services/metricbeat/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/opbeans-go file=/Users/mdelapenya/.op/compose/services/opbeans-go/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/opbeans-java file=/Users/mdelapenya/.op/compose/services/opbeans-java/docker-compose.yml
TRAC[0052] Extracting boxed file                         dir=/Users/mdelapenya/.op/compose/services/vsphere file=/Users/mdelapenya/.op/compose/services/vsphere/docker-compose.yml

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
