### PR TITLE
chore: initialise timeout factor next to the declaration

### DIFF
--- a/e2e/_suites/fleet/ingest_manager_test.go
+++ b/e2e/_suites/fleet/ingest_manager_test.go
@@ -48,7 +48,6 @@ func setUpSuite() {
 	}
 	common.AgentVersionBase = v
 
-	common.TimeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", common.TimeoutFactor)
 	common.AgentVersion = shell.GetEnv("BEAT_VERSION", common.AgentVersionBase)
 
 	// check if version is an alias

--- a/e2e/_suites/helm/helm_charts_test.go
+++ b/e2e/_suites/helm/helm_charts_test.go
@@ -37,10 +37,6 @@ var elasticAPMActive = false
 
 var helmManager helm.Manager
 
-// timeoutFactor a multiplier for the max timeout when doing backoff retries.
-// It can be overriden by TIMEOUT_FACTOR env var
-var timeoutFactor = 2
-
 //nolint:unused
 var kubectlClient kubectl.Kubectl
 
@@ -80,7 +76,6 @@ func setupSuite() {
 	helmVersion = shell.GetEnv("HELM_VERSION", helmVersion)
 	helmChartVersion = shell.GetEnv("HELM_CHART_VERSION", helmChartVersion)
 	kubernetesVersion = shell.GetEnv("KUBERNETES_VERSION", kubernetesVersion)
-	timeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", timeoutFactor)
 
 	stackVersion = shell.GetEnv("STACK_VERSION", stackVersion)
 	v, err := utils.GetElasticArtifactVersion(stackVersion)
@@ -187,7 +182,7 @@ func (ts *HelmChartTestSuite) aResourceWillExposePods(resourceType string) error
 		return err
 	}
 
-	maxTimeout := time.Duration(timeoutFactor) * time.Minute
+	maxTimeout := time.Duration(common.TimeoutFactor) * time.Minute
 
 	exp := common.GetExponentialBackOff(maxTimeout)
 	retryCount := 1

--- a/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
+++ b/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
@@ -37,14 +37,6 @@ const defaultBeatVersion = "8.0.0-SNAPSHOT"
 var defaultEventsWaitTimeout = 60 * time.Second
 var defaultDeployWaitTimeout = 60 * time.Second
 
-func init() {
-	// initialise timeout factor
-	common.TimeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", common.TimeoutFactor)
-
-	defaultEventsWaitTimeout = defaultEventsWaitTimeout * time.Duration(common.TimeoutFactor)
-	defaultDeployWaitTimeout = defaultDeployWaitTimeout * time.Duration(common.TimeoutFactor)
-}
-
 type podsManager struct {
 	kubectl kubernetes.Control
 	ctx     context.Context
@@ -471,6 +463,9 @@ func InitializeTestSuite(ctx *godog.TestSuiteContext) {
 	ctx.BeforeSuite(func() {
 		// init logger
 		config.Init()
+
+		defaultEventsWaitTimeout = defaultEventsWaitTimeout * time.Duration(common.TimeoutFactor)
+		defaultDeployWaitTimeout = defaultDeployWaitTimeout * time.Duration(common.TimeoutFactor)
 
 		err := cluster.Initialize(suiteContext, "testdata/kind.yml")
 		if err != nil {

--- a/internal/common/retry.go
+++ b/internal/common/retry.go
@@ -8,11 +8,16 @@ import (
 	"time"
 
 	backoff "github.com/cenkalti/backoff/v4"
+	"github.com/elastic/e2e-testing/internal/shell"
 )
 
 // TimeoutFactor a multiplier for the max timeout when doing backoff retries.
 // It can be overriden by TIMEOUT_FACTOR env var
 var TimeoutFactor = 3
+
+func init() {
+	TimeoutFactor = shell.GetEnvInteger("TIMEOUT_FACTOR", TimeoutFactor)
+}
 
 // GetExponentialBackOff returns a preconfigured exponential backoff instance
 func GetExponentialBackOff(elapsedTime time.Duration) *backoff.ExponentialBackOff {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It initialises the timeout factor in the common package, avaoiding the multiple initialisation performed in all test suites.

Besides that, we removed a local version of the timeout factor variable for the Helm test suite, using the default one.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
DRY and KISS

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Suggested by @jsoriano in https://github.com/elastic/e2e-testing/pull/1115#discussion_r625185882

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->