### PR TITLE
Auto bootstrap fleet during initialize scenario

### DIFF
--- a/cli/config/compose/profiles/fleet/configurations/kibana.config.yml
+++ b/cli/config/compose/profiles/fleet/configurations/kibana.config.yml
@@ -16,5 +16,5 @@ xpack.fleet.registryUrl: http://package-registry:8080
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.host: http://elasticsearch:9200
 xpack.fleet.agents.fleet_server.hosts:
-  - http://kibana:5601
+  - http://fleet-server:8220
 xpack.fleet.agents.tlsCheckDisabled: true

--- a/cli/config/compose/profiles/fleet/docker-compose.yml
+++ b/cli/config/compose/profiles/fleet/docker-compose.yml
@@ -40,3 +40,22 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080"]
       retries: 300
       interval: 1s
+
+  fleet-server:
+    image: "docker.elastic.co/beats/elastic-agent:${stackVersion:-8.0.0-SNAPSHOT}"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+      kibana:
+        condition: service_healthy
+    healthcheck:
+      test: "curl -f http://127.0.0.1:8220/api/status | grep HEALTHY 2>&1 >/dev/null"
+      retries: 12
+      interval: 5s
+    environment:
+      - "FLEET_SERVER_ENABLE=1"
+      - "FLEET_SERVER_INSECURE_HTTP=1"
+      - "KIBANA_FLEET_SETUP=1"
+      - "KIBANA_FLEET_HOST=http://kibana:5601"
+      - "FLEET_SERVER_HOST=0.0.0.0"
+      - "FLEET_SERVER_PORT=8220"

--- a/e2e/_suites/fleet/ingest_manager_test.go
+++ b/e2e/_suites/fleet/ingest_manager_test.go
@@ -176,22 +176,6 @@ func InitializeIngestManagerTestSuite(ctx *godog.TestSuiteContext) {
 
 		imts.Fleet.setup()
 
-		// we are going to bootstrap Fleet Server in a centos container, using TAR installer, and the base version
-		// Because it is the first agent in Fleet, there is no FleetServerHost
-		fleetServerBaseImage := "centos"
-		fleetServerInstallerType := "tar"
-		fleetServerVersion := common.AgentVersionBase
-		agentInstaller := installer.GetElasticAgentInstaller(fleetServerBaseImage, fleetServerInstallerType, fleetServerVersion, "")
-
-		// bootstrap Fleet Server only once: we need to set the version here
-		imts.Fleet.Version = fleetServerVersion
-		err = imts.Fleet.bootstrapFleetServerWithInstaller(fleetServerBaseImage, fleetServerInstallerType)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"installer": agentInstaller,
-			}).Fatal("Fleet Server could not be bootstrapped")
-		}
-
 		imts.StandAlone.RuntimeDependenciesStartDate = time.Now().UTC()
 	})
 


### PR DESCRIPTION
Signed-off-by: Adam Stokes <51892+adam-stokes@users.noreply.github.com>

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

This makes fleet server automatically available in bootstrapped mode so that additional agents just need to enroll in the default policy for tests.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Speeds up the test scenarios by having a working environment to test the additional elastic-agents

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

