### PR TITLE
consolidate kibana api to internal project structure

### DIFF
--- a/internal/kibana/agents.go
+++ b/internal/kibana/agents.go
@@ -1,0 +1,226 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kibana
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Jeffail/gabs/v2"
+	log "github.com/sirupsen/logrus"
+)
+
+// UnEnrollAgent unenrolls agent from fleet
+func (c *Client) UnEnrollAgent(hostname string, force bool) error {
+	agentID, err := c.GetAgentIDByHostname(hostname)
+	if err != nil {
+		return err
+	}
+	reqBody := `{}`
+	if force {
+		reqBody = `{"force": true}`
+	}
+	statusCode, respBody, _ := c.post(fmt.Sprintf("%s/agents/%s/unenroll", FleetAPI, agentID), []byte(reqBody))
+	if statusCode != 200 {
+		return fmt.Errorf("could not unenroll agent; API status code = %d, response body = %s", statusCode, respBody)
+	}
+	return nil
+}
+
+// UpgradeAgent upgrades an agent from to version
+func (c *Client) UpgradeAgent(hostname string, version string) error {
+	agentID, err := c.GetAgentIDByHostname(hostname)
+	if err != nil {
+		return err
+	}
+	reqBody := `{"version":"` + version + `", "force": true}`
+	statusCode, respBody, err := c.post(fmt.Sprintf("%s/agents/%s/upgrade", FleetAPI, agentID), []byte(reqBody))
+	if statusCode != 200 {
+		log.WithFields(log.Fields{
+			"body":       respBody,
+			"error":      err,
+			"statusCode": statusCode,
+		}).Error("Could not upgrade agent")
+
+		return err
+	}
+	return nil
+
+}
+
+// ListAgents returns the list of agents enrolled with Fleet.
+func (c *Client) ListAgents() (*gabs.Container, error) {
+	statusCode, respBody, err := c.get(fmt.Sprintf("%s/agents", FleetAPI))
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":  respBody,
+			"error": err,
+		}).Error("Could not get Fleet's online agents")
+		return nil, err
+	}
+
+	if statusCode != 200 {
+		log.WithFields(log.Fields{
+			"body":       respBody,
+			"error":      err,
+			"statusCode": statusCode,
+		}).Error("Could not get Fleet's online agents")
+
+		return nil, err
+	}
+
+	jsonResponse, err := gabs.ParseJSON([]byte(respBody))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+			"body":  respBody,
+		}).Error("Could not parse response into JSON")
+		return nil, err
+	}
+
+	return jsonResponse, nil
+}
+
+// GetAgentByHostname get an agent by the local_metadata.host.name property
+func (c *Client) GetAgentByHostname(hostname string) (*gabs.Container, error) {
+	jsonParsed, err := c.ListAgents()
+	if err != nil {
+		return jsonParsed, err
+	}
+
+	hosts := jsonParsed.Path("list").Children()
+
+	for _, host := range hosts {
+		agentHostname := host.Path("local_metadata.host.hostname").Data().(string)
+		// a hostname has an agentID by status
+		if agentHostname == hostname {
+			log.WithFields(log.Fields{
+				"agent": host,
+			}).Trace("Agent found")
+			return host, nil
+		}
+	}
+
+	return jsonParsed, nil
+}
+
+// GetAgentIDByHostname gets agent id by hostname
+func (c *Client) GetAgentIDByHostname(hostname string) (string, error) {
+	jsonParsed, err := c.GetAgentByHostname(hostname)
+	if err != nil {
+		return "", err
+	}
+	agentID := jsonParsed.Path("id").Data().(string)
+	log.WithFields(log.Fields{
+		"agentId": agentID,
+	}).Trace("Agent Id found")
+	return agentID, nil
+}
+
+// GetAgentStatusByHostname gets agent status by hostname
+func (c *Client) GetAgentStatusByHostname(hostname string) (string, error) {
+	agentID, err := c.GetAgentIDByHostname(hostname)
+	if err != nil {
+		return "", err
+	}
+
+	statusCode, respBody, err := c.get(fmt.Sprintf("%s/agents/%s", FleetAPI, agentID))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":       respBody,
+			"error":      err,
+			"statusCode": statusCode,
+		}).Error("Could not get agent response")
+		return "", err
+	}
+
+	jsonResponse, err := gabs.ParseJSON([]byte(respBody))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+			"body":  respBody,
+		}).Error("Could not parse response into JSON")
+		return "", err
+	}
+
+	agentStatus := jsonResponse.Path("item.status").Data().(string)
+	log.WithFields(log.Fields{
+		"agentStatus": agentStatus,
+	}).Trace("Agent Status found")
+	return agentStatus, nil
+}
+
+// GetAgentEvents get events of agent
+func (c *Client) GetAgentEvents(applicationName string, agentID string, packagePolicyID string, updatedAt string) error {
+	statusCode, respBody, err := c.get(fmt.Sprintf("%s/agents/%s/events", FleetAPI, agentID))
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"agentID":         agentID,
+			"application":     applicationName,
+			"body":            respBody,
+			"error":           err,
+			"packagePolicyID": packagePolicyID,
+		}).Error("Could not get agent events from Fleet")
+
+		return err
+	}
+
+	jsonResponse, err := gabs.ParseJSON([]byte(respBody))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":        err,
+			"responseBody": jsonResponse,
+		}).Error("Could not parse response into JSON")
+		return err
+	}
+
+	if statusCode != 200 {
+		log.WithFields(log.Fields{
+			"agentID":         agentID,
+			"application":     applicationName,
+			"body":            jsonResponse,
+			"error":           err,
+			"packagePolicyID": packagePolicyID,
+		}).Error("Could not get agent events from Fleet")
+
+		return err
+	}
+
+	listItems := jsonResponse.Path("list").Children()
+	for _, item := range listItems {
+		message := item.Path("message").Data().(string)
+		// we use a string because we are not able to process what comes in the event, so we will do
+		// an alphabetical order, as they share same layout but different millis and timezone format
+		timestamp := item.Path("timestamp").Data().(string)
+
+		log.WithFields(log.Fields{
+			"agentID":         agentID,
+			"application":     applicationName,
+			"event_at":        timestamp,
+			"message":         message,
+			"packagePolicyID": packagePolicyID,
+			"updated_at":      updatedAt,
+		}).Trace("Event found")
+
+		matches := (strings.Contains(message, applicationName) &&
+			strings.Contains(message, "["+agentID+"]: State changed to") &&
+			strings.Contains(message, "Protecting with policy {"+packagePolicyID+"}"))
+
+		if matches && timestamp > updatedAt {
+			log.WithFields(log.Fields{
+				"application":     applicationName,
+				"event_at":        timestamp,
+				"packagePolicyID": packagePolicyID,
+				"updated_at":      updatedAt,
+				"message":         message,
+			}).Info("Event after the update was found")
+			return nil
+		}
+	}
+
+	return fmt.Errorf("No %s events where found for the agent in the %s policy", applicationName, packagePolicyID)
+}

--- a/internal/kibana/client.go
+++ b/internal/kibana/client.go
@@ -1,0 +1,94 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kibana
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// Client is responsible for exporting dashboards from Kibana.
+type Client struct {
+	host     string
+	username string
+	password string
+}
+
+// NewClient creates a new instance of the client.
+func NewClient() (*Client, error) {
+	host := BaseURL
+	username := "elastic"
+	password := "changeme"
+
+	return &Client{
+		host:     host,
+		username: username,
+		password: password,
+	}, nil
+}
+
+func (c *Client) get(resourcePath string) (int, []byte, error) {
+	return c.sendRequest(http.MethodGet, resourcePath, nil)
+}
+
+func (c *Client) post(resourcePath string, body []byte) (int, []byte, error) {
+	return c.sendRequest(http.MethodPost, resourcePath, body)
+}
+
+func (c *Client) put(resourcePath string, body []byte) (int, []byte, error) {
+	return c.sendRequest(http.MethodPut, resourcePath, body)
+}
+
+func (c *Client) delete(resourcePath string) (int, []byte, error) {
+	return c.sendRequest(http.MethodDelete, resourcePath, nil)
+}
+
+func (c *Client) sendRequest(method, resourcePath string, body []byte) (int, []byte, error) {
+	reqBody := bytes.NewReader(body)
+	base, err := url.Parse(c.host)
+	if err != nil {
+		return 0, nil, errors.Wrapf(err, "could not create base URL from host: %v", c.host)
+	}
+
+	rel, err := url.Parse(resourcePath)
+	if err != nil {
+		return 0, nil, errors.Wrapf(err, "could not create relative URL from resource path: %v", resourcePath)
+	}
+
+	u := base.ResolveReference(rel)
+
+	log.WithFields(log.Fields{
+		"method": method,
+		"url":    u,
+	}).Trace("Kibana API Query")
+
+	req, err := http.NewRequest(method, u.String(), reqBody)
+	if err != nil {
+		return 0, nil, errors.Wrapf(err, "could not create %v request to Kibana API resource: %s", method, resourcePath)
+	}
+
+	req.SetBasicAuth(c.username, c.password)
+	req.Header.Add("content-type", "application/json")
+	req.Header.Add("kbn-xsrf", "e2e-tests")
+
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not send request to Kibana API")
+	}
+
+	defer resp.Body.Close()
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, errors.Wrap(err, "could not read response body")
+	}
+
+	return resp.StatusCode, body, nil
+}

--- a/internal/kibana/integrations.go
+++ b/internal/kibana/integrations.go
@@ -1,0 +1,133 @@
+package kibana
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Jeffail/gabs/v2"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// IntegrationPackage used to share information about a integration
+type IntegrationPackage struct {
+	ID      string `json:"id,omitempty"`
+	Name    string `json:"name"`
+	Title   string `json:"title"`
+	Version string `json:"version"`
+}
+
+// GetIntegrations returns all available integrations
+func (c *Client) GetIntegrations() ([]IntegrationPackage, error) {
+	statusCode, respBody, err := c.get(fmt.Sprintf("%s/epm/packages", FleetAPI))
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":  respBody,
+			"error": err,
+		}).Error("Could not get Integration package")
+		return []IntegrationPackage{}, err
+	}
+
+	if statusCode != 200 {
+		log.WithFields(log.Fields{
+			"body":       respBody,
+			"error":      err,
+			"statusCode": statusCode,
+		}).Error("Could not get Fleet's installed integrations")
+
+		return nil, err
+	}
+
+	jsonParsed, err := gabs.ParseJSON([]byte(respBody))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":        err,
+			"responseBody": jsonParsed,
+		}).Error("Could not parse get response into JSON")
+		return []IntegrationPackage{}, err
+	}
+
+	var resp struct {
+		Packages []IntegrationPackage `json:"response"`
+	}
+
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return []IntegrationPackage{}, errors.Wrap(err, "Unable to convert integration package to JSON")
+	}
+
+	return resp.Packages, nil
+
+}
+
+// GetIntegrationByPackageName returns metadata from an integration from Fleet
+func (c *Client) GetIntegrationByPackageName(packageName string) (IntegrationPackage, error) {
+	integrationPackages, err := c.GetIntegrations()
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Error("Could not get Integration packages list")
+		return IntegrationPackage{}, err
+	}
+
+	for _, pkg := range integrationPackages {
+		if strings.EqualFold(pkg.Name, packageName) {
+			return pkg, nil
+		}
+	}
+
+	return IntegrationPackage{}, errors.New("Unable to find package")
+}
+
+// GetIntegrationFromAgentPolicy get package policy from agent policy
+func (c *Client) GetIntegrationFromAgentPolicy(packageName string, policy Policy) (PackageDataStream, error) {
+	packagePolicies, err := c.ListPackagePolicies()
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":  err,
+			"policy": policy,
+		}).Trace("An error retrieving the package policies")
+		return PackageDataStream{}, err
+	}
+
+	for _, child := range packagePolicies {
+		if policy.ID == child.PolicyID && strings.EqualFold(packageName, child.Name) {
+			return child, nil
+		}
+	}
+
+	return PackageDataStream{}, errors.New("Unable to find package in policy")
+}
+
+// AddIntegrationToPolicy adds an integration to policy
+func (c *Client) AddIntegrationToPolicy(packageDS PackageDataStream) error {
+	reqBody, err := json.Marshal(packageDS)
+	if err != nil {
+		return errors.Wrap(err, "could not convert policy-package (request) to JSON")
+	}
+
+	statusCode, respBody, err := c.post(fmt.Sprintf("%s/package_policies", FleetAPI), reqBody)
+	if err != nil {
+		return errors.Wrap(err, "could not add package to policy")
+	}
+
+	if statusCode != 200 {
+		return fmt.Errorf("could not add package to policy; API status code = %d; response body = %s", statusCode, respBody)
+	}
+	return nil
+}
+
+// DeleteIntegrationFromPolicy adds an integration to policy
+func (c *Client) DeleteIntegrationFromPolicy(packageDS PackageDataStream) error {
+	reqBody := `{"packagePolicyIds":["` + packageDS.ID + `"]}`
+	statusCode, respBody, err := c.post(fmt.Sprintf("%s/package_policies/delete", FleetAPI), []byte(reqBody))
+	if err != nil {
+		return errors.Wrap(err, "could not delete integration from policy")
+	}
+
+	if statusCode != 200 {
+		return fmt.Errorf("could not delete integration from policy; API status code = %d; response body = %s", statusCode, respBody)
+	}
+	return nil
+}

--- a/internal/kibana/policies.go
+++ b/internal/kibana/policies.go
@@ -1,0 +1,124 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kibana
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// Policy represents an Ingest Manager policy.
+type Policy struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Namespace   string `json:"namespace"`
+}
+
+// ListPolicies returns the list of policies
+func (c *Client) ListPolicies() ([]Policy, error) {
+	statusCode, respBody, err := c.get(fmt.Sprintf("%s/agent_policies", FleetAPI))
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":  respBody,
+			"error": err,
+		}).Error("Could not get Fleet's policies")
+		return nil, err
+	}
+
+	if statusCode != 200 {
+		log.WithFields(log.Fields{
+			"error":      err,
+			"statusCode": statusCode,
+		}).Error("Could not get Fleet's policies")
+
+		return nil, err
+	}
+
+	var resp struct {
+		Items []Policy `json:"items"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, errors.Wrap(err, "Unable to convert list of policies to JSON")
+	}
+
+	return resp.Items, nil
+}
+
+// Var represents a single variable at the package or
+// data stream level, encapsulating the data type of the
+// variable and it's value.
+type Var struct {
+	Value interface{} `json:"value"`
+	Type  string      `json:"type"`
+}
+
+// Vars is a collection of variables either at the package or
+// data stream level.
+type Vars map[string]Var
+
+// DataStream represents a data stream within a package.
+type DataStream struct {
+	Type    string `json:"type"`
+	Dataset string `json:"dataset"`
+}
+
+// Input represents a package-level input.
+type Input struct {
+	Type    string        `json:"type"`
+	Enabled bool          `json:"enabled"`
+	Streams []interface{} `json:"streams"`
+	Vars    Vars          `json:"vars"`
+}
+
+// PackageDataStream represents a request to add a single package's single data stream to a
+// Policy in Ingest Manager.
+type PackageDataStream struct {
+	ID          string             `json:"id,omitempty"`
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Namespace   string             `json:"namespace"`
+	PolicyID    string             `json:"policy_id"`
+	Enabled     bool               `json:"enabled"`
+	OutputID    string             `json:"output_id"`
+	Inputs      []Input            `json:"inputs"`
+	Package     IntegrationPackage `json:"package"`
+}
+
+// ListPackagePolicies return list of package policies
+func (c *Client) ListPackagePolicies() ([]PackageDataStream, error) {
+	statusCode, respBody, err := c.get(fmt.Sprintf("%s/package_policies", FleetAPI))
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":  respBody,
+			"error": err,
+		}).Error("Could not get Fleet's package policies")
+		return nil, err
+	}
+
+	if statusCode != 200 {
+		log.WithFields(log.Fields{
+			"error":      err,
+			"statusCode": statusCode,
+		}).Error("Could not get Fleet's package policies")
+
+		return nil, err
+	}
+
+	var resp struct {
+		Items []PackageDataStream `json:"items"`
+	}
+
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, errors.Wrap(err, "Unable to convert list of package policies to JSON")
+	}
+
+	return resp.Items, nil
+}

--- a/internal/kibana/server.go
+++ b/internal/kibana/server.go
@@ -1,0 +1,310 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kibana
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/Jeffail/gabs/v2"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"go.elastic.co/apm"
+)
+
+// EnrollmentAPIKey struct for holding enrollment response
+type EnrollmentAPIKey struct {
+	Active   bool   `json:"active"`
+	APIKey   string `json:"api_key"`
+	APIKeyID string `json:"api_key_id"`
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	PolicyID string `json:"policy_id"`
+}
+
+// CreateEnrollmentAPIKey creates an enrollment api key
+func (c *Client) CreateEnrollmentAPIKey(policy Policy) (EnrollmentAPIKey, error) {
+	uuid := uuid.New().String()
+
+	reqBody := `{"policy_id": "` + policy.ID + `", "name": "Test token for ` + policy.Name + `-` + uuid + `"}`
+	statusCode, respBody, _ := c.post(fmt.Sprintf("%s/enrollment-api-keys", FleetAPI), []byte(reqBody))
+	if statusCode != 200 {
+		jsonParsed, err := gabs.ParseJSON([]byte(respBody))
+		log.WithFields(log.Fields{
+			"body":       jsonParsed,
+			"reqBody":    reqBody,
+			"error":      err,
+			"statusCode": statusCode,
+		}).Error("Could not create enrollment api key")
+
+		return EnrollmentAPIKey{}, err
+	}
+
+	var resp struct {
+		Enrollment EnrollmentAPIKey `json:"item"`
+	}
+
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return EnrollmentAPIKey{}, errors.Wrap(err, "Unable to convert enrollment response to JSON")
+	}
+
+	return resp.Enrollment, nil
+}
+
+// DeleteEnrollmentAPIKey deletes the enrollment api key
+func (c *Client) DeleteEnrollmentAPIKey(enrollmentID string) error {
+	statusCode, respBody, err := c.delete(fmt.Sprintf("%s/enrollment-api-keys/%s", FleetAPI, enrollmentID))
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":  respBody,
+			"error": err,
+		}).Error("Could not delete enrollment key")
+		return err
+	}
+
+	if statusCode != 200 {
+		log.WithFields(log.Fields{
+			"body":       respBody,
+			"error":      err,
+			"statusCode": statusCode,
+		}).Error("Could not delete enrollment key")
+
+		return err
+	}
+	return nil
+}
+
+// ListEnrollmentAPIKeys list the enrollment api keys
+func (c *Client) ListEnrollmentAPIKeys() ([]EnrollmentAPIKey, error) {
+	statusCode, respBody, err := c.get(fmt.Sprintf("%s/enrollment-api-keys", FleetAPI))
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":  respBody,
+			"error": err,
+		}).Error("Could not get Integration package")
+		return []EnrollmentAPIKey{}, err
+	}
+
+	if statusCode != 200 {
+		log.WithFields(log.Fields{
+			"body":       respBody,
+			"error":      err,
+			"statusCode": statusCode,
+		}).Error("Could not get enrollment apis")
+
+		return []EnrollmentAPIKey{}, err
+	}
+
+	var resp struct {
+		List []EnrollmentAPIKey `json:"list"`
+	}
+
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, errors.Wrap(err, "Unable to convert list of enrollment apis to JSON")
+	}
+
+	return resp.List, nil
+
+}
+
+// RecreateFleet this will force recreate the fleet configuration
+func (c *Client) RecreateFleet() error {
+	waitForFleet := func() error {
+		reqBody := `{ "forceRecreate": true }`
+		statusCode, respBody, err := c.post(fmt.Sprintf("%s/agents/setup", FleetAPI), []byte(reqBody))
+		if err != nil {
+			log.WithFields(log.Fields{
+				"body":       respBody,
+				"error":      err,
+				"statusCode": statusCode,
+			}).Error("Could not initialise Fleet setup")
+			return err
+		}
+
+		jsonResponse, err := gabs.ParseJSON([]byte(respBody))
+		if err != nil {
+			log.WithFields(log.Fields{
+				"body":       jsonResponse,
+				"error":      err,
+				"statusCode": statusCode,
+			}).Error("Could not parse JSON response")
+			return err
+		}
+
+		if statusCode != 200 {
+			log.WithFields(log.Fields{
+				"statusCode": statusCode,
+				"body":       jsonResponse,
+			}).Warn("Fleet not ready")
+			return errors.New("Fleet not ready")
+		}
+
+		log.WithFields(log.Fields{
+			"body":       jsonResponse,
+			"statusCode": statusCode,
+		}).Info("Fleet setup done")
+		return nil
+	}
+	err := backoff.Retry(waitForFleet, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 10))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// WaitForFleet waits for fleet server to be ready
+func (c *Client) WaitForFleet() error {
+	waitForFleet := func() error {
+		statusCode, respBody, err := c.get(fmt.Sprintf("%s/agents/setup", FleetAPI))
+		if err != nil {
+			log.WithFields(log.Fields{
+				"body":       respBody,
+				"error":      err,
+				"statusCode": statusCode,
+			}).Error("Could not verify Fleet is setup and ready")
+			return err
+		}
+		if statusCode != 200 {
+			log.WithFields(log.Fields{
+				"statusCode": statusCode,
+			}).Warn("Fleet not ready")
+			return err
+		}
+
+		jsonResponse, err := gabs.ParseJSON([]byte(respBody))
+		if err != nil {
+			log.WithFields(log.Fields{
+				"body":       jsonResponse,
+				"error":      err,
+				"statusCode": statusCode,
+			}).Error("Could not parse JSON response")
+			return err
+		}
+
+		isReady := jsonResponse.Path("isReady").Data().(bool)
+		if !isReady {
+			log.WithFields(log.Fields{
+				"body":       jsonResponse,
+				"error":      err,
+				"statusCode": statusCode,
+			}).Error("Kibana has not been initialized")
+			return errors.New("Kibana has not been initialized")
+		}
+		log.Info("Kibana setup initialized")
+		return nil
+	}
+	err := backoff.Retry(waitForFleet, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 15))
+	if err != nil {
+		return err
+	}
+	return nil
+
+}
+
+// WaitForReady waits for Kibana to be healthy and accept connections
+func (c *Client) WaitForReady(maxTimeoutMinutes time.Duration) (bool, error) {
+	var (
+		initialInterval     = 500 * time.Millisecond
+		randomizationFactor = 0.5
+		multiplier          = 2.0
+		maxInterval         = 5 * time.Second
+		maxElapsedTime      = maxTimeoutMinutes
+	)
+
+	ctx := context.Background()
+	exp := backoff.NewExponentialBackOff()
+	exp.InitialInterval = initialInterval
+	exp.RandomizationFactor = randomizationFactor
+	exp.Multiplier = multiplier
+	exp.MaxInterval = maxInterval
+	exp.MaxElapsedTime = maxElapsedTime
+
+	retryCount := 1
+
+	kibanaStatus := func() error {
+		span, _ := apm.StartSpanOptions(ctx, "Health", "kibana.health", apm.SpanOptions{
+			Parent: apm.SpanFromContext(ctx).TraceContext(),
+		})
+		defer span.End()
+
+		statusCode, respBody, err := c.get("status")
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error":          err,
+				"statusCode":     statusCode,
+				"respBody":       respBody,
+				"retry":          retryCount,
+				"statusEndpoint": fmt.Sprintf("%s/status", BaseURL),
+				"elapsedTime":    exp.GetElapsedTime(),
+			}).Warn("The Kibana instance is not healthy yet")
+
+			retryCount++
+
+			return err
+		}
+
+		log.WithFields(log.Fields{
+			"retries":        retryCount,
+			"statusEndpoint": fmt.Sprintf("%s/status", BaseURL),
+			"elapsedTime":    exp.GetElapsedTime(),
+		}).Info("The Kibana instance is healthy")
+
+		return nil
+	}
+
+	err := backoff.Retry(kibanaStatus, exp)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// GetDataStreams get data streams from deployed agents
+func (c *Client) GetDataStreams() (*gabs.Container, error) {
+	statusCode, respBody, err := c.get(fmt.Sprintf("%s/data_streams", FleetAPI))
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"body":  respBody,
+			"error": err,
+		}).Error("Could not get Fleet data streams")
+		return &gabs.Container{}, err
+	}
+
+	if statusCode != 200 {
+		log.WithFields(log.Fields{
+			"body":       respBody,
+			"error":      err,
+			"statusCode": statusCode,
+		}).Error("Could not get Fleet data streams api")
+
+		return &gabs.Container{}, err
+	}
+
+	jsonParsed, err := gabs.ParseJSON([]byte(respBody))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":        err,
+			"responseBody": jsonParsed,
+		}).Error("Could not parse response into JSON")
+		return nil, err
+	}
+
+	// data streams should contain array of elements
+	dataStreams := jsonParsed.Path("data_streams")
+
+	log.WithFields(log.Fields{
+		"count": len(dataStreams.Children()),
+	}).Debug("Data Streams retrieved")
+
+	return dataStreams, nil
+}

--- a/internal/kibana/url_prefixes.go
+++ b/internal/kibana/url_prefixes.go
@@ -1,0 +1,13 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kibana
+
+const (
+	// BaseURL Kibana host address
+	BaseURL = "http://localhost:5601"
+
+	// FleetAPI is the prefix for all Kibana Fleet API resources.
+	FleetAPI = "/api/fleet"
+)


### PR DESCRIPTION
Add all relevant kibana api calls into the golang project standard of
`internal/kibana`.

Signed-off-by: Adam Stokes <51892+adam-stokes@users.noreply.github.com>

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

This PR is the start of some refactoring to get the project in a more standardized layout. It adds all the related kibana api calls into `internal/kibana` and also has additional api calls added to abstract out more of the work that is being handled in the testsuites. Currently, this is only an additive PR to get the bits in place for a further refactor of the testsuites and cli.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It is nice to have all the relevant api calls under a single location that is easily identifiable

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have run the Unit tests for the CLI, and they are passing locally~~
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
~~- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Nothing to test at this moment as there are several subsequent PR's that will utilize this new api in the scenario testsuites

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #959 

## Follow-ups

<!-- Optional
Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->

Once this PR is approved and merge I have several additional changes that make use of this code in the testsuites.

This is part of a larger refactor https://github.com/elastic/e2e-testing/compare/feat-kibana-refactor that gives a better idea of where these new additions will be utilized and which of the original code is moved/removed. Most of the code related to this PR lives in `cli/services/kibana.go` and additional code lives in `e2e/_suites/fleet/fleet.go` `e2e/_suites/fleet/integrations.go`. In the referenced `feat-kibana-refactor` branch you can get a better idea of how that looks and get a feel for the direction I am taking.