### PR TITLE
Uniquify the stand-alone step for checking agent status

### DIFF
--- a/e2e/_suites/fleet/features/stand_alone_agent.feature
+++ b/e2e/_suites/fleet/features/stand_alone_agent.feature
@@ -54,7 +54,7 @@ Examples: Ubi8
 @run_fleet_server
 Scenario Outline: Deploying a <image> stand-alone agent with fleet server mode
   When a "<image>" stand-alone agent is deployed with fleet server mode
-  Then the agent is listed in Fleet as "online"
+  Then the stand-alone agent is listed in Fleet as "online"
 
 @default
 Examples: default

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -68,7 +68,7 @@ func (sats *StandAloneTestSuite) contributeSteps(s *godog.ScenarioContext) {
 	s.Step(`^there is new data in the index from agent$`, sats.thereIsNewDataInTheIndexFromAgent)
 	s.Step(`^the "([^"]*)" docker container is stopped$`, sats.theDockerContainerIsStopped)
 	s.Step(`^there is no new data in the index after agent shuts down$`, sats.thereIsNoNewDataInTheIndexAfterAgentShutsDown)
-	s.Step(`^the agent is listed in Fleet as "([^"]*)"$`, sats.theAgentIsListedInFleetWithStatus)
+	s.Step(`^the stand-alone agent is listed in Fleet as "([^"]*)"$`, sats.theAgentIsListedInFleetWithStatus)
 }
 
 func (sats *StandAloneTestSuite) theAgentIsListedInFleetWithStatus(desiredStatus string) error {


### PR DESCRIPTION
There were 2 steps identical in both the stand-alone and fleet test suites.
Running the stand-alone test suite was picking up the step from the fleet test
suite and trying to reference the FleetTestSuite structure which did not hold
any of the agent information (like the hostname) for the stand alone tests.

This fixes it so that the standalone test step is being referenced in the
correct test suite.

Signed-off-by: Adam Stokes <51892+adam-stokes@users.noreply.github.com>

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Makes the steps unique between stand-alone and fleet test suites

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The stand-alone tests were incorrectly picking up steps from the fleet test suite

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
e2e/_suites/fleet/ > godog -t '@run_fleet_server'
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #984 
