### PR TITLE
Re-use bind mounts for kibana docker image

### DIFF
--- a/cli/config/compose/profiles/fleet/docker-compose.yml
+++ b/cli/config/compose/profiles/fleet/docker-compose.yml
@@ -32,21 +32,24 @@ services:
     platform: ${stackPlatform:-linux/amd64}
     ports:
       - "5601:5601"
-    environment:
-      - "SERVER_NAME=kibana"
-      - "SERVER_HOST=0.0.0.0"
-      - "TELEMETRY_ENABLED=false"
-      - "ELASTICSEARCH_HOSTS=http://elasticsearch:9200"
-      - "ELASTICSEARCH_USERNAME=elastic"
-      - "ELASTICSEARCH_PASSWORD=changeme"
-      - "MONITORING_UI_CONTAINER_ELASTICSEARCH_ENABLED=true"
-      - "XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY='12345678901234567890123456789012'"
-      - "XPACK_FLEET_ENABLED=true"
-      - "XPACK_FLEET_REGISTRYURL=https://epr-staging.elastic.co"
-      - "XPACK_FLEET_AGENTS_ENABLED=true"
-      - "XPACK_FLEET_AGENTS_ELASTICSEARCH_HOST=http://elasticsearch:9200"
-      - "XPACK_FLEET_AGENTS_FLEET_SERVER_HOSTS=http://fleet-server:8220"
-      - "XPACK_FLEET_AGENTS_TLSCHECKDISABLED=true"
+    volumes:
+      - ./configurations/kibana.config.yml:/usr/share/kibana/config/kibana.yml
+    # FIXME: revert back once https://github.com/elastic/kibana/issues/103084 is fixed
+    # environment:
+    #   - "SERVER_NAME=kibana"
+    #   - "SERVER_HOST=0.0.0.0"
+    #   - "TELEMETRY_ENABLED=false"
+    #   - "ELASTICSEARCH_HOSTS=http://elasticsearch:9200"
+    #   - "ELASTICSEARCH_USERNAME=elastic"
+    #   - "ELASTICSEARCH_PASSWORD=changeme"
+    #   - "MONITORING_UI_CONTAINER_ELASTICSEARCH_ENABLED=true"
+    #   - "XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY='12345678901234567890123456789012'"
+    #   - "XPACK_FLEET_ENABLED=true"
+    #   - "XPACK_FLEET_REGISTRYURL=https://epr-staging.elastic.co"
+    #   - "XPACK_FLEET_AGENTS_ENABLED=true"
+    #   - "XPACK_FLEET_AGENTS_ELASTICSEARCH_HOST=http://elasticsearch:9200"
+    #   - "XPACK_FLEET_AGENTS_FLEET_SERVER_HOSTS=http://fleet-server:8220"
+    #   - "XPACK_FLEET_AGENTS_TLSCHECKDISABLED=true"
   fleet-server:
     image: "docker.elastic.co/beats/elastic-agent:${stackVersion:-8.0.0-SNAPSHOT}"
     depends_on:


### PR DESCRIPTION
Currently there is a bug in the way kibana docker image is built that doesnt
pull in all the environment variables:

https://github.com/elastic/kibana/issues/103084

We can revert back to using environment vars once this bug is resolved

Signed-off-by: Adam Stokes <51892+adam-stokes@users.noreply.github.com>

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Goes back to bind mounting the kibana config

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

There currently is a bug in the way Kibana docker image is built when converting environment variables found in docker-compose to be passed along to the kibana cli.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closed #1273

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
