### PR TITLE
fix: use beat_version as fallback if it's provided

### DIFF
--- a/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
+++ b/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
@@ -136,7 +136,7 @@ func (m *podsManager) configureDockerImage(podName string) error {
 		log.Debugf("Configuring Docker image for %s", podName)
 
 		artifactName := utils.BuildArtifactName(podName, common.BeatVersion, "linux", "amd64", "tar.gz", true)
-		imagePath, err := utils.FetchBeatsBinary(m.ctx, artifactName, podName, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
+		imagePath, err := utils.FetchBeatsBinary(m.ctx, artifactName, podName, common.BeatVersion, utils.TimeoutFactor, true)
 		if err != nil {
 			return err
 		}

--- a/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
+++ b/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
@@ -135,8 +135,7 @@ func (m *podsManager) configureDockerImage(podName string) error {
 	if useCISnapshots || beatsLocalPath != "" {
 		log.Debugf("Configuring Docker image for %s", podName)
 
-		// this method will detect if the GITHUB_CHECK_SHA1 variable is set
-		artifactName := utils.BuildArtifactName(podName, common.BeatVersion, common.BeatVersion, "linux", "amd64", "tar.gz", true)
+		artifactName := utils.BuildArtifactName(podName, common.BeatVersion, "linux", "amd64", "tar.gz", true)
 		imagePath, err := utils.FetchBeatsBinary(m.ctx, artifactName, podName, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
 		if err != nil {
 			return err

--- a/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
+++ b/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
@@ -136,9 +136,8 @@ func (m *podsManager) configureDockerImage(podName string) error {
 		log.Debugf("Configuring Docker image for %s", podName)
 
 		// this method will detect if the GITHUB_CHECK_SHA1 variable is set
-		artifactName := utils.BuildArtifactName(podName, common.BeatVersion, common.BeatVersionBase, "linux", "amd64", "tar.gz", true)
-
-		imagePath, err := utils.FetchBeatsBinary(m.ctx, artifactName, podName, common.BeatVersion, common.BeatVersionBase, utils.TimeoutFactor, true)
+		artifactName := utils.BuildArtifactName(podName, common.BeatVersion, common.BeatVersion, "linux", "amd64", "tar.gz", true)
+		imagePath, err := utils.FetchBeatsBinary(m.ctx, artifactName, podName, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
 		if err != nil {
 			return err
 		}

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -360,9 +360,9 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 	beatsLocalPath := shell.GetEnv("BEATS_LOCAL_PATH", "")
 	if useCISnapshots || beatsLocalPath != "" {
 		arch := utils.GetArchitecture()
-		artifactName := utils.BuildArtifactName("metricbeat", mts.Version, common.BeatVersionBase, "linux", arch, "tar.gz", true)
 
-		imagePath, err := utils.FetchBeatsBinary(mts.currentContext, artifactName, "metricbeat", mts.Version, common.BeatVersionBase, utils.TimeoutFactor, true)
+		artifactName := utils.BuildArtifactName("metricbeat", mts.Version, common.BeatVersion, "linux", arch, "tar.gz", true)
+		imagePath, err := utils.FetchBeatsBinary(mts.currentContext, artifactName, "metricbeat", mts.Version, common.BeatVersion, utils.TimeoutFactor, true)
 		if err != nil {
 			return err
 		}

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -362,7 +362,7 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 		arch := utils.GetArchitecture()
 
 		artifactName := utils.BuildArtifactName("metricbeat", mts.Version, "linux", arch, "tar.gz", true)
-		imagePath, err := utils.FetchBeatsBinary(mts.currentContext, artifactName, "metricbeat", mts.Version, common.BeatVersion, utils.TimeoutFactor, true)
+		imagePath, err := utils.FetchBeatsBinary(mts.currentContext, artifactName, "metricbeat", mts.Version, utils.TimeoutFactor, true)
 		if err != nil {
 			return err
 		}

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -361,7 +361,7 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 	if useCISnapshots || beatsLocalPath != "" {
 		arch := utils.GetArchitecture()
 
-		artifactName := utils.BuildArtifactName("metricbeat", mts.Version, common.BeatVersion, "linux", arch, "tar.gz", true)
+		artifactName := utils.BuildArtifactName("metricbeat", mts.Version, "linux", arch, "tar.gz", true)
 		imagePath, err := utils.FetchBeatsBinary(mts.currentContext, artifactName, "metricbeat", mts.Version, common.BeatVersion, utils.TimeoutFactor, true)
 		if err != nil {
 			return err

--- a/internal/common/defaults.go
+++ b/internal/common/defaults.go
@@ -102,7 +102,15 @@ func InitVersions() {
 	BeatVersion = v
 
 	// detects if the BeatVersion is set by the GITHUB_CHECK_SHA1 variable
-	BeatVersion = utils.CheckPRVersion(BeatVersion, BeatVersionBase)
+	fallbackVersion := BeatVersionBase
+	if BeatVersion != BeatVersionBase {
+		log.WithFields(log.Fields{
+			"BeatVersionBase": BeatVersionBase,
+			"BeatVersion":     BeatVersion,
+		}).Trace("Beat Version provided: will be used as fallback")
+		fallbackVersion = BeatVersion
+	}
+	BeatVersion = utils.CheckPRVersion(BeatVersion, fallbackVersion)
 
 	StackVersion = shell.GetEnv("STACK_VERSION", BeatVersionBase)
 	v, err = utils.GetElasticArtifactVersion(StackVersion)

--- a/internal/installer/elasticagent_deb.go
+++ b/internal/installer/elasticagent_deb.go
@@ -143,7 +143,7 @@ func (i *elasticAgentDEBPackage) Preinstall(ctx context.Context) error {
 	extension := "deb"
 
 	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
+	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/installer/elasticagent_deb.go
+++ b/internal/installer/elasticagent_deb.go
@@ -142,8 +142,8 @@ func (i *elasticAgentDEBPackage) Preinstall(ctx context.Context) error {
 	arch := utils.GetArchitecture()
 	extension := "deb"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersionBase, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersionBase, utils.TimeoutFactor, true)
+	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersion, os, arch, extension, false)
+	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/installer/elasticagent_deb.go
+++ b/internal/installer/elasticagent_deb.go
@@ -142,7 +142,7 @@ func (i *elasticAgentDEBPackage) Preinstall(ctx context.Context) error {
 	arch := utils.GetArchitecture()
 	extension := "deb"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersion, os, arch, extension, false)
+	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
 	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/internal/installer/elasticagent_docker.go
+++ b/internal/installer/elasticagent_docker.go
@@ -97,8 +97,8 @@ func (i *elasticAgentDockerPackage) Preinstall(ctx context.Context) error {
 	arch := utils.GetArchitecture()
 	extension := "tar.gz"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersionBase, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersionBase, utils.TimeoutFactor, true)
+	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersion, os, arch, extension, false)
+	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/installer/elasticagent_docker.go
+++ b/internal/installer/elasticagent_docker.go
@@ -97,7 +97,7 @@ func (i *elasticAgentDockerPackage) Preinstall(ctx context.Context) error {
 	arch := utils.GetArchitecture()
 	extension := "tar.gz"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersion, os, arch, extension, false)
+	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
 	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/internal/installer/elasticagent_docker.go
+++ b/internal/installer/elasticagent_docker.go
@@ -98,7 +98,7 @@ func (i *elasticAgentDockerPackage) Preinstall(ctx context.Context) error {
 	extension := "tar.gz"
 
 	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
+	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/installer/elasticagent_rpm.go
+++ b/internal/installer/elasticagent_rpm.go
@@ -146,8 +146,8 @@ func (i *elasticAgentRPMPackage) Preinstall(ctx context.Context) error {
 	}
 	extension := "rpm"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersionBase, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersionBase, utils.TimeoutFactor, true)
+	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersion, os, arch, extension, false)
+	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/installer/elasticagent_rpm.go
+++ b/internal/installer/elasticagent_rpm.go
@@ -146,7 +146,7 @@ func (i *elasticAgentRPMPackage) Preinstall(ctx context.Context) error {
 	}
 	extension := "rpm"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersion, os, arch, extension, false)
+	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
 	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/internal/installer/elasticagent_rpm.go
+++ b/internal/installer/elasticagent_rpm.go
@@ -147,7 +147,7 @@ func (i *elasticAgentRPMPackage) Preinstall(ctx context.Context) error {
 	extension := "rpm"
 
 	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
+	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/installer/elasticagent_tar.go
+++ b/internal/installer/elasticagent_tar.go
@@ -118,7 +118,7 @@ func (i *elasticAgentTARPackage) Preinstall(ctx context.Context) error {
 	}
 	extension := "tar.gz"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersion, os, arch, extension, false)
+	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
 	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/internal/installer/elasticagent_tar.go
+++ b/internal/installer/elasticagent_tar.go
@@ -118,8 +118,8 @@ func (i *elasticAgentTARPackage) Preinstall(ctx context.Context) error {
 	}
 	extension := "tar.gz"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersionBase, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersionBase, utils.TimeoutFactor, true)
+	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, common.BeatVersion, os, arch, extension, false)
+	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/installer/elasticagent_tar.go
+++ b/internal/installer/elasticagent_tar.go
@@ -119,7 +119,7 @@ func (i *elasticAgentTARPackage) Preinstall(ctx context.Context) error {
 	extension := "tar.gz"
 
 	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, common.BeatVersion, utils.TimeoutFactor, true)
+	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, utils.TimeoutFactor, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -44,13 +44,11 @@ const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // BuildArtifactName builds the artifact name from the different coordinates for the artifact
-func BuildArtifactName(artifact string, version string, fallbackVersion string, OS string, arch string, extension string, isDocker bool) string {
+func BuildArtifactName(artifact string, artifactVersion string, OS string, arch string, extension string, isDocker bool) string {
 	dockerString := ""
 	if isDocker {
 		dockerString = ".docker"
 	}
-
-	artifactVersion := CheckPRVersion(version, fallbackVersion)
 
 	lowerCaseExtension := strings.ToLower(extension)
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -89,7 +89,7 @@ func CheckPRVersion(version string, fallbackVersion string) string {
 // to be used will be defined by the local snapshot produced by the local build.
 // Else, if the environment variable BEATS_USE_CI_SNAPSHOTS is set, then the artifact
 // to be downloaded will be defined by the latest snapshot produced by the Beats CI.
-func FetchBeatsBinary(ctx context.Context, artifactName string, artifact string, version string, fallbackVersion string, timeoutFactor int, xpack bool) (string, error) {
+func FetchBeatsBinary(ctx context.Context, artifactName string, artifact string, version string, timeoutFactor int, xpack bool) (string, error) {
 	beatsLocalPath := shell.GetEnv("BEATS_LOCAL_PATH", "")
 	if beatsLocalPath != "" {
 		span, _ := apm.StartSpanOptions(ctx, "Fetching Beats binary", "beats.local.fetch", apm.SpanOptions{
@@ -160,7 +160,7 @@ func FetchBeatsBinary(ctx context.Context, artifactName string, artifact string,
 
 		log.Debugf("Using CI snapshots for %s", artifact)
 
-		bucket, prefix, object := getGCPBucketCoordinates(artifactName, artifact, version, fallbackVersion)
+		bucket, prefix, object := getGCPBucketCoordinates(artifactName, artifact, version)
 
 		maxTimeout := time.Duration(timeoutFactor) * time.Minute
 
@@ -194,7 +194,7 @@ func GetArchitecture() string {
 }
 
 // getGCPBucketCoordinates it calculates the bucket path in GCP
-func getGCPBucketCoordinates(fileName string, artifact string, version string, fallbackVersion string) (string, string, string) {
+func getGCPBucketCoordinates(fileName string, artifact string, version string) (string, string, string) {
 	bucket := "beats-ci-artifacts"
 	prefix := fmt.Sprintf("snapshots/%s", artifact)
 	object := fileName
@@ -204,8 +204,7 @@ func getGCPBucketCoordinates(fileName string, artifact string, version string, f
 	if commitSHA != "" {
 		log.WithFields(log.Fields{
 			"commit":  commitSHA,
-			"PR":      version,
-			"version": fallbackVersion,
+			"version": version,
 		}).Debug("Using CI snapshots for a commit")
 		prefix = fmt.Sprintf("commits/%s", commitSHA)
 		object = artifact + "/" + fileName

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -373,7 +373,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		defer os.Unsetenv("BEATS_LOCAL_PATH")
 		os.Setenv("BEATS_LOCAL_PATH", beatsDir)
 
-		_, err := FetchBeatsBinary(ctx, "foo_fileName", artifact, version, version, TimeoutFactor, true)
+		_, err := FetchBeatsBinary(ctx, "foo_fileName", artifact, version, TimeoutFactor, true)
 		assert.NotNil(t, err)
 	})
 
@@ -384,7 +384,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, version, TimeoutFactor, true)
+		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -395,7 +395,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-aarch64.rpm"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, version, TimeoutFactor, true)
+		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -407,7 +407,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-amd64.deb"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, version, TimeoutFactor, true)
+		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -418,7 +418,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-arm64.deb"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, version, TimeoutFactor, true)
+		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -430,7 +430,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-linux-amd64.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, version, TimeoutFactor, true)
+		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -441,7 +441,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, version, TimeoutFactor, true)
+		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -452,7 +452,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-linux-arm64.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, version, TimeoutFactor, true)
+		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -464,7 +464,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, version, TimeoutFactor, true)
+		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -475,7 +475,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, version, TimeoutFactor, true)
+		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -487,7 +487,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, version, TimeoutFactor, true)
+		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -498,7 +498,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, version, TimeoutFactor, true)
+		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -568,7 +568,7 @@ func TestGetGCPBucketCoordinates_Commits(t *testing.T) {
 
 		fileName := "elastic-agent-" + testVersion + "-x86_64.rpm"
 
-		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, testVersion)
+		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "commits/0123456789")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-x86_64.rpm")
@@ -580,7 +580,7 @@ func TestGetGCPBucketCoordinates_Commits(t *testing.T) {
 
 		fileName := "elastic-agent-" + testVersion + "-amd64.deb"
 
-		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, testVersion)
+		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "commits/0123456789")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-amd64.deb")
@@ -592,7 +592,7 @@ func TestGetGCPBucketCoordinates_Commits(t *testing.T) {
 
 		fileName := "elastic-agent-" + testVersion + "-linux-x86_64.tar.gz"
 
-		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, testVersion)
+		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "commits/0123456789")
 		assert.Equal(t, object, "elastic-agent/elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")
@@ -606,7 +606,7 @@ func TestGetGCPBucketCoordinates_Snapshots(t *testing.T) {
 	t.Run("Fetching snapshots bucket for RPM package", func(t *testing.T) {
 		fileName := "elastic-agent-" + testVersion + "-x86_64.rpm"
 
-		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, testVersion)
+		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "snapshots/elastic-agent")
 		assert.Equal(t, object, "elastic-agent-"+testVersion+"-x86_64.rpm")
@@ -615,7 +615,7 @@ func TestGetGCPBucketCoordinates_Snapshots(t *testing.T) {
 	t.Run("Fetching snapshots bucket for DEB package", func(t *testing.T) {
 		fileName := "elastic-agent-" + testVersion + "-amd64.deb"
 
-		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, testVersion)
+		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "snapshots/elastic-agent")
 		assert.Equal(t, object, "elastic-agent-"+testVersion+"-amd64.deb")
@@ -624,7 +624,7 @@ func TestGetGCPBucketCoordinates_Snapshots(t *testing.T) {
 	t.Run("Fetching snapshots bucket for TAR package adds OS to fileName and object", func(t *testing.T) {
 		fileName := "elastic-agent-" + testVersion + "-linux-x86_64.tar.gz"
 
-		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version, testVersion)
+		bucket, prefix, object := getGCPBucketCoordinates(fileName, artifact, version)
 		assert.Equal(t, bucket, "beats-ci-artifacts")
 		assert.Equal(t, prefix, "snapshots/elastic-agent")
 		assert.Equal(t, object, "elastic-agent-"+testVersion+"-linux-x86_64.tar.gz")

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -54,10 +54,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "rpm"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, false)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "RPM", false)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "RPM", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For RPM (arm64)", func(t *testing.T) {
@@ -65,10 +65,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "rpm"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-aarch64.rpm"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, false)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "RPM", false)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "RPM", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -77,10 +77,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "deb"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-amd64.deb"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, false)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "DEB", false)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "DEB", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For DEB (arm64)", func(t *testing.T) {
@@ -88,10 +88,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "deb"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-arm64.deb"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, false)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "DEB", false)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "DEB", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -100,10 +100,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, false)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", false)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For TAR (arm64)", func(t *testing.T) {
@@ -111,10 +111,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-arm64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, false)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", false)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -127,10 +127,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-docker-image-linux-amd64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker from Elastic's repository (arm64)", func(t *testing.T) {
@@ -142,10 +142,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-docker-image-linux-arm64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -158,10 +158,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-docker-image-linux-amd64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker UBI8 from Elastic's repository (arm64)", func(t *testing.T) {
@@ -173,10 +173,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-docker-image-linux-arm64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -189,10 +189,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker from local repository (arm64)", func(t *testing.T) {
@@ -204,10 +204,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -220,10 +220,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker UBI8 from local repository (arm64)", func(t *testing.T) {
@@ -235,10 +235,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -251,10 +251,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker from GCP (arm64)", func(t *testing.T) {
@@ -266,10 +266,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -282,10 +282,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker UBI8 from GCP (arm64)", func(t *testing.T) {
@@ -297,10 +297,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, version, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, version, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -311,13 +311,12 @@ func TestBuildArtifactName(t *testing.T) {
 		artifact = "elastic-agent"
 		arch := "amd64"
 		extension := "tar.gz"
-		fallbackVersion := "8.0.0-SNAPSHOT"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-docker-image-linux-amd64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, fallbackVersion, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, fallbackVersion, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker for a Pull Request (arm64)", func(t *testing.T) {
@@ -327,13 +326,12 @@ func TestBuildArtifactName(t *testing.T) {
 		artifact = "elastic-agent"
 		arch := "arm64"
 		extension := "tar.gz"
-		fallbackVersion := "8.0.0-SNAPSHOT"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-docker-image-linux-arm64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, fallbackVersion, OS, arch, extension, true)
+		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, fallbackVersion, OS, arch, "TAR.GZ", true)
+		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It uses the BEAT_VERSION variable as fallback when provided. For that reason, upstream jobs must provide the Beat version, as they must know in which version they want to run the tests.

On the same hand, we are simplifying the methods to calculate the paths, removing the need to pass a fallback version, as this is already calculated at the initialisation of the configuration/environment, within the InitVersions method.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Builds triggered by Beats maintenance branches are not able to calculate the right paths to fetch binaries from GCP, and this is caused because the Beats version is a moving target that cannot be calculated without inspecting Beats code (libbeat/version/version.go). I.e., last 7.13 commit is using 7.13.2 as version, which created 7.13.2-SNAPSHOT artifacts in GCP.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

```shell
git checkout 7.13.x
TAGS="fleet_mode_agent && install" GITHUB_CHECK_SHA1=ad5f805dd30118cba3748189ef03bb945c958628 TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEATS_USE_CI_SNAPSHOTS=true DEVELOPER_MODE=true BEAT_VERSION=7.13.2-SNAPSHOT make -C e2e/_suites/fleet functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #1197


<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
We need to pass the BEAT_VERSION in the Beats' packaging job, reading from `make get-version' appending `-SNAPSHOT`. Will send a PR ASAP

<!-- Optional

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->