### PR TITLE
feat: support MSSQL Server integration in tests

### DIFF
--- a/.ci/.e2e-tests.yaml
+++ b/.ci/.e2e-tests.yaml
@@ -57,6 +57,8 @@ SUITES:
         tags: "integrations && kafka"
       - name: "Metricbeat"
         tags: "metricbeat"
+      - name: "MS SQL Server"
+        tags: "integrations && mssql"
       - name: "MySQL"
         pullRequestFilter: " && ~old_versions"
         tags: "integrations && mysql"

--- a/e2e/_suites/metricbeat/features/integrations.feature
+++ b/e2e/_suites/metricbeat/features/integrations.feature
@@ -66,6 +66,12 @@ Examples: Kafka
 | kafka       | 1.1.0    |
 | kafka       | 0.10.2.2 |
 
+@mssql
+@xpack
+Examples: MS SQL Server
+| integration | version        |
+| mssql       | 2017-GA-ubuntu |
+
 @oracle
 @skip
 @xpack

--- a/internal/sanitizer/sanitizer.go
+++ b/internal/sanitizer/sanitizer.go
@@ -22,6 +22,8 @@ func GetConfigSanitizer(serviceType string) ConfigSanitizer {
 		return DockerComposeSanitizer{}
 	} else if strings.ToLower(serviceType) == "dropwizard" {
 		return DropwizardSanitizer{}
+	} else if strings.ToLower(serviceType) == "mssql" {
+		return MSSQLSanitizer{}
 	} else if strings.ToLower(serviceType) == "mysql" {
 		return MySQLSanitizer{}
 	}
@@ -54,6 +56,18 @@ type DropwizardSanitizer struct{}
 func (s DropwizardSanitizer) Sanitize(content string) string {
 	log.Debug("Sanitising dropwizard")
 	return strings.ReplaceAll(content, "metrics_path: /metrics/metrics", "metrics_path: /test/metrics")
+}
+
+// MSSQLSanitizer represents a sanitizer for MSSQL Server
+type MSSQLSanitizer struct{}
+
+// Sanitize prepends test application context
+func (s MSSQLSanitizer) Sanitize(content string) string {
+	log.Debug("Sanitising mssql")
+	replacedContent := strings.ReplaceAll(content, `domain\username`, "sa")
+	replacedContent = strings.ReplaceAll(replacedContent, "verysecurepassword", "1234_asdf")
+
+	return replacedContent
 }
 
 // MySQLSanitizer represents a sanitizer for Dropwizard

--- a/internal/sanitizer/sanitizer_test.go
+++ b/internal/sanitizer/sanitizer_test.go
@@ -32,6 +32,11 @@ func TestGetConfigSanitizer(t *testing.T) {
 			expectedContent: ": /metrics",
 		},
 		{
+			service:         "mssql",
+			content:         `username: domain\username\n password: verysecurepassword`,
+			expectedContent: `username: sa\n password: 1234_asdf`,
+		},
+		{
 			service:         "mysql",
 			content:         `hosts: ["root:secret@tcp(mysql:3306)/"]`,
 			expectedContent: `hosts: ["root:test@tcp(mysql:3306)/"]`,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds the recently added "x-pack's MSSQL integration for metricbeat" to the Metricbeat test suite. We need to massage the configuration files a bit, that's why we are adding a new sanitizer for the incoming config files from Beats repo, whic basically means applying MSSQL Server's default credentials: (user: `sa`, password `1234_asdf`).

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We found that the MSSQL Server integration was broken in Beats (see elastic/beats#26440) , and for that reason we want to add this test as part of the regression test suite.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

To run the unit tests:
```shell
make unit-test
```

To run the E2E tests for the new integration:
```shell
TAGS="integrations && mssql" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true make -C e2e/_suites/metricbeat functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates elastic/beats#26440

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->