### PR TITLE
Remove the agent config file parameters for stand alone

### DIFF
--- a/cli/config/compose/services/elastic-agent/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/docker-compose.yml
@@ -19,5 +19,3 @@ services:
     platform: ${elasticAgentPlatform:-linux/amd64}
     ports:
       - "127.0.0.1:8220:8220"
-    volumes:
-      - "${elasticAgentConfigFile}:/usr/share/elastic-agent/elastic-agent.yml"

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -7,7 +7,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -22,10 +21,9 @@ import (
 
 // StandAloneTestSuite represents the scenarios for Stand-alone-mode
 type StandAloneTestSuite struct {
-	AgentConfigFilePath string
-	Cleanup             bool
-	Hostname            string
-	Image               string
+	Cleanup  bool
+	Hostname string
+	Image    string
 	// date controls for queries
 	AgentStoppedDate             time.Time
 	RuntimeDependenciesStartDate time.Time
@@ -44,21 +42,6 @@ func (sats *StandAloneTestSuite) afterScenario() {
 		_ = serviceManager.RemoveServicesFromCompose(context.Background(), FleetProfileName, []string{serviceName}, profileEnv)
 	} else {
 		log.WithField("service", serviceName).Info("Because we are running in development mode, the service won't be stopped")
-	}
-
-	if _, err := os.Stat(sats.AgentConfigFilePath); err == nil {
-		beatsLocalPath := shell.GetEnv("BEATS_LOCAL_PATH", "")
-		if beatsLocalPath == "" {
-			os.Remove(sats.AgentConfigFilePath)
-
-			log.WithFields(log.Fields{
-				"path": sats.AgentConfigFilePath,
-			}).Trace("Elastic Agent configuration file removed.")
-		} else {
-			log.WithFields(log.Fields{
-				"path": sats.AgentConfigFilePath,
-			}).Trace("Elastic Agent configuration file not removed because it's part of a repository.")
-		}
 	}
 }
 
@@ -102,11 +85,6 @@ func (sats *StandAloneTestSuite) startAgent(image string, env map[string]string)
 		dockerImageTag += "-amd64"
 	}
 
-	configurationFilePath, err := steps.FetchBeatConfiguration(true, "elastic-agent", "elastic-agent.docker.yml")
-	if err != nil {
-		return err
-	}
-
 	serviceManager := services.NewServiceManager()
 
 	profileEnv["elasticAgentDockerImageSuffix"] = ""
@@ -118,10 +96,7 @@ func (sats *StandAloneTestSuite) startAgent(image string, env map[string]string)
 
 	containerName := fmt.Sprintf("%s_%s_%d", FleetProfileName, ElasticAgentServiceName, 1)
 
-	sats.AgentConfigFilePath = configurationFilePath
-
 	profileEnv["elasticAgentContainerName"] = containerName
-	profileEnv["elasticAgentConfigFile"] = sats.AgentConfigFilePath
 	profileEnv["elasticAgentPlatform"] = "linux/amd64"
 	profileEnv["elasticAgentTag"] = dockerImageTag
 
@@ -129,7 +104,7 @@ func (sats *StandAloneTestSuite) startAgent(image string, env map[string]string)
 		profileEnv[k] = v
 	}
 
-	err = serviceManager.AddServicesToCompose(context.Background(), FleetProfileName, []string{ElasticAgentServiceName}, profileEnv)
+	err := serviceManager.AddServicesToCompose(context.Background(), FleetProfileName, []string{ElasticAgentServiceName}, profileEnv)
 	if err != nil {
 		log.Error("Could not deploy the elastic-agent")
 		return err


### PR DESCRIPTION
Signed-off-by: Adam Stokes <51892+adam-stokes@users.noreply.github.com>

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

This removes the volume mounting of elastic-agent.yml for fleet server stand alone. The side effect is that we will have to think about how we want to approach fleet mode outside of that. Currently in stand alone that config file is not useful and it causes device and resource errors when mounting inside of docker when operations within the elastic-agent occur.

I think for the other use cases we can tests integrations etc more dynamically than having elastic-agent.yml mounted as a volume. Thoughts?

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Testing standalone fleet server will fail if this configuration and volume exists

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Related issues
- Closes #981

## Follow-ups

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->



