### PR TITLE
feat: instrument k8s-autodiscover with APM

### DIFF
--- a/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
+++ b/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cucumber/godog"
 	messages "github.com/cucumber/messages-go/v10"
 	log "github.com/sirupsen/logrus"
+	"go.elastic.co/apm"
 
 	"github.com/elastic/e2e-testing/cli/config"
 	"github.com/elastic/e2e-testing/internal/common"
@@ -35,12 +36,22 @@ var beatVersions = map[string]string{}
 var defaultEventsWaitTimeout = 60 * time.Second
 var defaultDeployWaitTimeout = 60 * time.Second
 
+var tx *apm.Transaction
+var stepSpan *apm.Span
+
 type podsManager struct {
 	kubectl kubernetes.Control
 	ctx     context.Context
 }
 
 func (m *podsManager) executeTemplateFor(podName string, writer io.Writer, options []string) error {
+	span, _ := apm.StartSpanOptions(m.ctx, "Executing template for pod", "pod.template.execute", apm.SpanOptions{
+		Parent: apm.SpanFromContext(m.ctx).TraceContext(),
+	})
+	span.Context.SetLabel("pod", podName)
+	span.Context.SetLabel("options", options)
+	defer span.End()
+
 	path := filepath.Join("testdata/templates", sanitizeName(podName)+".yml.tmpl")
 
 	err := m.configureDockerImage(podName)
@@ -105,6 +116,12 @@ func (m *podsManager) configureDockerImage(podName string) error {
 		return nil
 	}
 
+	span, _ := apm.StartSpanOptions(m.ctx, "Configuring Docker image", "pod.docker-image.configure", apm.SpanOptions{
+		Parent: apm.SpanFromContext(m.ctx).TraceContext(),
+	})
+	span.Context.SetLabel("pod", podName)
+	defer span.End()
+
 	// we are caching the versions by pod to avoid downloading and loading/tagging the Docker image multiple times
 	if beatVersions[podName] != "" {
 		log.Tracef("The beat version was already loaded: %s", beatVersions[podName])
@@ -121,7 +138,7 @@ func (m *podsManager) configureDockerImage(podName string) error {
 		// this method will detect if the GITHUB_CHECK_SHA1 variable is set
 		artifactName := utils.BuildArtifactName(podName, common.BeatVersion, common.BeatVersionBase, "linux", "amd64", "tar.gz", true)
 
-		imagePath, err := utils.FetchBeatsBinary(context.Background(), artifactName, podName, common.BeatVersion, common.BeatVersionBase, utils.TimeoutFactor, true)
+		imagePath, err := utils.FetchBeatsBinary(m.ctx, artifactName, podName, common.BeatVersion, common.BeatVersionBase, utils.TimeoutFactor, true)
 		if err != nil {
 			return err
 		}
@@ -200,6 +217,14 @@ func (m *podsManager) isRunning(podName string, options []string) error {
 }
 
 func (m *podsManager) resourceIs(podName string, state string, options ...string) error {
+	span, _ := apm.StartSpanOptions(m.ctx, "Checking resource state", "pod.state.check", apm.SpanOptions{
+		Parent: apm.SpanFromContext(m.ctx).TraceContext(),
+	})
+	span.Context.SetLabel("options", options)
+	span.Context.SetLabel("pod", podName)
+	span.Context.SetLabel("state", state)
+	defer span.End()
+
 	switch state {
 	case "running":
 		return m.isRunning(podName, options)
@@ -260,7 +285,7 @@ func (m *podsManager) collectsEventsWith(podName string, condition string) error
 	}
 
 	return m.waitForEventsCondition(podName, func(ctx context.Context, localPath string) (bool, error) {
-		ok, err := containsEventsWith(localPath, condition)
+		ok, err := containsEventsWith(m.ctx, localPath, condition)
 		if ok {
 			return true, nil
 		}
@@ -283,7 +308,7 @@ func (m *podsManager) doesNotCollectEvents(podName, condition, duration string) 
 	}
 
 	return m.waitForEventsCondition(podName, func(ctx context.Context, localPath string) (bool, error) {
-		events, err := readEventsWith(localPath, condition)
+		events, err := readEventsWith(m.ctx, localPath, condition)
 		if err != nil {
 			return false, err
 		}
@@ -316,6 +341,12 @@ func (m *podsManager) doesNotCollectEvents(podName, condition, duration string) 
 }
 
 func (m *podsManager) waitForEventsCondition(podName string, conditionFn func(ctx context.Context, localPath string) (bool, error)) error {
+	span, _ := apm.StartSpanOptions(m.ctx, "Waiting for events conditions", "pod.events.waitForCondition", apm.SpanOptions{
+		Parent: apm.SpanFromContext(m.ctx).TraceContext(),
+	})
+	span.Context.SetLabel("pod", podName)
+	defer span.End()
+
 	ctx, cancel := context.WithTimeout(m.ctx, defaultEventsWaitTimeout)
 	defer cancel()
 
@@ -348,6 +379,12 @@ func (m *podsManager) waitForEventsCondition(podName string, conditionFn func(ct
 }
 
 func (m *podsManager) getPodInstances(ctx context.Context, podName string) (instances []string, err error) {
+	span, _ := apm.StartSpanOptions(m.ctx, "Getting pod instances", "pod.instances.get", apm.SpanOptions{
+		Parent: apm.SpanFromContext(m.ctx).TraceContext(),
+	})
+	span.Context.SetLabel("pod", podName)
+	defer span.End()
+
 	app := sanitizeName(podName)
 	ticker := backoff.WithContext(backoff.NewConstantBackOff(1*time.Second), ctx)
 	err = backoff.Retry(func() error {
@@ -391,15 +428,22 @@ func flattenMap(m map[string]interface{}) map[string]interface{} {
 	return flattened
 }
 
-func containsEventsWith(path string, condition string) (bool, error) {
-	events, err := readEventsWith(path, condition)
+func containsEventsWith(ctx context.Context, path string, condition string) (bool, error) {
+	events, err := readEventsWith(ctx, path, condition)
 	if err != nil {
 		return false, err
 	}
 	return len(events) > 0, nil
 }
 
-func readEventsWith(path string, condition string) ([]map[string]interface{}, error) {
+func readEventsWith(ctx context.Context, path string, condition string) ([]map[string]interface{}, error) {
+	span, _ := apm.StartSpanOptions(ctx, "Reading events", "kubernetes.events.read", apm.SpanOptions{
+		Parent: apm.SpanFromContext(ctx).TraceContext(),
+	})
+	span.Context.SetLabel("condition", condition)
+	span.Context.SetLabel("path", path)
+	defer span.End()
+
 	key, value, ok := splitCondition(condition)
 	if !ok {
 		return nil, fmt.Errorf("invalid condition '%s'", condition)
@@ -465,8 +509,22 @@ func InitializeTestSuite(ctx *godog.TestSuiteContext) {
 		defaultEventsWaitTimeout = defaultEventsWaitTimeout * time.Duration(utils.TimeoutFactor)
 		defaultDeployWaitTimeout = defaultDeployWaitTimeout * time.Duration(utils.TimeoutFactor)
 
+		var suiteTx *apm.Transaction
+		var suiteParentSpan *apm.Span
+
+		// instrumentation
+		defer apm.DefaultTracer.Flush(nil)
+		suiteTx = apm.DefaultTracer.StartTransaction("Initialise k8s Autodiscover", "test.suite")
+		defer suiteTx.End()
+		suiteParentSpan = suiteTx.StartSpan("Before k8s Autodiscover test suite", "test.suite.before", nil)
+		suiteContext = apm.ContextWithSpan(suiteContext, suiteParentSpan)
+		defer suiteParentSpan.End()
+
 		err := cluster.Initialize(suiteContext, "testdata/kind.yml")
 		if err != nil {
+			e := apm.DefaultTracer.NewError(err)
+			e.Send()
+
 			log.WithError(err).Fatal("Failed to initialize cluster")
 		}
 		log.DeferExitHandler(func() {
@@ -475,6 +533,21 @@ func InitializeTestSuite(ctx *godog.TestSuiteContext) {
 	})
 
 	ctx.AfterSuite(func() {
+		f := func() {
+			apm.DefaultTracer.Flush(nil)
+		}
+		defer f()
+
+		// instrumentation
+		var suiteTx *apm.Transaction
+		var suiteParentSpan *apm.Span
+		defer apm.DefaultTracer.Flush(nil)
+		suiteTx = apm.DefaultTracer.StartTransaction("Tear Down k8s Autodiscover", "test.suite")
+		defer suiteTx.End()
+		suiteParentSpan = suiteTx.StartSpan("After k8s Autodiscover test suite", "test.suite.after", nil)
+		suiteContext = apm.ContextWithSpan(suiteContext, suiteParentSpan)
+		defer suiteParentSpan.End()
+
 		cluster.Cleanup(suiteContext)
 		cancel()
 	})
@@ -487,6 +560,9 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	var kubectl kubernetes.Control
 	var pods podsManager
 	ctx.BeforeScenario(func(p *messages.Pickle) {
+		tx = apm.DefaultTracer.StartTransaction(p.GetName(), "test.scenario")
+		tx.Context.SetLabel("suite", "k8s Autodiscover")
+
 		kubectl = cluster.Kubectl().WithNamespace(scenarioCtx, "")
 		if kubectl.Namespace != "" {
 			log.Debugf("Running scenario %s in namespace: %s", p.Name, kubectl.Namespace)
@@ -495,9 +571,36 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 		pods.ctx = scenarioCtx
 		log.DeferExitHandler(func() { kubectl.Cleanup(scenarioCtx) })
 	})
-	ctx.AfterScenario(func(*messages.Pickle, error) {
+	ctx.AfterScenario(func(p *messages.Pickle, err error) {
+		if err != nil {
+			e := apm.DefaultTracer.NewError(err)
+			e.Send()
+		}
+
+		f := func() {
+			tx.End()
+
+			apm.DefaultTracer.Flush(nil)
+		}
+		defer f()
+
 		kubectl.Cleanup(scenarioCtx)
 		cancel()
+	})
+
+	ctx.BeforeStep(func(step *godog.Step) {
+		stepSpan = tx.StartSpan(step.GetText(), "test.scenario.step", nil)
+		pods.ctx = apm.ContextWithSpan(scenarioCtx, stepSpan)
+	})
+	ctx.AfterStep(func(st *godog.Step, err error) {
+		if err != nil {
+			e := apm.DefaultTracer.NewError(err)
+			e.Send()
+		}
+
+		if stepSpan != nil {
+			stepSpan.End()
+		}
 	})
 
 	ctx.Step(`^"([^"]*)" have passed$`, func(d string) error { return waitDuration(scenarioCtx, d) })

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -178,7 +178,7 @@ func (c *Cluster) Initialize(ctx context.Context, kindConfigPath string) error {
 
 // Cleanup deletes the kind cluster if available
 func (c *Cluster) Cleanup(ctx context.Context) {
-	span, _ := apm.StartSpanOptions(ctx, "Cleanup cluster", "docker-compose.cluster.cleanup", apm.SpanOptions{
+	span, _ := apm.StartSpanOptions(ctx, "Cleanup cluster", "kubernetes.cluster.cleanup", apm.SpanOptions{
 		Parent: apm.SpanFromContext(ctx).TraceContext(),
 	})
 	defer span.End()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds APM traces for the k8s autodiscover test suite, and for that we had to basically pass the Go context through all API methods. We are:

- starting a transaction before the test scenario
  - adding a span for each internal operation/method, passing the current context as parent
  - each operation defers the close of the span
- closing the transaction after the test scenario
- using Godog's `beforeStep/afterStep` life cycle hooks to automatically create/close spans per scenario step, which will serve as parent span for the internal operations within it. This life cycle hook will be used to capture step errors, sending APM errors to the Cloud.
- using Godog's `beforeScenario/afterScenario` life cycle hooks to start/flush the transaction for each scenario. The transaction will receive the `test.scenario` type.
- using Godog's `beforeSuite/afterSuite` to create specific transaction for initialisation/destruction of the runtime dependencies. The transaction will receive the `test.suite` type.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We want to share metrics with the Data Collections team (integrations) about that, so that we can count on numbers, not in guesses.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

```shell
$ TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEATS_USE_CI_SNAPSHOTS=false DEVELOPER_MODE=true ELASTIC_APM_ACTIVE=true  make -C e2e/_suites/kubernetes-autodiscover functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #687

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->