### PR TITLE
fix: resolve issues in k8s-autodiscover test suite

### DIFF
--- a/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
+++ b/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
@@ -23,6 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/elastic/e2e-testing/cli/config"
+	"github.com/elastic/e2e-testing/internal/common"
 	"github.com/elastic/e2e-testing/internal/deploy"
 	"github.com/elastic/e2e-testing/internal/kubernetes"
 	"github.com/elastic/e2e-testing/internal/shell"
@@ -30,8 +31,6 @@ import (
 )
 
 var beatVersions = map[string]string{}
-
-const defaultBeatVersion = "8.0.0-SNAPSHOT"
 
 var defaultEventsWaitTimeout = 60 * time.Second
 var defaultDeployWaitTimeout = 60 * time.Second
@@ -112,12 +111,7 @@ func (m *podsManager) configureDockerImage(podName string) error {
 		return nil
 	}
 
-	beatVersion := shell.GetEnv("BEAT_VERSION", defaultBeatVersion)
-	v, err := utils.GetElasticArtifactVersion(beatVersion)
-	if err != nil {
-		return err
-	}
-	beatVersion = v
+	beatVersion := common.BeatVersion + "-amd64"
 
 	useCISnapshots := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
 	beatsLocalPath := shell.GetEnv("BEATS_LOCAL_PATH", "")
@@ -125,9 +119,9 @@ func (m *podsManager) configureDockerImage(podName string) error {
 		log.Debugf("Configuring Docker image for %s", podName)
 
 		// this method will detect if the GITHUB_CHECK_SHA1 variable is set
-		artifactName := utils.BuildArtifactName(podName, beatVersion, defaultBeatVersion, "linux", "amd64", "tar.gz", true)
+		artifactName := utils.BuildArtifactName(podName, common.BeatVersion, common.BeatVersionBase, "linux", "amd64", "tar.gz", true)
 
-		imagePath, err := utils.FetchBeatsBinary(artifactName, podName, beatVersion, defaultBeatVersion, utils.TimeoutFactor, true)
+		imagePath, err := utils.FetchBeatsBinary(artifactName, podName, common.BeatVersion, common.BeatVersionBase, utils.TimeoutFactor, true)
 		if err != nil {
 			return err
 		}
@@ -138,11 +132,9 @@ func (m *podsManager) configureDockerImage(podName string) error {
 			return err
 		}
 
-		beatVersion = beatVersion + "-amd64"
-
 		// tag the image with the proper docker tag, including platform
 		err = deploy.TagImage(
-			"docker.elastic.co/beats/"+podName+":"+defaultBeatVersion,
+			"docker.elastic.co/beats/"+podName+":"+common.BeatVersionBase,
 			"docker.elastic.co/observability-ci/"+podName+":"+beatVersion,
 		)
 		if err != nil {
@@ -467,6 +459,8 @@ func InitializeTestSuite(ctx *godog.TestSuiteContext) {
 	ctx.BeforeSuite(func() {
 		// init logger
 		config.Init()
+
+		common.InitVersions()
 
 		defaultEventsWaitTimeout = defaultEventsWaitTimeout * time.Duration(utils.TimeoutFactor)
 		defaultDeployWaitTimeout = defaultDeployWaitTimeout * time.Duration(utils.TimeoutFactor)

--- a/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
+++ b/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
@@ -113,6 +113,11 @@ func (m *podsManager) configureDockerImage(podName string) error {
 	}
 
 	beatVersion := shell.GetEnv("BEAT_VERSION", defaultBeatVersion)
+	v, err := utils.GetElasticArtifactVersion(beatVersion)
+	if err != nil {
+		return err
+	}
+	beatVersion = v
 
 	useCISnapshots := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
 	beatsLocalPath := shell.GetEnv("BEATS_LOCAL_PATH", "")

--- a/internal/deploy/docker_client.go
+++ b/internal/deploy/docker_client.go
@@ -386,7 +386,7 @@ func LoadImage(imagePath string) error {
 func TagImage(src string, target string) error {
 	dockerClient := getDockerClient()
 
-	maxTimeout := 15 * time.Second
+	maxTimeout := 5 * time.Second * time.Duration(utils.TimeoutFactor)
 	exp := utils.GetExponentialBackOff(maxTimeout)
 	retryCount := 0
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR does two things:

- uses the timeout factor to tag images, as we showed an error in #1165 in the first scenario ot being able to tag the image on time.
- uses the initialisation of versions from the common package

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The beat version was not resolved when it was an alias (i.e. in maintenance branches), and the Docker image loaded from Beats CI was too slow, for that reason we are using test framework's timeout factor, which multiplies by 5 the default timeout.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests for the CLI, and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

Run a test suite for Beats, in this case a PR against master:
```shell
SUITE="kubernetes-autodiscover" TAGS="heartbeat" TIMEOUT_FACTOR=3 BEATS_USE_CI_SNAPSHOTS=true GITHUB_CHECK_SHA1=de9f51b9dc4c297e0df2f946d5ada9ee739ca147 LOG_LEVEL=TRACE BEATS_USE_CI_SNAPSHOTS=true ELASTIC_APM_ACTIVE=false DEVELOPER_MODE=true make -C e2e functional-test
```
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #1165
- After the backport to maintenance branches, Closes #1166

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->