### PR TITLE
fix: delay checking stale agent version until it's used

### DIFF
--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -169,7 +169,15 @@ func (fts *FleetTestSuite) anStaleAgentIsDeployedToFleetWithInstaller(image, ver
 
 	agentStaleVersion = shell.GetEnv("ELASTIC_AGENT_STALE_VERSION", agentStaleVersion)
 	// check if stale version is an alias
-	agentStaleVersion = e2e.GetElasticArtifactVersion(agentStaleVersion)
+	v, err := e2e.GetElasticArtifactVersion(agentStaleVersion)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"version": agentStaleVersion,
+		}).Error("Failed to get stale version")
+		return err
+	}
+	agentStaleVersion = v
 
 	useCISnapshots := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
 	if useCISnapshots && !strings.HasSuffix(agentStaleVersion, "-SNAPSHOT") {

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/elastic/e2e-testing/cli/services"
 	curl "github.com/elastic/e2e-testing/cli/shell"
+	shell "github.com/elastic/e2e-testing/cli/shell"
 	"github.com/elastic/e2e-testing/e2e"
 	"github.com/elastic/e2e-testing/e2e/steps"
 	"github.com/google/uuid"
@@ -165,6 +166,15 @@ func (fts *FleetTestSuite) contributeSteps(s *godog.ScenarioContext) {
 func (fts *FleetTestSuite) anStaleAgentIsDeployedToFleetWithInstaller(image, version, installerType string) error {
 	agentVersionBackup := fts.Version
 	defer func() { fts.Version = agentVersionBackup }()
+
+	agentStaleVersion = shell.GetEnv("ELASTIC_AGENT_STALE_VERSION", agentStaleVersion)
+	// check if stale version is an alias
+	agentStaleVersion = e2e.GetElasticArtifactVersion(agentStaleVersion)
+
+	useCISnapshots := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
+	if useCISnapshots && !strings.HasSuffix(agentStaleVersion, "-SNAPSHOT") {
+		agentStaleVersion += "-SNAPSHOT"
+	}
 
 	switch version {
 	case "stale":

--- a/e2e/_suites/fleet/ingest_manager_test.go
+++ b/e2e/_suites/fleet/ingest_manager_test.go
@@ -7,7 +7,6 @@ package main
 import (
 	"context"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/cucumber/godog"
@@ -36,15 +35,6 @@ func setUpSuite() {
 
 	timeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", timeoutFactor)
 	agentVersion = shell.GetEnv("BEAT_VERSION", agentVersionBase)
-
-	agentStaleVersion = shell.GetEnv("ELASTIC_AGENT_STALE_VERSION", agentStaleVersion)
-	// check if stale version is an alias
-	agentStaleVersion = e2e.GetElasticArtifactVersion(agentStaleVersion)
-
-	useCISnapshots := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
-	if useCISnapshots && !strings.HasSuffix(agentStaleVersion, "-SNAPSHOT") {
-		agentStaleVersion += "-SNAPSHOT"
-	}
 
 	// check if version is an alias
 	agentVersion = e2e.GetElasticArtifactVersion(agentVersion)

--- a/e2e/_suites/fleet/ingest_manager_test.go
+++ b/e2e/_suites/fleet/ingest_manager_test.go
@@ -32,22 +32,43 @@ func setUpSuite() {
 	}
 
 	// check if base version is an alias
-	agentVersionBase = e2e.GetElasticArtifactVersion(agentVersionBase)
+	v, err := e2e.GetElasticArtifactVersion(agentVersionBase)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"version": agentVersionBase,
+		}).Fatal("Failed to get agent base version, aborting")
+	}
+	agentVersionBase = v
 
 	timeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", timeoutFactor)
 	agentVersion = shell.GetEnv("BEAT_VERSION", agentVersionBase)
 
 	// check if version is an alias
-	agentVersion = e2e.GetElasticArtifactVersion(agentVersion)
+	v, err = e2e.GetElasticArtifactVersion(agentVersion)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"version": agentVersion,
+		}).Fatal("Failed to get agent version, aborting")
+	}
+	agentVersion = v
 
 	stackVersion = shell.GetEnv("STACK_VERSION", stackVersion)
-	stackVersion = e2e.GetElasticArtifactVersion(stackVersion)
+	v, err = e2e.GetElasticArtifactVersion(stackVersion)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"version": stackVersion,
+		}).Fatal("Failed to get stack version, aborting")
+	}
+	stackVersion = v
 
 	kibanaVersion = shell.GetEnv("KIBANA_VERSION", "")
 	if kibanaVersion == "" {
 		// we want to deploy a released version for Kibana
 		// if not set, let's use stackVersion
-		kibanaVersion = e2e.GetElasticArtifactVersion(stackVersion)
+		kibanaVersion = stackVersion
 	}
 
 	imts = IngestManagerTestSuite{

--- a/e2e/_suites/fleet/ingest_manager_test.go
+++ b/e2e/_suites/fleet/ingest_manager_test.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/cucumber/godog"
@@ -97,9 +98,10 @@ func InitializeIngestManagerTestSuite(ctx *godog.TestSuiteContext) {
 			"stackVersion":  stackVersion,
 		}
 
-		profileEnv["kibanaDockerNamespace"] = "observability-ci"
-		if kibanaVersion == "" {
-			profileEnv["kibanaDockerNamespace"] = "kibana"
+		profileEnv["kibanaDockerNamespace"] = "kibana"
+		if strings.HasPrefix(kibanaVersion, "pr") {
+			// because it comes from a PR
+			profileEnv["kibanaDockerNamespace"] = "observability-ci"
 		}
 
 		profile := FleetProfileName

--- a/e2e/_suites/helm/helm_charts_test.go
+++ b/e2e/_suites/helm/helm_charts_test.go
@@ -81,7 +81,14 @@ func setupSuite() {
 	timeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", timeoutFactor)
 
 	stackVersion = shell.GetEnv("STACK_VERSION", stackVersion)
-	stackVersion = e2e.GetElasticArtifactVersion(stackVersion)
+	v, err := e2e.GetElasticArtifactVersion(stackVersion)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"version": stackVersion,
+		}).Fatal("Failed to get stack version, aborting")
+	}
+	stackVersion = v
 
 	h, err := k8s.HelmFactory(helmVersion)
 	if err != nil {

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -69,13 +69,27 @@ func setupSuite() {
 	}
 
 	// check if base version is an alias
-	metricbeatVersionBase = e2e.GetElasticArtifactVersion(metricbeatVersionBase)
+	v, err := e2e.GetElasticArtifactVersion(metricbeatVersionBase)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"version": metricbeatVersionBase,
+		}).Fatal("Failed to get metricbeat base version, aborting")
+	}
+	metricbeatVersionBase = v
 
 	metricbeatVersion = shell.GetEnv("BEAT_VERSION", metricbeatVersionBase)
 	timeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", timeoutFactor)
 
 	stackVersion = shell.GetEnv("STACK_VERSION", stackVersion)
-	stackVersion = e2e.GetElasticArtifactVersion(stackVersion)
+	v, err = e2e.GetElasticArtifactVersion(stackVersion)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"version": stackVersion,
+		}).Fatal("Failed to get stack version, aborting")
+	}
+	stackVersion = v
 
 	serviceManager = services.NewServiceManager()
 

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -194,7 +194,7 @@ func GetExponentialBackOff(elapsedTime time.Duration) *backoff.ExponentialBackOf
 // 1. Elastic's artifact repository, building the JSON path query based
 // If the version is a PR, then it will return the version without checking the artifacts API
 // i.e. GetElasticArtifactVersion("$VERSION")
-func GetElasticArtifactVersion(version string) string {
+func GetElasticArtifactVersion(version string) (string, error) {
 	exp := GetExponentialBackOff(time.Minute)
 
 	retryCount := 1
@@ -233,11 +233,7 @@ func GetElasticArtifactVersion(version string) string {
 
 	err := backoff.Retry(apiStatus, exp)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"error":   err,
-			"version": version,
-		}).Fatal("Failed to get version, aborting")
-		return ""
+		return "", err
 	}
 
 	jsonParsed, err := gabs.ParseJSON([]byte(body))
@@ -245,8 +241,8 @@ func GetElasticArtifactVersion(version string) string {
 		log.WithFields(log.Fields{
 			"error":   err,
 			"version": version,
-		}).Fatal("Could not parse the response body to retrieve the version, aborting")
-		return ""
+		}).Error("Could not parse the response body to retrieve the version")
+		return "", err
 	}
 
 	builds := jsonParsed.Path("version.builds")
@@ -259,7 +255,7 @@ func GetElasticArtifactVersion(version string) string {
 		"version": latestVersion,
 	}).Debug("Latest version for current version obtained")
 
-	return latestVersion
+	return latestVersion, nil
 }
 
 // GetElasticArtifactURL returns the URL of a released artifact, which its full name is defined in the first argument,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It moves the initialisation of the stale agent version from the setup suite phase (before any scenario) to the only step it's used (deploying an stale agent to      Fleet).

Besides that, we detected that the namespace for the custom kibana image was not properly set, so we are making sure the custom version starts with "pr" (it's a PR)
to use the proper Docker namespace.

Finally, we are changing the signature of the method to check if a version is an alias, returning the error so that the caller handles it in whatever manner it needs, instead of handling it in the internal method.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It will avoid failing all scenarios if the stale agent version is not found. Instead it will fail the step. Therefore setup methods will fail the setup with `log.Fatal`, and steps will simply return the error, failing that scenario only.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

```shell
# stale agent, only
SUITE="fleet" TAGS="fleet_mode_agent && nightly" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEATS_USE_CI_SNAPSHOT=false DEVELOPER_MODE=true make -C e2e functional-test
# all suite for centos
SUITE="fleet" TAGS="fleet_mode_agent && centos" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEATS_USE_CI_SNAPSHOT=false DEVELOPER_MODE=true make -C e2e functional-test
```


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #1015

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->