### PR TITLE
[mergify] assign the original author

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,25 +15,34 @@ pull_request_rules:
             ```
   - name: backport patches to 7.x branch
     conditions:
+      - merged
       - base=master
       - label=v7.13.0
     actions:
       backport:
+        assignees:
+          - "{{ author }}"
         branches:
           - "7.x"
   - name: backport patches to 7.12 branch
     conditions:
+      - merged
       - base=master
       - label=v7.12.0
     actions:
       backport:
+        assignees:
+          - "{{ author }}"
         branches:
           - "7.12.x"
   - name: backport patches to 7.11 branch
     conditions:
+      - merged
       - base=master
       - label=v7.11.0
     actions:
       backport:
+        assignees:
+          - "{{ author }}"
         branches:
           - "7.11.x"


### PR DESCRIPTION
## What does this PR do?

Mergify now supports the original author assignation. https://docs.mergify.io/actions/backport/#options. Besides, use the `merged` condition to avoid waiting GH commit status checks while this should be a post-merge event based.

## Why is it important?

To help with the tracking when mergify creates backports