### PR TITLE
Move kubernetes/kubectl/kind code to internal project layout

### DIFF
--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -1,4 +1,4 @@
-package main
+package kubernetes
 
 import (
 	"context"
@@ -17,19 +17,22 @@ import (
 	"github.com/elastic/e2e-testing/internal/shell"
 )
 
-type kubernetesControl struct {
+// Control struct for k8s cluster
+type Control struct {
 	config           string
 	Namespace        string
 	NamespaceUID     string
 	createdNamespace bool
 }
 
-func (c kubernetesControl) WithConfig(config string) kubernetesControl {
+// WithConfig config setter
+func (c Control) WithConfig(config string) Control {
 	c.config = config
 	return c
 }
 
-func (c kubernetesControl) WithNamespace(ctx context.Context, namespace string) kubernetesControl {
+// WithNamespace namespace setter
+func (c Control) WithNamespace(ctx context.Context, namespace string) Control {
 	if namespace == "" {
 		namespace = "test-" + uuid.New().String()
 		err := c.createNamespace(ctx, namespace)
@@ -47,7 +50,7 @@ func (c kubernetesControl) WithNamespace(ctx context.Context, namespace string) 
 	return c
 }
 
-func (c kubernetesControl) createNamespace(ctx context.Context, namespace string) error {
+func (c Control) createNamespace(ctx context.Context, namespace string) error {
 	if namespace == "" {
 		return nil
 	}
@@ -70,7 +73,8 @@ func (c kubernetesControl) createNamespace(ctx context.Context, namespace string
 	}, exp)
 }
 
-func (c kubernetesControl) Cleanup(ctx context.Context) error {
+// Cleanup deletes k8s namespace
+func (c Control) Cleanup(ctx context.Context) error {
 	if c.createdNamespace && c.Namespace != "" {
 		output, err := c.Run(ctx, "delete", "namespace", c.Namespace)
 		if err != nil {
@@ -80,11 +84,13 @@ func (c kubernetesControl) Cleanup(ctx context.Context) error {
 	return nil
 }
 
-func (c kubernetesControl) Run(ctx context.Context, runArgs ...string) (output string, err error) {
+// Run ability to run kubectl commands
+func (c Control) Run(ctx context.Context, runArgs ...string) (output string, err error) {
 	return c.RunWithStdin(ctx, nil, runArgs...)
 }
 
-func (c kubernetesControl) RunWithStdin(ctx context.Context, stdin io.Reader, runArgs ...string) (output string, err error) {
+// RunWithStdin run kubectl commands passing in options from stdin
+func (c Control) RunWithStdin(ctx context.Context, stdin io.Reader, runArgs ...string) (output string, err error) {
 	shell.CheckInstalledSoftware("kubectl")
 	var args []string
 	if c.config != "" {
@@ -97,23 +103,26 @@ func (c kubernetesControl) RunWithStdin(ctx context.Context, stdin io.Reader, ru
 	return shell.ExecuteWithStdin(ctx, ".", stdin, "kubectl", args...)
 }
 
-type kubernetesCluster struct {
+// Cluster kind structure definition
+type Cluster struct {
 	kindName   string
 	kubeconfig string
 
 	tmpDir string
 }
 
-func (c kubernetesCluster) Kubectl() kubernetesControl {
-	return kubernetesControl{}.WithConfig(c.kubeconfig)
+// Kubectl executable reference to kubectl with applied kubeconfig
+func (c Cluster) Kubectl() Control {
+	return Control{}.WithConfig(c.kubeconfig)
 }
 
-func (c kubernetesCluster) isAvailable(ctx context.Context) error {
+func (c Cluster) isAvailable(ctx context.Context) error {
 	_, err := c.Kubectl().Run(ctx, "api-versions")
 	return err
 }
 
-func (c *kubernetesCluster) initialize(ctx context.Context) error {
+// Initialize detect existing cluster contexts, otherwise will create one via Kind
+func (c *Cluster) Initialize(ctx context.Context, kindConfigPath string) error {
 	err := c.isAvailable(ctx)
 	if err == nil {
 		return nil
@@ -138,7 +147,7 @@ func (c *kubernetesCluster) initialize(ctx context.Context) error {
 	args := []string{
 		"create", "cluster",
 		"--name", name,
-		"--config", "testdata/kind.yml",
+		"--config", kindConfigPath,
 		"--kubeconfig", c.kubeconfig,
 	}
 	if version, ok := os.LookupEnv("KUBERNETES_VERSION"); ok && version != "" {
@@ -157,7 +166,8 @@ func (c *kubernetesCluster) initialize(ctx context.Context) error {
 	return nil
 }
 
-func (c *kubernetesCluster) cleanup(ctx context.Context) {
+// Cleanup deletes the kind cluster if available
+func (c *Cluster) Cleanup(ctx context.Context) {
 	if c.kindName != "" {
 		_, err := shell.Execute(ctx, ".", "kind", "delete", "cluster", "--name", c.kindName)
 		if err != nil {


### PR DESCRIPTION
This is mainly a cleanup to keep all internal related code that could be
reusable in our `internal` directory layout.

Next steps would be to take what's in `internal/kubectl` and merge with this code.

Signed-off-by: Adam Stokes <51892+adam-stokes@users.noreply.github.com>

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

This is mainly moving files around and placing the kubernetes/kubectl/kind specific information under a `kubernetes` namespace

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Keep the project structure consistent

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
cd e2e/_suites/kubernetes-autodiscover
OP_LOG_LEVEL=TRACE godog
```
