### PR TITLE
cli: support passing in environment options and better service def

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -37,7 +37,7 @@ $ ./op stop service mysql -v 5.7.12
 $ ./op stop profile metricbeat
 ```
 
-Additionally, you can pass in environment options that will be passed along to the docker-compose configurations during deployment
+Additionally, you can pass in environment options that will be passed along to the docker-compose configurations during deployment through use of the `-e` flag.
 
 ```
 $ ./op run profile fleet -s elastic-agent:8.0.0-SNAPSHOT -s debian-systemd:latest -e fleetServerMode=1 -e debian_systemdContainerName=test_container_1

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,6 +18,12 @@ $ ./op run service mysql -v 5.7.12
 $ ./op run profile metricbeat
 ```
 
+To pass in multiple services at once:
+
+```
+$ ./op run profile fleet -s elastic-agent:8.0.0-SNAPSHOT -s debian-systemd:latest
+```
+
 The tool also provides a way to stop those running services:
 ```sh
 # if you are in the Go development world
@@ -29,6 +35,12 @@ $ GO111MODULE=on go build -i -o op
 $ ./op stop service apache -v 2.4.20
 $ ./op stop service mysql -v 5.7.12
 $ ./op stop profile metricbeat
+```
+
+Additionally, you can pass in environment options that will be passed along to the docker-compose configurations during deployment
+
+```
+$ ./op run profile fleet -s elastic-agent:8.0.0-SNAPSHOT -s debian-systemd:latest -e fleetServerMode=1 -e debian_systemdContainerName=test_container_1
 ```
 
 >By the way, `op` comes from `Observability Provisioner`.


### PR DESCRIPTION
This provides ability to pass in `-e key=value` to allow applying additional
environment settings to the profiles/services

Also changes the way services are declared by allowing to pass in multiple `-s`
flags instead of doing the string parsing

Signed-off-by: Adam Stokes <51892+adam-stokes@users.noreply.github.com>

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Converts passing multiple services to utilize the `-s service_name:tag -s service_nam_2:tag` approach. Adds ability to pass in multiple `-e key=val` items when wanting to customize the variables within the docker-compose templates

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Adds another layer of validation for parsing additional services via the cli without doing the `strings.Split(',')`. Adds additional customization options via environment variables and follows the same approach as both docker/docker-compose when defining those key/values on the cli

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
OP_LOG_LEVEL=TRACE go run main.go run profile fleet -s elastic-agent:8.0.0-SNAPSHOT -s debian-systemd:latest -e fleetServerMode=1 -e debian_systemdContainerName=mytest
```

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
OP_LOG_LEVEL=TRACE go run main.go run profile fleet -s elastic-agent:8.0.0-SNAPSHOT -s debian-systemd:latest -e fleetServerMode=1 -e debian_systemdContainerName=mytest
TRAC[0000] Validating required tools: [docker docker-compose]
TRAC[0000] Binary is present                             binary=docker path=/usr/local/bin/docker
TRAC[0000] Binary is present                             binary=docker-compose path=/usr/local/bin/docker-compose
TRAC[0000] 'op' workdirs created.                        profilesPath=/Users/adam/.op/compose/profiles servicesPath=/Users/adam/.op/compose/services
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/profiles/fleet/configurations file=/Users/adam/.op/compose/profiles/fleet/configurations/kibana.config.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/profiles/fleet file=/Users/adam/.op/compose/profiles/fleet/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/profiles/helm file=/Users/adam/.op/compose/profiles/helm/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/profiles/metricbeat file=/Users/adam/.op/compose/profiles/metricbeat/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/apm-server file=/Users/adam/.op/compose/services/apm-server/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/centos-systemd file=/Users/adam/.op/compose/services/centos-systemd/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/centos file=/Users/adam/.op/compose/services/centos/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/debian-systemd file=/Users/adam/.op/compose/services/debian-systemd/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/debian file=/Users/adam/.op/compose/services/debian/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/elastic-agent file=/Users/adam/.op/compose/services/elastic-agent/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/elasticsearch file=/Users/adam/.op/compose/services/elasticsearch/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/kibana file=/Users/adam/.op/compose/services/kibana/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/metricbeat file=/Users/adam/.op/compose/services/metricbeat/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/opbeans-go file=/Users/adam/.op/compose/services/opbeans-go/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/opbeans-java file=/Users/adam/.op/compose/services/opbeans-java/docker-compose.yml
TRAC[0000] Extracting boxed file                         dir=/Users/adam/.op/compose/services/vsphere file=/Users/adam/.op/compose/services/vsphere/docker-compose.yml
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/apm-server/docker-compose.yml service=apm-server
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/centos/docker-compose.yml service=centos
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/centos-systemd/docker-compose.yml service=centos-systemd
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/debian/docker-compose.yml service=debian
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/debian-systemd/docker-compose.yml service=debian-systemd
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/elastic-agent/docker-compose.yml service=elastic-agent
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/elasticsearch/docker-compose.yml service=elasticsearch
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/kibana/docker-compose.yml service=kibana
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/metricbeat/docker-compose.yml service=metricbeat
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/opbeans-go/docker-compose.yml service=opbeans-go
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/opbeans-java/docker-compose.yml service=opbeans-java
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/services/vsphere/docker-compose.yml service=vsphere
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/profiles/fleet/docker-compose.yml service=fleet
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/profiles/helm/docker-compose.yml service=helm
TRAC[0000] Workspace file                                path=/Users/adam/.op/compose/profiles/metricbeat/docker-compose.yml service=metricbeat
TRAC[0000] Adding key/value to environment               env=fleetServerMode var=1
TRAC[0000] Adding key/value to environment               env=debian_systemdContainerName var=mytest
TRAC[0000] Compose file found at workdir                 composeFilePath=/Users/adam/.op/compose/profiles/fleet/docker-compose.yml type=profiles
Found orphan containers (931a6ebfe7c0_fleet_elastic-agent_1, fleet_debian-systemd_1) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
fleet_package-registry_1 is up-to-date
fleet_elasticsearch_1 is up-to-date
fleet_kibana_1 is up-to-date
DEBU[0000] Docker compose executed.                      cmd="[up -d]" composeFilePaths="[/Users/adam/.op/compose/profiles/fleet/docker-compose.yml]" env="map[debian_systemdContainerName:mytest fleetServerMode:1 profileVersion:latest]" profile=fleet
TRAC[0000] Updating state                                dir=/Users/adam/.op stateFile=/Users/adam/.op/fleet-profile.run
TRAC[0000] State updated                                 dir=/Users/adam/.op stateFile=/Users/adam/.op/fleet-profile.run
TRAC[0000] Adding service                                image=elastic-agent tag=8.0.0-SNAPSHOT
TRAC[0000] Adding service                                image=debian-systemd tag=latest
TRAC[0000] Adding services to compose                    profile=fleet services="[elastic-agent debian-systemd]"
TRAC[0000] Compose file found at workdir                 composeFilePath=/Users/adam/.op/compose/profiles/fleet/docker-compose.yml type=profiles
TRAC[0000] Compose file found at workdir                 composeFilePath=/Users/adam/.op/compose/services/elastic-agent/docker-compose.yml type=services
TRAC[0000] Compose file found at workdir                 composeFilePath=/Users/adam/.op/compose/services/debian-systemd/docker-compose.yml type=services
The elasticAgentDockerImageSuffix variable is not set. Defaulting to a blank string.
The elasticAgentContainerName variable is not set. Defaulting to a blank string.
The elasticAgentConfigFile variable is not set. Defaulting to a blank string.
fleet_elasticsearch_1 is up-to-date
Recreating fleet_debian-systemd_1 ...
fleet_package-registry_1 is up-to-date
fleet_kibana_1 is up-to-date
```