### PR TITLE
Update Elastic Agent to not use Kibana

### DIFF
--- a/cli/config/compose/services/elastic-agent/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/docker-compose.yml
@@ -9,13 +9,12 @@ services:
       kibana:
         condition: service_healthy
     environment:
-      - "KIBANA_HOST=http://${kibanaHost:-kibana}:${kibanaPort:-5601}"
+      - "FLEET_SERVER_ELASTICSEARCH_HOST=http://${elasticsearchHost:-elasticsearch}:${elasticsearchPort:-9200}"
       - "FLEET_SERVER_ENABLE=${fleetServerMode:-0}"
       - "FLEET_SERVER_INSECURE_HTTP=${fleetServerMode:-0}"
-      - "KIBANA_FLEET_SETUP=${fleetServerMode:-0}"
       - "FLEET_SERVER_HOST=0.0.0.0"
-      - "KIBANA_USERNAME=elastic"
-      - "KIBANA_PASSWORD=changeme"
+      - "FLEET_SERVER_ELASTICSEARCH_USERNAME=elastic"
+      - "FLEET_SERVER_ELASTICSEARCH_PASSWORD=changeme"
     platform: ${elasticAgentPlatform:-linux/amd64}
     ports:
       - "127.0.0.1:8220:8220"

--- a/e2e/_suites/fleet/features/stand_alone_agent.feature
+++ b/e2e/_suites/fleet/features/stand_alone_agent.feature
@@ -60,3 +60,8 @@ Scenario Outline: Deploying a <image> stand-alone agent with fleet server mode
 Examples: default
   | image   |
   | default |
+
+@ubi8
+Examples: Ubi8
+  | image   |
+  | ubi8    |


### PR DESCRIPTION
## What does this PR do?

Changes the Elastic Agent service in the docker compose file to use Elasticsearch instead of Kibana

## Why is it important?

Because of updates on Fleet Server

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

