### PR TITLE
fix: use new method to calculate binary paths in ZIP installer (#1297) backport for 7.14.x

### DIFF
--- a/internal/installer/elasticagent_zip.go
+++ b/internal/installer/elasticagent_zip.go
@@ -109,8 +109,7 @@ func (i *elasticAgentZIPPackage) Preinstall(ctx context.Context) error {
 	arch := "x86_64"
 	extension := "zip"
 
-	binaryName := utils.BuildArtifactName(artifact, common.BeatVersion, os, arch, extension, false)
-	binaryPath, err := utils.FetchBeatsBinary(ctx, binaryName, artifact, common.BeatVersion, utils.TimeoutFactor, true)
+	_, binaryPath, err := utils.FetchElasticArtifact(ctx, artifact, common.BeatVersion, os, arch, extension, false, true)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"artifact":  artifact,


### PR DESCRIPTION
Backports the following commits to 7.14.x:
 - fix: use new method to calculate binary paths in ZIP installer (#1297)