### PR TITLE
ci: use withNode step to avoid reusing workers

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -286,7 +286,7 @@ def generateStep(Map args = [:]){
   def oss = args.get('oss')
   def platform = args.get('platform')
   return {
-    withNode(labels: 'ubuntu-18.04 && immutable && docker', sleepMax: 20, forceWorspace: true){
+    withNode(labels: 'ubuntu-18.04 && immutable && docker', sleepMax: 20, forceWorkspace: true){
       try {
         deleteDir()
         unstash 'source'
@@ -323,7 +323,7 @@ def generateFunctionalTestStep(Map args = [:]){
   def workerLabels = "${platform} && immutable && docker"
 
   return {
-    withNode(labels: "${workerLabels}", sleepMax: 20, forceWorspace: true){
+    withNode(labels: "${workerLabels}", sleepMax: 20, forceWorkspace: true){
       deleteDir()
       unstash 'source'
       withGoEnv(version: "${GO_VERSION}"){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -286,7 +286,7 @@ def generateStep(Map args = [:]){
   def oss = args.get('oss')
   def platform = args.get('platform')
   return {
-    node('ubuntu-18.04 && immutable && docker') {
+    withNode(labels: 'ubuntu-18.04 && immutable && docker', sleepMax: 20, forceWorspace: true){
       try {
         deleteDir()
         unstash 'source'
@@ -295,8 +295,6 @@ def generateStep(Map args = [:]){
             sh script: 'make build', label: 'Create releases'
           }
         }
-      } catch(e) {
-        error(e.toString())
       } finally {
         archiveArtifacts allowEmptyArchive: true, artifacts: "${BASE_DIR}/cli/.github/releases/download/**"
       }
@@ -325,7 +323,7 @@ def generateFunctionalTestStep(Map args = [:]){
   def workerLabels = "${platform} && immutable && docker"
 
   return {
-    node("${workerLabels}") {
+    withNode(labels: "${workerLabels}", sleepMax: 20, forceWorspace: true){
       deleteDir()
       unstash 'source'
       withGoEnv(version: "${GO_VERSION}"){


### PR DESCRIPTION
## What does this PR do?

Use the `withNode` step (https://github.com/elastic/apm-pipeline-library/blob/master/vars/withNode.groovy) 

## Why is it important?

Add self-resilience when the provisioner allocates an existing worker instead assigning a new one.

```
Step the file system Agent folder is empty
```

![image](https://user-images.githubusercontent.com/2871786/112982124-03aecd80-9154-11eb-97d0-3f6b71236300.png)
