### PR TITLE
fix: retry tagging the loaded docker image up-to 15 seconds

### DIFF
--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -241,7 +241,7 @@ func TagImage(src string, target string) error {
 				"target":      target,
 				"elapsedTime": exp.GetElapsedTime(),
 				"retries":     retryCount,
-			}).Error("Could not tag the Docker image.")
+			}).Warn("Could not tag the Docker image.")
 			return err
 		}
 

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
@@ -211,21 +213,48 @@ func LoadImage(imagePath string) error {
 func TagImage(src string, target string) error {
 	dockerClient := getDockerClient()
 
-	err := dockerClient.ImageTag(context.Background(), src, target)
-	if err != nil {
+	maxTimeout := 15 * time.Second
+	retryCount := 0
+	var (
+		initialInterval     = 500 * time.Millisecond
+		randomizationFactor = 0.5
+		multiplier          = 2.0
+		maxInterval         = 5 * time.Second
+		maxElapsedTime      = maxTimeout
+	)
+
+	exp := backoff.NewExponentialBackOff()
+	exp.InitialInterval = initialInterval
+	exp.RandomizationFactor = randomizationFactor
+	exp.Multiplier = multiplier
+	exp.MaxInterval = maxInterval
+	exp.MaxElapsedTime = maxElapsedTime
+
+	tagImageFn := func() error {
+		retryCount++
+
+		err := dockerClient.ImageTag(context.Background(), src, target)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error":       err,
+				"src":         src,
+				"target":      target,
+				"elapsedTime": exp.GetElapsedTime(),
+				"retries":     retryCount,
+			}).Error("Could not tag the Docker image.")
+			return err
+		}
+
 		log.WithFields(log.Fields{
-			"error":  err,
-			"src":    src,
-			"target": target,
-		}).Error("Could not tag the Docker image.")
-		return err
+			"src":         src,
+			"target":      target,
+			"elapsedTime": exp.GetElapsedTime(),
+			"retries":     retryCount,
+		}).Debug("Docker image tagged successfully")
+		return nil
 	}
 
-	log.WithFields(log.Fields{
-		"src":    src,
-		"target": target,
-	}).Debug("Docker image tagged successfully")
-	return nil
+	return backoff.Retry(tagImageFn, exp)
 }
 
 // RemoveDevNetwork removes the developer network

--- a/e2e/_suites/fleet/installers.go
+++ b/e2e/_suites/fleet/installers.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/elastic/e2e-testing/cli/docker"
 	"github.com/elastic/e2e-testing/e2e"
@@ -200,9 +199,6 @@ func (i *DockerPackage) Preinstall() error {
 	if err != nil {
 		return err
 	}
-
-	// wait for tagging to ensure the loaded image is present
-	e2e.Sleep(3 * time.Second)
 
 	// we need to tag the loaded image because its tag relates to the target branch
 	return docker.TagImage(

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -408,9 +408,6 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 
 		mts.Version = mts.Version + "-amd64"
 
-		// wait for tagging to ensure the loaded image is present
-		e2e.Sleep(3 * time.Second)
-
 		err = docker.TagImage(
 			"docker.elastic.co/beats/metricbeat:"+metricbeatVersionBase,
 			"docker.elastic.co/observability-ci/metricbeat:"+mts.Version,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It applies a backoff strategy for tagging a docker image, removing the active wait of 3 seconds that was sitting in front of its usages. Now the tag will be retried up-to 15 seconds, which is enough.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We detected that 3 seconds is sometimes not enough on CI, causing flakiness in the test exeuction for Beats PRs.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

```shell
git checkout 7.x
## echo 'Apply this PR to that branch as the commit relates to 7.x'
SUITE="metricbeat" TAGS="integrations && haproxy" GITHUB_CHECK_SHA1="7657100c68c502b0ab2e6cc934f18a527c95d9f4" BEATS_USE_CI_SNAPSHOTS=true TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #948
- Workaround until #942 is in place


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
See #942

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->