### PR TITLE
feat: check how many processes of a process are running in the host

### DIFF
--- a/e2e/_suites/fleet/features/backend_processes.feature
+++ b/e2e/_suites/fleet/features/backend_processes.feature
@@ -6,8 +6,8 @@ Feature: Backend Processes
 Scenario Outline: Deploying the <os> agent
   Given a "<os>" agent is deployed to Fleet with "tar" installer
   When the "elastic-agent" process is in the "started" state on the host
-  Then the "filebeat" process is in the "started" state on the host
-    And the "metricbeat" process is in the "started" state on the host
+  Then there are "2" instances of the "filebeat" process in the "started" state
+    And there are "2" instances of the "metricbeat" process in the "started" state
 
 @centos
 Examples: Centos
@@ -23,8 +23,8 @@ Examples: Debian
 Scenario Outline: Deploying the <os> agent with enroll and then run on rpm and deb
   Given a "<os>" agent is deployed to Fleet with "systemd" installer
   When the "elastic-agent" process is in the "started" state on the host
-  Then the "filebeat" process is in the "started" state on the host
-    And the "metricbeat" process is in the "started" state on the host
+  Then there are "2" instances of the "filebeat" process in the "started" state
+    And there are "2" instances of the "metricbeat" process in the "started" state
 
 @centos
 Examples: Centos
@@ -57,8 +57,8 @@ Examples: Debian
 Scenario Outline: Restarting the installed <os> agent
   Given a "<os>" agent is deployed to Fleet with "tar" installer
   When the "elastic-agent" process is "restarted" on the host
-  Then the "filebeat" process is in the "started" state on the host
-    And the "metricbeat" process is in the "started" state on the host
+  Then there are "2" instances of the "filebeat" process in the "started" state
+    And there are "2" instances of the "metricbeat" process in the "started" state
 
 @centos
 Examples: Centos
@@ -75,8 +75,8 @@ Scenario Outline: Restarting the <os> host with persistent agent restarts backen
   Given a "<os>" agent is deployed to Fleet with "tar" installer
   When the host is restarted
   Then the "elastic-agent" process is in the "started" state on the host
-    And the "filebeat" process is in the "started" state on the host
-    And the "metricbeat" process is in the "started" state on the host
+    And there are "2" instances of the "filebeat" process in the "started" state
+    And there are "2" instances of the "metricbeat" process in the "started" state
 
 @centos
 Examples: Centos

--- a/e2e/_suites/fleet/features/stand_alone_agent.feature
+++ b/e2e/_suites/fleet/features/stand_alone_agent.feature
@@ -7,8 +7,8 @@ Feature: Stand-alone Agent
 @start-agent
 Scenario Outline: Starting the <image> agent starts backend processes
   When a "<image>" stand-alone agent is deployed
-  Then the "filebeat" process is in the "started" state on the host
-    And the "metricbeat" process is in the "started" state on the host
+  Then there are "2" instances of the "filebeat" process in the "started" state
+    And there are "2" instances of the "metricbeat" process in the "started" state
 
 @default
 Examples: default

--- a/e2e/_suites/fleet/features/stand_alone_agent.feature
+++ b/e2e/_suites/fleet/features/stand_alone_agent.feature
@@ -7,7 +7,7 @@ Feature: Stand-alone Agent
 @start-agent
 Scenario Outline: Starting the <image> agent starts backend processes
   When a "<image>" stand-alone agent is deployed
-  Then there are "2" instances of the "filebeat" process in the "started" state
+  Then there are "1" instances of the "filebeat" process in the "started" state
     And there are "2" instances of the "metricbeat" process in the "started" state
 
 @default

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -543,7 +543,7 @@ func (fts *FleetTestSuite) theFileSystemAgentFolderIsEmpty() error {
 		return err
 	}
 
-	if strings.Contains(content, "No such file or directory") {
+	if content == "" || strings.Contains(content, "No such file or directory") {
 		return nil
 	}
 

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -441,7 +441,7 @@ func (fts *FleetTestSuite) processStateChangedOnTheHost(process string, state st
 
 	containerName := fts.getContainerName(agentInstaller, 1)
 
-	return docker.CheckProcessStateOnTheHost(containerName, process, "stopped", common.TimeoutFactor)
+	return docker.CheckProcessStateOnTheHost(containerName, process, "stopped", 1, common.TimeoutFactor)
 }
 
 func (fts *FleetTestSuite) setup() error {

--- a/e2e/_suites/fleet/ingest_manager_test.go
+++ b/e2e/_suites/fleet/ingest_manager_test.go
@@ -104,6 +104,7 @@ func InitializeIngestManagerTestScenario(ctx *godog.ScenarioContext) {
 	})
 
 	ctx.Step(`^the "([^"]*)" process is in the "([^"]*)" state on the host$`, imts.processStateOnTheHost)
+	ctx.Step(`^there are "([^"]*)" instances of the "([^"]*)" process in the "([^"]*)" state$`, imts.thereAreInstancesOfTheProcessInTheState)
 
 	imts.Fleet.contributeSteps(ctx)
 }

--- a/e2e/_suites/fleet/world.go
+++ b/e2e/_suites/fleet/world.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/elastic/e2e-testing/internal/common"
 	"github.com/elastic/e2e-testing/internal/docker"
@@ -17,6 +18,10 @@ type IngestManagerTestSuite struct {
 }
 
 func (imts *IngestManagerTestSuite) processStateOnTheHost(process string, state string) error {
+	return imts.thereAreInstancesOfTheProcessInTheState("1", process, state)
+}
+
+func (imts *IngestManagerTestSuite) thereAreInstancesOfTheProcessInTheState(ocurrences string, process string, state string) error {
 	profile := common.FleetProfileName
 
 	var containerName string
@@ -28,5 +33,10 @@ func (imts *IngestManagerTestSuite) processStateOnTheHost(process string, state 
 		containerName = imts.Fleet.getContainerName(agentInstaller, 1)
 	}
 
-	return docker.CheckProcessStateOnTheHost(containerName, process, state, common.TimeoutFactor)
+	count, err := strconv.Atoi(ocurrences)
+	if err != nil {
+		return err
+	}
+
+	return docker.CheckProcessStateOnTheHost(containerName, process, state, count, common.TimeoutFactor)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It creates a new step that abstract the logic to get the number of processes in a desired state, calling this new step in the existing one (with 1 as number of ocurrences).

We had to refactor the existing code to wait for processes, as it only checked that a process existed in the host using `pgrep -n -l`, which only checks for the existence of the latest process for a process.

With this new approach, we are switching to `pgrep -d , $THE_PROCESS`, which separates each pid for the process with the comma delimiter. Having that list of pids for a process we execute `ps -q $PID -o state --no-headers` (linux only) to get the current state of that pid, to discard zombie processes (we detected that the elastic-agent on Centos creates 3 processes, 2 of them in the zombie state cc/ @michalpristas).

Finally, we refactored the existing method to get the output of executing a command in a container to avoid receiving extra bytes at the beginning of the output. In the previous code we had a list of bytes to remove, but now we simply use a Docker client helper utility (stdcopy) that splits stdout from stderr in the container, making possible to retrieve just the output. See https://stackoverflow.com/a/57132902 for further information.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It creates a more comprehensive check about the background processes that the elastic-agent spawns in the host, as we want to make sure the number of processes is correct.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

Tests for the backend processes:
```
SUITE="fleet" TAGS="backend_processes" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEATS_USE_CI_SNAPSHOT=false DEVELOPER_MODE=false make -C e2e functional-test
```

#### Considerations for the stand-alone mode using the Docker image
We noticed that the elastic-agent running in the docker image in stand-alone mode spawns only 1 filebeat process, instead of 2 as using the TAR/DEB/RPM installers. Maybe @michalpristas can help out here.
```
SUITE="fleet" TAGS="stand_alone_agent" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEATS_USE_CI_SNAPSHOT=false DEVELOPER_MODE=false make -C e2e functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #218

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->