### PR TITLE
Fix fleet server test

### DIFF
--- a/cli/config/compose/services/elastic-agent/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/docker-compose.yml
@@ -19,5 +19,5 @@ services:
     platform: ${elasticAgentPlatform:-linux/amd64}
     ports:
       - "127.0.0.1:8220:8220"
-    volumes:
-      - "${elasticAgentConfigFile}:/usr/share/elastic-agent/elastic-agent.yml"
+    #volumes:
+    #  - "${elasticAgentConfigFile}:/usr/share/elastic-agent/elastic-agent.yml"

--- a/e2e/_suites/fleet/features/stand_alone_agent.feature
+++ b/e2e/_suites/fleet/features/stand_alone_agent.feature
@@ -54,7 +54,7 @@ Examples: Ubi8
 @run_fleet_server
 Scenario Outline: Deploying a <image> stand-alone agent with fleet server mode
   When a "<image>" stand-alone agent is deployed with fleet server mode
-  Then the agent is listed in Fleet as "online"
+  Then the agent is listed in the Fleet UI as "online"
 
 @default
 Examples: default

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -68,7 +68,7 @@ func (sats *StandAloneTestSuite) contributeSteps(s *godog.ScenarioContext) {
 	s.Step(`^there is new data in the index from agent$`, sats.thereIsNewDataInTheIndexFromAgent)
 	s.Step(`^the "([^"]*)" docker container is stopped$`, sats.theDockerContainerIsStopped)
 	s.Step(`^there is no new data in the index after agent shuts down$`, sats.thereIsNoNewDataInTheIndexAfterAgentShutsDown)
-	s.Step(`^the agent is listed in Fleet as "([^"]*)"$`, sats.theAgentIsListedInFleetWithStatus)
+	s.Step(`^the agent is listed in the Fleet UI as "([^"]*)"$`, sats.theAgentIsListedInFleetWithStatus)
 }
 
 func (sats *StandAloneTestSuite) theAgentIsListedInFleetWithStatus(desiredStatus string) error {


### PR DESCRIPTION

## What does this PR do?

Follow up of https://github.com/elastic/e2e-testing/pull/978

## Why is it important?

Because 978 is broken

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

