### PR TITLE
fix: do not use GT_REPO variable, use fixed repo name instead

### DIFF
--- a/.ci/e2eKibana.groovy
+++ b/.ci/e2eKibana.groovy
@@ -29,8 +29,7 @@ pipeline {
       [key: 'GT_REPO', value: '$.repository.full_name'],
       [key: 'GT_PR', value: '$.issue.number'],
       [key: 'GT_BODY', value: '$.comment.body'],
-      [key: 'GT_COMMENT_ID', value: '$.comment.id'],
-      [key: 'GT_PAYLOAD', value: '$']
+      [key: 'GT_COMMENT_ID', value: '$.comment.id']
      ],
     genericHeaderVariables: [
      [key: 'x-github-event', regexpFilter: 'comment']
@@ -54,7 +53,6 @@ pipeline {
         PATH = "${env.HOME}/bin:${env.HOME}/node_modules:${env.HOME}/node_modules/.bin:${env.PATH}"
       }
       steps {
-        echo(message: "$env.GT_PAYLOAD")
         checkPermissions()
         buildKibanaDockerImage(refspec: getBranch())
         catchError(buildResult: 'UNSTABLE', message: 'Unable to run e2e tests', stageResult: 'FAILURE') {

--- a/.ci/e2eKibana.groovy
+++ b/.ci/e2eKibana.groovy
@@ -7,6 +7,7 @@ pipeline {
   environment {
     REPO = 'kibana'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    ELASTIC_REPO = "elastic/${env.REPO}"
     GITHUB_APP_SECRET = 'secret/observability-team/ci/github-app'
     GITHUB_CHECK_E2E_TESTS_NAME = 'E2E Tests'
     PIPELINE_LOG_LEVEL = "INFO"
@@ -70,7 +71,7 @@ def checkPermissions(){
       error("Only PRs from Elasticians can be tested with Fleet E2E tests")
     }
 
-    if(!hasCommentAuthorWritePermissions(repoName: 'elastic/kibana', commentId: env.GT_COMMENT_ID)){
+    if(!hasCommentAuthorWritePermissions(repoName: "${env.ELASTIC_REPO}", commentId: env.GT_COMMENT_ID)){
       error("Only Elasticians can trigger Fleet E2E tests")
     }
   }
@@ -94,7 +95,7 @@ def runE2ETests(String suite) {
   def prID = getID()
   def token = githubAppToken(secret: "${env.GITHUB_APP_SECRET}")
 
-  def pullRequest = githubApiCall(token: token, url: "https://api.github.com/repos/${env.GT_REPO}/pulls/${prID}")
+  def pullRequest = githubApiCall(token: token, url: "https://api.github.com/repos/${env.ELASTIC_REPO}/pulls/${prID}")
   def baseRef = pullRequest?.base?.ref
   def headSha = pullRequest?.head?.sha
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It creates a global env var for repo name (`elastic/kibana`), which will be used instead of the usages of GT_REPO.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We noticed that, although the webhook event was properly captured by `regexpFilterText: '$GT_REPO$GT_BODY'`, at the moment we used it later in the pipeline, **for a manual trigger**, the `GT_REPO` variable was `null`. I.e.:

```groovy
def pullRequest = githubApiCall(token: token, url: "https://api.github.com/repos/${env.GT_REPO}/pulls/${prID}")
```

See https://beats-ci.elastic.co/blue/organizations/jenkins/e2e-tests%2Fe2e-testing-kibana-fleet/detail/e2e-testing-kibana-fleet/19/pipeline/

>githubApiCall: The REST API call https://api.github.com/repos/null/pulls/97041 return the message : java.lang.Exception: httpRequest: Failure connecting to the service https://api.github.com/repos/null/pulls/97041 : httpRequest: Failure connecting to the service https://api.github.com/repos/null/pulls/97041 : 





<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #1046 #1045 #1044 #1043 #1042 #1037

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->