### PR TITLE
feat: support running elastic-agent alongside Beats

### DIFF
--- a/.ci/.e2e-tests.yaml
+++ b/.ci/.e2e-tests.yaml
@@ -32,6 +32,9 @@ SUITES:
       - name: "Backend Processes"
         pullRequestFilter: " && ~debian"
         tags: "backend_processes"
+      - name: "Beats Background Processes"
+        pullRequestFilter: " && ~debian"
+        tags: "running_on_beats"
   - suite: "metricbeat"
     platforms:
       - "ubuntu-18.04"

--- a/e2e/_suites/fleet/features/running_on_top_of_beats.feature
+++ b/e2e/_suites/fleet/features/running_on_top_of_beats.feature
@@ -1,0 +1,18 @@
+@running_on_beats
+Feature: Running on top of Beats
+  Scenarios for the Elastic Agent verifying the elastic-agent process runs alongside an existing Beats process.
+
+@enroll
+Scenario Outline: Deploying the <os> Elastic-Agent with enroll and then run on top of <beats-process>
+  Given a "<os>" agent is deployed to Fleet on top of "<beats-process>"
+  When the "elastic-agent" process is in the "started" state on the host
+  Then there are "3" instances of the "<beats-process>" process in the "started" state
+    And the agent is listed in Fleet as "online"
+
+@beats
+Examples: Beats
+| os     | beats-process |
+| centos | filebeat      |
+| centos | metricbeat    |
+| debian | filebeat      |
+| debian | metricbeat    |

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -143,6 +143,7 @@ func (fts *FleetTestSuite) beforeScenario() {
 
 func (fts *FleetTestSuite) contributeSteps(s *godog.ScenarioContext) {
 	s.Step(`^a "([^"]*)" agent is deployed to Fleet$`, fts.anAgentIsDeployedToFleet)
+	s.Step(`^a "([^"]*)" agent is deployed to Fleet on top of "([^"]*)"$`, fts.anAgentIsDeployedToFleetOnTopOfBeat)
 	s.Step(`^a "([^"]*)" agent is deployed to Fleet with "([^"]*)" installer$`, fts.anAgentIsDeployedToFleetWithInstaller)
 	s.Step(`^a "([^"]*)" agent "([^"]*)" is deployed to Fleet with "([^"]*)" installer$`, fts.anStaleAgentIsDeployedToFleetWithInstaller)
 	s.Step(`^agent is in version "([^"]*)"$`, fts.agentInVersion)
@@ -315,6 +316,18 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleet(image string) error {
 	if image == "debian" {
 		installerType = "deb"
 	}
+	fts.BeatsProcess = ""
+
+	return fts.anAgentIsDeployedToFleetWithInstallerAndFleetServer(image, installerType)
+}
+
+func (fts *FleetTestSuite) anAgentIsDeployedToFleetOnTopOfBeat(image string, beatsProcess string) error {
+	installerType := "rpm"
+	if image == "debian" {
+		installerType = "deb"
+	}
+
+	fts.BeatsProcess = beatsProcess
 
 	return fts.anAgentIsDeployedToFleetWithInstallerAndFleetServer(image, installerType)
 }

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -47,6 +47,7 @@ type FleetTestSuite struct {
 	Version             string // current elastic-agent version
 	kibanaClient        *kibana.Client
 	deployer            deploy.Deployment
+	BeatsProcess        string // (optional) name of the Beats that must be present before installing the elastic-agent
 	// date controls for queries
 	AgentStoppedDate             time.Time
 	RuntimeDependenciesStartDate time.Time
@@ -120,6 +121,7 @@ func (fts *FleetTestSuite) afterScenario() {
 	fts.CurrentToken = ""
 	fts.Image = ""
 	fts.StandAlone = false
+	fts.BeatsProcess = ""
 }
 
 // beforeScenario creates the state needed by a scenario
@@ -319,6 +321,7 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleet(image string) error {
 
 // supported installers: tar, rpm, deb
 func (fts *FleetTestSuite) anAgentIsDeployedToFleetWithInstaller(image string, installerType string) error {
+	fts.BeatsProcess = ""
 	return fts.anAgentIsDeployedToFleetWithInstallerAndFleetServer(image, installerType)
 }
 
@@ -342,6 +345,10 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleetWithInstallerAndFleetServer(i
 	fts.CurrentTokenID = enrollmentKey.ID
 
 	agentService := deploy.NewServiceRequest(common.ElasticAgentServiceName).WithFlavour(image).WithScale(deployedAgentsCount)
+	if fts.BeatsProcess != "" {
+		agentService = agentService.WithBackgroundProcess(fts.BeatsProcess)
+	}
+
 	services := []deploy.ServiceRequest{
 		agentService,
 	}

--- a/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
+++ b/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
@@ -135,8 +135,7 @@ func (m *podsManager) configureDockerImage(podName string) error {
 	if useCISnapshots || beatsLocalPath != "" {
 		log.Debugf("Configuring Docker image for %s", podName)
 
-		artifactName := utils.BuildArtifactName(podName, common.BeatVersion, "linux", "amd64", "tar.gz", true)
-		imagePath, err := utils.FetchBeatsBinary(m.ctx, artifactName, podName, common.BeatVersion, utils.TimeoutFactor, true)
+		_, imagePath, err := utils.FetchElasticArtifact(m.ctx, podName, common.BeatVersion, "linux", "amd64", "tar.gz", true, true)
 		if err != nil {
 			return err
 		}

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -359,8 +359,7 @@ func (mts *MetricbeatTestSuite) runMetricbeatService() error {
 	if useCISnapshots || beatsLocalPath != "" {
 		arch := utils.GetArchitecture()
 
-		artifactName := utils.BuildArtifactName("metricbeat", mts.Version, "linux", arch, "tar.gz", true)
-		imagePath, err := utils.FetchBeatsBinary(mts.currentContext, artifactName, "metricbeat", mts.Version, utils.TimeoutFactor, true)
+		_, imagePath, err := utils.FetchElasticArtifact(mts.currentContext, "metricbeat", mts.Version, "linux", arch, "tar.gz", true, true)
 		if err != nil {
 			return err
 		}

--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -333,7 +333,7 @@ func (mts *MetricbeatTestSuite) installedUsingConfiguration(configuration string
 	mts.Version = common.BeatVersion
 	mts.setIndexName()
 
-	configurationFilePath, err := steps.FetchBeatConfiguration(false, "metricbeat", configuration+".yml")
+	configurationFilePath, err := steps.FetchBeatConfiguration(mts.currentContext, false, "metricbeat", configuration+".yml")
 	if err != nil {
 		return err
 	}

--- a/e2e/steps/configurations.go
+++ b/e2e/steps/configurations.go
@@ -5,21 +5,30 @@
 package steps
 
 import (
+	"context"
 	"path"
 
 	"github.com/elastic/e2e-testing/internal/shell"
 	"github.com/elastic/e2e-testing/internal/utils"
 	log "github.com/sirupsen/logrus"
+	"go.elastic.co/apm"
 )
 
 // FetchBeatConfiguration where 'configFileName' represents the configuration file, including extension.
 // It will read environment to determine if it must read a file from the local file system, or in the
 // contrary, download a file from Github. In the latter case, it will use a commit of the maintenance branch
 // used in the tests
-func FetchBeatConfiguration(xpack bool, beat string, configFileName string) (string, error) {
+func FetchBeatConfiguration(ctx context.Context, xpack bool, beat string, configFileName string) (string, error) {
 	beatsLocalPath := shell.GetEnv("BEATS_LOCAL_PATH", "")
 
 	if beatsLocalPath != "" {
+		span, _ := apm.StartSpanOptions(ctx, "Fetching Beats configuration", "beats.local.fetch-config", apm.SpanOptions{
+			Parent: apm.SpanFromContext(ctx).TraceContext(),
+		})
+		span.Context.SetLabel("beat", beat)
+		span.Context.SetLabel("config", configFileName)
+		defer span.End()
+
 		configurationFilePath := beatsLocalPath
 		if xpack {
 			configurationFilePath = path.Join(beatsLocalPath, "x-pack")
@@ -43,6 +52,15 @@ func FetchBeatConfiguration(xpack bool, beat string, configFileName string) (str
 	}
 
 	configurationFileURL += "/" + beat + "/" + configFileName
+
+	span, _ := apm.StartSpanOptions(ctx, "Fetching Beats configuration", "beats.github.fetch-config", apm.SpanOptions{
+		Parent: apm.SpanFromContext(ctx).TraceContext(),
+	})
+	span.Context.SetLabel("beat", beat)
+	span.Context.SetLabel("config", configFileName)
+	span.Context.SetLabel("configURL", configurationFileURL)
+	span.Context.SetLabel("refspec", refspec)
+	defer span.End()
 
 	configurationFilePath, err := utils.DownloadFile(configurationFileURL)
 	if err != nil {

--- a/internal/deploy/base.go
+++ b/internal/deploy/base.go
@@ -69,26 +69,23 @@ type WaitForServiceRequest struct {
 
 // ServiceRequest represents the service to be created using the provider
 type ServiceRequest struct {
-	Name           string
-	Flavour        string                  // optional, configured using builder method
-	flavourPath    []string                // full path to the flavour
-	Scale          int                     // default: 1
-	WaitStrategies []WaitForServiceRequest // wait strategies for the service
+	Name                string
+	BackgroundProcesses []string                // optional, configured using builder method to add processes that must be installed in the service
+	Flavour             string                  // optional, configured using builder method
+	flavourPath         []string                // full path to the flavour
+	Scale               int                     // default: 1
+	WaitStrategies      []WaitForServiceRequest // wait strategies for the service
 }
 
 // NewServiceRequest creates a request for a service
 func NewServiceRequest(n string) ServiceRequest {
 	return ServiceRequest{
-		Name:           n,
-		flavourPath:    []string{n},
-		Scale:          1,
-		WaitStrategies: []WaitForServiceRequest{},
+		Name:                n,
+		BackgroundProcesses: []string{},
+		flavourPath:         []string{n},
+		Scale:               1,
+		WaitStrategies:      []WaitForServiceRequest{},
 	}
-}
-
-// GetRealFlavour returns the name of the last element in the flavour chain
-func (sr ServiceRequest) GetRealFlavour() string {
-	return sr.flavourPath[len(sr.flavourPath)-1]
 }
 
 // GetName returns the name of the service request, including flavour if needed
@@ -100,6 +97,12 @@ func (sr ServiceRequest) GetName() string {
 	}
 
 	return serviceIncludingFlavour
+}
+
+// WithBackgroundProcess adds a background process to the service. Each implementation should define how to install the process
+func (sr ServiceRequest) WithBackgroundProcess(bp ...string) ServiceRequest {
+	sr.BackgroundProcesses = append(sr.BackgroundProcesses, bp...)
+	return sr
 }
 
 // WithFlavour adds a flavour for the service, resulting in a look-up of the service in the config directory,

--- a/internal/deploy/base.go
+++ b/internal/deploy/base.go
@@ -72,7 +72,6 @@ type ServiceRequest struct {
 	Name                string
 	BackgroundProcesses []string                // optional, configured using builder method to add processes that must be installed in the service
 	Flavour             string                  // optional, configured using builder method
-	flavourPath         []string                // full path to the flavour
 	Scale               int                     // default: 1
 	WaitStrategies      []WaitForServiceRequest // wait strategies for the service
 }
@@ -82,7 +81,6 @@ func NewServiceRequest(n string) ServiceRequest {
 	return ServiceRequest{
 		Name:                n,
 		BackgroundProcesses: []string{},
-		flavourPath:         []string{n},
 		Scale:               1,
 		WaitStrategies:      []WaitForServiceRequest{},
 	}
@@ -92,8 +90,8 @@ func NewServiceRequest(n string) ServiceRequest {
 func (sr ServiceRequest) GetName() string {
 	serviceIncludingFlavour := sr.Name
 	if sr.Flavour != "" {
-		// discover the flavours in the subdirs
-		serviceIncludingFlavour = filepath.Join(sr.flavourPath...)
+		// discover the flavour in the subdir
+		serviceIncludingFlavour = filepath.Join(sr.Name, sr.Flavour)
 	}
 
 	return serviceIncludingFlavour
@@ -109,20 +107,6 @@ func (sr ServiceRequest) WithBackgroundProcess(bp ...string) ServiceRequest {
 // using flavour as a subdir of the service
 func (sr ServiceRequest) WithFlavour(f string) ServiceRequest {
 	sr.Flavour = f
-
-	sr.flavourPath = []string{sr.Name}
-
-	if sr.Flavour != "" {
-		// discover the flavour in the subdir
-		// we will use the '-' character to represent a subdir in the Gherkin files.
-		// This way we will abstract from the underlying OS path separator, nesting
-		// subdirs with each occurrente. I.e. 'a-b-c' will look up the file name under
-		// "name/a/b/c" in Linux and "name\a\b\c" in Windows.
-		flavourPath := strings.Split(sr.Flavour, "-")
-
-		sr.flavourPath = append(sr.flavourPath, flavourPath...)
-	}
-
 	return sr
 }
 

--- a/internal/deploy/base_test.go
+++ b/internal/deploy/base_test.go
@@ -16,12 +16,21 @@ func Test_ServiceRequest_GetName(t *testing.T) {
 		srv := NewServiceRequest("foo")
 
 		assert.Equal(t, "foo", srv.GetName(), "Service name has no flavour")
+		assert.Equal(t, "foo", srv.GetRealFlavour(), "Flavour matches with service name")
 	})
 
 	t.Run("ServiceRequest including flavour", func(t *testing.T) {
 		srv := NewServiceRequest("foo").WithFlavour("bar")
 
 		assert.Equal(t, filepath.Join("foo", "bar"), srv.GetName(), "Service name includes flavour")
+		assert.Equal(t, "bar", srv.GetRealFlavour(), "Flavour matches with latest flavour")
+	})
+
+	t.Run("ServiceRequest including flavour with subdirs", func(t *testing.T) {
+		srv := NewServiceRequest("foo").WithFlavour("bar-baaz")
+
+		assert.Equal(t, filepath.Join("foo", "bar", "baaz"), srv.GetName(), "Service name includes flavour with subdir")
+		assert.Equal(t, "baaz", srv.GetRealFlavour(), "Flavour matches with latest flavour")
 	})
 }
 

--- a/internal/deploy/base_test.go
+++ b/internal/deploy/base_test.go
@@ -16,21 +16,18 @@ func Test_ServiceRequest_GetName(t *testing.T) {
 		srv := NewServiceRequest("foo")
 
 		assert.Equal(t, "foo", srv.GetName(), "Service name has no flavour")
-		assert.Equal(t, "foo", srv.GetRealFlavour(), "Flavour matches with service name")
 	})
 
 	t.Run("ServiceRequest including flavour", func(t *testing.T) {
 		srv := NewServiceRequest("foo").WithFlavour("bar")
 
 		assert.Equal(t, filepath.Join("foo", "bar"), srv.GetName(), "Service name includes flavour")
-		assert.Equal(t, "bar", srv.GetRealFlavour(), "Flavour matches with latest flavour")
 	})
 
 	t.Run("ServiceRequest including flavour with subdirs", func(t *testing.T) {
 		srv := NewServiceRequest("foo").WithFlavour("bar-baaz")
 
 		assert.Equal(t, filepath.Join("foo", "bar", "baaz"), srv.GetName(), "Service name includes flavour with subdir")
-		assert.Equal(t, "baaz", srv.GetRealFlavour(), "Flavour matches with latest flavour")
 	})
 }
 

--- a/internal/deploy/base_test.go
+++ b/internal/deploy/base_test.go
@@ -23,12 +23,6 @@ func Test_ServiceRequest_GetName(t *testing.T) {
 
 		assert.Equal(t, filepath.Join("foo", "bar"), srv.GetName(), "Service name includes flavour")
 	})
-
-	t.Run("ServiceRequest including flavour with subdirs", func(t *testing.T) {
-		srv := NewServiceRequest("foo").WithFlavour("bar-baaz")
-
-		assert.Equal(t, filepath.Join("foo", "bar", "baaz"), srv.GetName(), "Service name includes flavour with subdir")
-	})
 }
 
 func Test_ServiceRequest_WithScale(t *testing.T) {

--- a/internal/installer/base.go
+++ b/internal/installer/base.go
@@ -45,3 +45,38 @@ func Attach(ctx context.Context, deploy deploy.Deployment, service deploy.Servic
 
 	return nil, nil
 }
+
+func systemCtlPostInstall(ctx context.Context, linux string, artifact string, execFn func(ctx context.Context, args []string) (string, error)) error {
+	cmds := []string{"systemctl", "restart", artifact}
+	span, _ := apm.StartSpanOptions(ctx, "Post-install operations for the "+artifact, artifact+"."+linux+".post-install", apm.SpanOptions{
+		Parent: apm.SpanFromContext(ctx).TraceContext(),
+	})
+	span.Context.SetLabel("arguments", cmds)
+	span.Context.SetLabel("artifact", artifact)
+	span.Context.SetLabel("linux", linux)
+	defer span.End()
+
+	_, err := execFn(ctx, cmds)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func systemCtlStart(ctx context.Context, linux string, artifact string, execFn func(ctx context.Context, args []string) (string, error)) error {
+	cmds := []string{"systemctl", "start", artifact}
+	span, _ := apm.StartSpanOptions(ctx, "Starting "+artifact+" service", artifact+"."+linux+".start", apm.SpanOptions{
+		Parent: apm.SpanFromContext(ctx).TraceContext(),
+	})
+	span.Context.SetLabel("arguments", cmds)
+	span.Context.SetLabel("artifact", artifact)
+	span.Context.SetLabel("linux", linux)
+	defer span.End()
+
+	_, err := execFn(ctx, cmds)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/installer/base.go
+++ b/internal/installer/base.go
@@ -45,13 +45,3 @@ func Attach(ctx context.Context, deploy deploy.Deployment, service deploy.Servic
 
 	return nil, nil
 }
-
-// BasePackage holds references to basic state for all installers
-type BasePackage struct {
-	binaryName string
-	commitFile string
-	image      string
-	logFile    string
-	profile    string
-	service    string
-}

--- a/internal/installer/elasticagent_deb.go
+++ b/internal/installer/elasticagent_deb.go
@@ -142,8 +142,7 @@ func (i *elasticAgentDEBPackage) Preinstall(ctx context.Context) error {
 	arch := utils.GetArchitecture()
 	extension := "deb"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, utils.TimeoutFactor, true)
+	binaryName, binaryPath, err := utils.FetchElasticArtifact(ctx, artifact, common.BeatVersion, os, arch, extension, false, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/installer/elasticagent_docker.go
+++ b/internal/installer/elasticagent_docker.go
@@ -97,8 +97,7 @@ func (i *elasticAgentDockerPackage) Preinstall(ctx context.Context) error {
 	arch := utils.GetArchitecture()
 	extension := "tar.gz"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, utils.TimeoutFactor, true)
+	_, binaryPath, err := utils.FetchElasticArtifact(ctx, artifact, common.BeatVersion, os, arch, extension, false, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/installer/elasticagent_rpm.go
+++ b/internal/installer/elasticagent_rpm.go
@@ -146,8 +146,7 @@ func (i *elasticAgentRPMPackage) Preinstall(ctx context.Context) error {
 	}
 	extension := "rpm"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, utils.TimeoutFactor, true)
+	binaryName, binaryPath, err := utils.FetchElasticArtifact(ctx, artifact, common.BeatVersion, os, arch, extension, false, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/installer/elasticagent_tar.go
+++ b/internal/installer/elasticagent_tar.go
@@ -118,8 +118,7 @@ func (i *elasticAgentTARPackage) Preinstall(ctx context.Context) error {
 	}
 	extension := "tar.gz"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, utils.TimeoutFactor, true)
+	_, binaryPath, err := utils.FetchElasticArtifact(ctx, artifact, common.BeatVersion, os, arch, extension, false, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -43,8 +43,8 @@ const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 //nolint:unused
 var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-// BuildArtifactName builds the artifact name from the different coordinates for the artifact
-func BuildArtifactName(artifact string, artifactVersion string, OS string, arch string, extension string, isDocker bool) string {
+// buildArtifactName builds the artifact name from the different coordinates for the artifact
+func buildArtifactName(artifact string, artifactVersion string, OS string, arch string, extension string, isDocker bool) string {
 	dockerString := ""
 	if isDocker {
 		dockerString = ".docker"
@@ -84,12 +84,31 @@ func CheckPRVersion(version string, fallbackVersion string) string {
 	return version
 }
 
-// FetchBeatsBinary it downloads the binary and returns the location of the downloaded file
+// FetchElasticArtifact fetches an artifact from the right repository, returning binary name, path and error
+func FetchElasticArtifact(ctx context.Context, artifact string, version string, os string, arch string, extension string, isDocker bool, xpack bool) (string, string, error) {
+	binaryName := buildArtifactName(artifact, version, os, arch, extension, isDocker)
+	binaryPath, err := fetchBeatsBinary(ctx, binaryName, artifact, version, TimeoutFactor, xpack)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"artifact":  artifact,
+			"version":   version,
+			"os":        os,
+			"arch":      arch,
+			"extension": extension,
+			"error":     err,
+		}).Error("Could not download the binary for the agent")
+		return "", "", err
+	}
+
+	return binaryName, binaryPath, nil
+}
+
+// fetchBeatsBinary it downloads the binary and returns the location of the downloaded file
 // If the environment variable BEATS_LOCAL_PATH is set, then the artifact
 // to be used will be defined by the local snapshot produced by the local build.
 // Else, if the environment variable BEATS_USE_CI_SNAPSHOTS is set, then the artifact
 // to be downloaded will be defined by the latest snapshot produced by the Beats CI.
-func FetchBeatsBinary(ctx context.Context, artifactName string, artifact string, version string, timeoutFactor int, xpack bool) (string, error) {
+func fetchBeatsBinary(ctx context.Context, artifactName string, artifact string, version string, timeoutFactor int, xpack bool) (string, error) {
 	beatsLocalPath := shell.GetEnv("BEATS_LOCAL_PATH", "")
 	if beatsLocalPath != "" {
 		span, _ := apm.StartSpanOptions(ctx, "Fetching Beats binary", "beats.local.fetch", apm.SpanOptions{

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -111,7 +111,7 @@ func FetchElasticArtifact(ctx context.Context, artifact string, version string, 
 func fetchBeatsBinary(ctx context.Context, artifactName string, artifact string, version string, timeoutFactor int, xpack bool) (string, error) {
 	beatsLocalPath := shell.GetEnv("BEATS_LOCAL_PATH", "")
 	if beatsLocalPath != "" {
-		span, _ := apm.StartSpanOptions(ctx, "Fetching Beats binary", "beats.local.fetch", apm.SpanOptions{
+		span, _ := apm.StartSpanOptions(ctx, "Fetching Beats binary", "beats.local.fetch-binary", apm.SpanOptions{
 			Parent: apm.SpanFromContext(ctx).TraceContext(),
 		})
 		defer span.End()
@@ -133,7 +133,7 @@ func fetchBeatsBinary(ctx context.Context, artifactName string, artifact string,
 	}
 
 	handleDownload := func(URL string) (string, error) {
-		span, _ := apm.StartSpanOptions(ctx, "Fetching Beats binary", "beats.url.fetch", apm.SpanOptions{
+		span, _ := apm.StartSpanOptions(ctx, "Fetching Beats binary", "beats.url.fetch-binary", apm.SpanOptions{
 			Parent: apm.SpanFromContext(ctx).TraceContext(),
 		})
 		defer span.End()
@@ -172,7 +172,7 @@ func fetchBeatsBinary(ctx context.Context, artifactName string, artifact string,
 
 	useCISnapshots := shell.GetEnvBool("BEATS_USE_CI_SNAPSHOTS")
 	if useCISnapshots {
-		span, _ := apm.StartSpanOptions(ctx, "Fetching Beats binary", "beats.gcp.fetch", apm.SpanOptions{
+		span, _ := apm.StartSpanOptions(ctx, "Fetching Beats binary", "beats.gcp.fetch-binary", apm.SpanOptions{
 			Parent: apm.SpanFromContext(ctx).TraceContext(),
 		})
 		defer span.End()

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -54,10 +54,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "rpm"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "RPM", false)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "RPM", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For RPM (arm64)", func(t *testing.T) {
@@ -65,10 +65,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "rpm"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-aarch64.rpm"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "RPM", false)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "RPM", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -77,10 +77,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "deb"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-amd64.deb"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "DEB", false)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "DEB", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For DEB (arm64)", func(t *testing.T) {
@@ -88,10 +88,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "deb"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-arm64.deb"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "DEB", false)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "DEB", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -100,10 +100,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", false)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For TAR (arm64)", func(t *testing.T) {
@@ -111,10 +111,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-arm64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, false)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, false)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", false)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", false)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -127,10 +127,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-docker-image-linux-amd64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker from Elastic's repository (arm64)", func(t *testing.T) {
@@ -142,10 +142,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-docker-image-linux-arm64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -158,10 +158,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-docker-image-linux-amd64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker UBI8 from Elastic's repository (arm64)", func(t *testing.T) {
@@ -173,10 +173,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-docker-image-linux-arm64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -189,10 +189,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker from local repository (arm64)", func(t *testing.T) {
@@ -204,10 +204,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -220,10 +220,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker UBI8 from local repository (arm64)", func(t *testing.T) {
@@ -235,10 +235,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -251,10 +251,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker from GCP (arm64)", func(t *testing.T) {
@@ -266,10 +266,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -282,10 +282,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker UBI8 from GCP (arm64)", func(t *testing.T) {
@@ -297,10 +297,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 
@@ -313,10 +313,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-docker-image-linux-amd64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 	t.Run("For Docker for a Pull Request (arm64)", func(t *testing.T) {
@@ -328,10 +328,10 @@ func TestBuildArtifactName(t *testing.T) {
 		extension := "tar.gz"
 		expectedFileName := "elastic-agent-8.0.0-SNAPSHOT-docker-image-linux-arm64.tar.gz"
 
-		artifactName := BuildArtifactName(artifact, version, OS, arch, extension, true)
+		artifactName := buildArtifactName(artifact, version, OS, arch, extension, true)
 		assert.Equal(t, expectedFileName, artifactName)
 
-		artifactName = BuildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
+		artifactName = buildArtifactName(artifact, version, OS, arch, "TAR.GZ", true)
 		assert.Equal(t, expectedFileName, artifactName)
 	})
 }
@@ -373,7 +373,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		defer os.Unsetenv("BEATS_LOCAL_PATH")
 		os.Setenv("BEATS_LOCAL_PATH", beatsDir)
 
-		_, err := FetchBeatsBinary(ctx, "foo_fileName", artifact, version, TimeoutFactor, true)
+		_, err := fetchBeatsBinary(ctx, "foo_fileName", artifact, version, TimeoutFactor, true)
 		assert.NotNil(t, err)
 	})
 
@@ -384,7 +384,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-x86_64.rpm"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
+		downloadedFilePath, err := fetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -395,7 +395,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-aarch64.rpm"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
+		downloadedFilePath, err := fetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -407,7 +407,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-amd64.deb"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
+		downloadedFilePath, err := fetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -418,7 +418,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-arm64.deb"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
+		downloadedFilePath, err := fetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -430,7 +430,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-linux-amd64.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
+		downloadedFilePath, err := fetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -441,7 +441,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
+		downloadedFilePath, err := fetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -452,7 +452,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-linux-arm64.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
+		downloadedFilePath, err := fetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -464,7 +464,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
+		downloadedFilePath, err := fetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -475,7 +475,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
+		downloadedFilePath, err := fetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -487,7 +487,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-amd64.docker.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
+		downloadedFilePath, err := fetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})
@@ -498,7 +498,7 @@ func TestFetchBeatsBinaryFromLocalPath(t *testing.T) {
 		artifactName := "elastic-agent-ubi8-8.0.0-SNAPSHOT-linux-arm64.docker.tar.gz"
 		expectedFilePath := path.Join(distributionsDir, artifactName)
 
-		downloadedFilePath, err := FetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
+		downloadedFilePath, err := fetchBeatsBinary(ctx, artifactName, artifact, version, TimeoutFactor, true)
 		assert.Nil(t, err)
 		assert.Equal(t, downloadedFilePath, expectedFilePath)
 	})


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR reuse existing building blocks to create a new scenario in which the elastic-agent installer is installed on a vanilla systemd linux box (Centos and Debian) which has already installed certain Beats processes (filebeat, metricbeat).

For that reason, we are adding the ability to add background processes to the ServiceRequest struct, so that the installer code for a service is able to also install those processes before installing the agent. We are installing these beats processes using the same mechanism as the one used to install the agent, which means fetching the DEB, RPM files from the artifactory, and then using local tools (APT, YUM) to install them in the aforementioned vanilla linux container.

We are installing the beat in a linux container instead of using the official Beats one (i.e. docker.elastic.co/beats/metricbeat) because we need to install `systemd` in the beat image first. And this problem is resolved if we use our already baked systemd images for Debian and Centos. @ericdavisx, please let us know if not using the official docker images is an issue.

To run the tests, we are adding a new feature file with a new scenario, so that it's possible to filter the test runner to select these new tests. The scenario installs the agent on top of the desired beats process (at this moment filebeat and metricbeat, only), and then verifies the number of processes is two (defined by basic policy) plus the one related to the background process: 3 in total. Finally, the scenario checks the agent is online in Fleet. @ericdavisx, is there any other assertion we should perform here? We chose those ones to reuse the existing steps to the maximum.

To finish, this new feature file is added to the parallel execution on CI, for both ARM and AMD.

As a side note, we merged two methods that were always called in combination into only one: `FetchElasticArtifact` now calls `buildArtifactName` and `fetchBeatsBinary`. These two methods were converted into private (lowercase) to avoid using them separately.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It will cover certain use cases reported in https://github.com/elastic/e2e-testing/issues/330

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

```shell
$ TAGS="running_on_beats && enroll" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=false ELASTIC_APM_ACTIVE=false make -C e2e/_suites/fleet functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #330

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->