### PR TITLE
Add a standalone test scenario for fleet server mode

### DIFF
--- a/cli/config/compose/services/elastic-agent/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/docker-compose.yml
@@ -10,6 +10,14 @@ services:
         condition: service_healthy
     environment:
       - "KIBANA_HOST=http://${kibanaHost:-kibana}:${kibanaPort:-5601}"
+      - "FLEET_SERVER_ENABLE=${fleetServerMode:-0}"
+      - "FLEET_SERVER_INSECURE_HTTP=${fleetServerMode:-0}"
+      - "KIBANA_FLEET_SETUP=${fleetServerMode:-0}"
+      - "FLEET_SERVER_HOST=0.0.0.0"
+      - "KIBANA_USERNAME=elastic"
+      - "KIBANA_PASSWORD=changeme"
     platform: ${elasticAgentPlatform:-linux/amd64}
+    ports:
+      - "127.0.0.1:8220:8220"
     volumes:
       - "${elasticAgentConfigFile}:/usr/share/elastic-agent/elastic-agent.yml"

--- a/e2e/_suites/fleet/features/stand_alone_agent.feature
+++ b/e2e/_suites/fleet/features/stand_alone_agent.feature
@@ -50,3 +50,13 @@ Examples: default
 Examples: Ubi8
 | image   |
 | ubi8    |
+
+@run_fleet_server
+Scenario Outline: Deploying a <image> stand-alone agent with fleet server mode
+  When a "<image>" stand-alone agent is deployed with fleet server mode
+  Then the agent is listed in Fleet as "online"
+
+@default
+Examples: default
+  | image   |
+  | default |

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -406,6 +406,10 @@ func (fts *FleetTestSuite) setup() error {
 }
 
 func (fts *FleetTestSuite) theAgentIsListedInFleetWithStatus(desiredStatus string) error {
+	return theAgentIsListedInFleetWithStatus(desiredStatus, fts.Hostname)
+}
+
+func theAgentIsListedInFleetWithStatus(desiredStatus, hostname string) error {
 	log.Tracef("Checking if agent is listed in Fleet as %s", desiredStatus)
 
 	maxTimeout := time.Duration(timeoutFactor) * time.Minute * 2
@@ -414,7 +418,7 @@ func (fts *FleetTestSuite) theAgentIsListedInFleetWithStatus(desiredStatus strin
 	exp := e2e.GetExponentialBackOff(maxTimeout)
 
 	agentOnlineFn := func() error {
-		agentID, err := getAgentID(fts.Hostname)
+		agentID, err := getAgentID(hostname)
 		if err != nil {
 			retryCount++
 			return err
@@ -425,7 +429,7 @@ func (fts *FleetTestSuite) theAgentIsListedInFleetWithStatus(desiredStatus strin
 			if desiredStatus == "offline" || desiredStatus == "inactive" {
 				log.WithFields(log.Fields{
 					"elapsedTime": exp.GetElapsedTime(),
-					"hostname":    fts.Hostname,
+					"hostname":    hostname,
 					"retries":     retryCount,
 					"status":      desiredStatus,
 				}).Info("The Agent is not present in Fleet, as expected")
@@ -446,7 +450,7 @@ func (fts *FleetTestSuite) theAgentIsListedInFleetWithStatus(desiredStatus strin
 				"agentID":         agentID,
 				"isAgentInStatus": isAgentInStatus,
 				"elapsedTime":     exp.GetElapsedTime(),
-				"hostname":        fts.Hostname,
+				"hostname":        hostname,
 				"retry":           retryCount,
 				"status":          desiredStatus,
 			}).Warn(err.Error())
@@ -459,7 +463,7 @@ func (fts *FleetTestSuite) theAgentIsListedInFleetWithStatus(desiredStatus strin
 		log.WithFields(log.Fields{
 			"isAgentInStatus": isAgentInStatus,
 			"elapsedTime":     exp.GetElapsedTime(),
-			"hostname":        fts.Hostname,
+			"hostname":        hostname,
 			"retries":         retryCount,
 			"status":          desiredStatus,
 		}).Info("The Agent is in the desired status")


### PR DESCRIPTION

## What does this PR do?

Starts Elastic Agent with Fleet Server and auto-enroll.

There seems to be an issue with https://github.com/elastic/e2e-testing/compare/master...jalvz:fleet-server-standalone?expand=1#diff-a6c6a3ad6fe70a90f2f59acfe75e589cd5aa7ca78361c2e26472bd2d0bb4f44eL15, removing that line the Agent enrolls correctly.

With that line, the error looks like: `/usr/share/elastic-agent/elastic-agent.yml: rename /usr/share/elastic-agent/elastic-agent.yml /usr/share/elastic-agent/elastic-agent.yml.2021-03-31T14-16-29.6932.bak: device or resource busy`
Not sure what that is.

For reference, the following also works:

`docker run --network fleet_default -e KIBANA_HOST=http://kibana:5601 -e KIBANA_USERNAME=elastic -e KIBANA_PASSWORD=changeme -e KIBANA_FLEET_SETUP=1 -e FLEET_SERVER_ENABLE=1 -e FLEET_SERVER_INSECURE_HTTP=1 -e FLEET_SERVER_HOST=0.0.0.0 -p 8220:8220 docker.elastic.co/beats/elastic-agent:8.0.0-SNAPSHOT`

```yml
version: '2.4'
networks:
  default:
    name: "fleet_default"
services:
  elastic-agent:
    image: docker.elastic.co/beats/elastic-agent:8.0.0-SNAPSHOT
    container_name: elastic-agent-foo
    environment:
      - "KIBANA_HOST=http://kibana:5601"
      - "FLEET_SERVER_ENABLE=1"
      - "FLEET_SERVER_INSECURE_HTTP=1"
      - "KIBANA_FLEET_SETUP=1"
      - "FLEET_SERVER_HOST=0.0.0.0"
      - "KIBANA_USERNAME=elastic"
      - "KIBANA_PASSWORD=changeme"
    ports:
      - "127.0.0.1:8220:8220"
```

## Why is it important?

Required for upcoming tests 

## Checklist


- [] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Related issues

Related to #900 

