### PR TITLE
fix: .ci/scripts/push-multiplatform-manifest.sh: not found

### DIFF
--- a/.ci/e2eKibana.groovy
+++ b/.ci/e2eKibana.groovy
@@ -58,7 +58,6 @@ pipeline {
       stages {
         stage('Check permissions') {
           steps {
-            deleteDir()
             checkPermissions()
             setEnvVar('DOCKER_TAG', getDockerTagFromPayload())
           }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->
It removes an unnecessary `deleteDir` step.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
This delete dir wipe the workspace, so it deletes the `.ci` folder with all the content, the content there is needed in the `Push multiplatform manifest`

```
[2021-06-21T16:17:28.547Z] + .ci/scripts/push-multiplatform-manifest.sh kibana pr101828
[2021-06-21T16:17:28.547Z] /var/lib/jenkins/workspace/e2e-tests/e2e-testing-kibana-fleet/src/github.com/elastic/kibana@tmp/durable-85846351/script.sh: 1: .ci/scripts/push-multiplatform-manifest.sh: not found
[2021-06-21T16:17:28.753Z] Terminated
script returned exit code 127
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally~
~- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally~
~- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)~

