### PR TITLE
Add basic check on correct service is defined for profile runs

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"github.com/elastic/e2e-testing/cli/config"
@@ -78,7 +79,11 @@ func buildRunProfileCommand(key string, profile config.Profile) *cobra.Command {
 	return &cobra.Command{
 		Use:   key,
 		Short: `Runs the ` + profile.Name + ` profile`,
-		Long:  `Runs the ` + profile.Name + ` profile, spinning up the Services that compound it`,
+		Long: `Runs the ` + profile.Name + ` profile, spinning up the Services that compound it
+
+Example:
+  go run main.go run profile fleet -s elastic-agent:8.0.0-SNAPSHOT
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 			serviceManager := services.NewServiceManager()
 
@@ -99,6 +104,13 @@ func buildRunProfileCommand(key string, profile config.Profile) *cobra.Command {
 
 				for _, srv := range services {
 					arr := strings.Split(srv, ":")
+					if len(arr) != 2 {
+						log.WithFields(log.Fields{
+							"profile":  key,
+							"services": servicesToRun,
+						}).Error("Unable to determine the <image>:<tag>, please make sure to use a known docker tag format, eg. `elastic-agent:8.0.0-SNAPSHOT`")
+						os.Exit(1)
+					}
 					image := arr[0]
 					tag := arr[1]
 


### PR DESCRIPTION
This adds a length check on the string split for verifying that the
<service/image name>:\<tag> is defined when adding additional services to a
profile deployment.

Signed-off-by: Adam Stokes <51892+adam-stokes@users.noreply.github.com>

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

This PR provides a simple length check during the splitting of services when being added to a profile run

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Before there was no validation that a service was properly defined when being added to a profile run, so a command like the following would attempt to run:

`go run main.go run profile fleet -s elastic-agent`

We now check that at least 2 tokens exist for the <servicename-image>:<tag> and exit if not found with a helpful error message.

```
go run main.go run profile fleet -s elastic-agent
DEBU[0000] Docker compose executed.                      cmd="[up -d]" composeFilePaths="[/Users/adam/.op/compose/profiles/fleet/docker-compose.yml]" env="map[profileVersion:latest]" profile=fleet
TRAC[0000] Updating state                                dir=/Users/adam/.op stateFile=/Users/adam/.op/fleet-profile.run
TRAC[0000] State updated                                 dir=/Users/adam/.op stateFile=/Users/adam/.op/fleet-profile.run
ERRO[0000] Unable to determine the <image>:<tag>, please make sure to use a known docker tag format, eg. `-s elastic-agent:8.0.0-SNAPSHOT`  profile=fleet services=elastic-agent
exit status 1
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [x] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
± OP_LOG_LEVEL=TRACE go run main.go run profile fleet -s elastic-agent:8.0.0-SNAPSHOT
```

Verify that a Fleet server is deployed with an elastic agent attached


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #944
