### PR TITLE
fix: apply container name to elastic-agent Docker services

### DIFF
--- a/cli/config/compose/services/elastic-agent/centos/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/centos/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2.4'
 services:
   elastic-agent:
     image: docker.elastic.co/observability-ci/centos-systemd:latest
-    container_name: ${elasticAgentContainerName}
     entrypoint: "/usr/sbin/init"
     platform: ${stackPlatform:-linux/amd64}
     privileged: true

--- a/cli/config/compose/services/elastic-agent/centos/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/centos/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.4'
 services:
   elastic-agent:
     image: docker.elastic.co/observability-ci/centos-systemd:latest
-    container_name: ${centos_systemdContainerName}
+    container_name: ${elasticAgentContainerName}
     entrypoint: "/usr/sbin/init"
     platform: ${stackPlatform:-linux/amd64}
     privileged: true

--- a/cli/config/compose/services/elastic-agent/cloud/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/cloud/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2.4'
 services:
   elastic-agent:
     image: "docker.elastic.co/${elasticAgentDockerNamespace:-beats}/elastic-agent${elasticAgentDockerImageSuffix}:${elasticAgentTag:-8.0.0-SNAPSHOT}"
-    container_name:  ${elasticAgentContainerName}
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/cli/config/compose/services/elastic-agent/debian/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/debian/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2.4'
 services:
   elastic-agent:
     image: docker.elastic.co/observability-ci/debian-systemd:latest
-    container_name: ${elasticAgentContainerName} 
     entrypoint: "/sbin/init"
     platform: ${stackPlatform:-linux/amd64}
     privileged: true

--- a/cli/config/compose/services/elastic-agent/debian/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/debian/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.4'
 services:
   elastic-agent:
     image: docker.elastic.co/observability-ci/debian-systemd:latest
-    container_name: ${debian_systemdContainerName} 
+    container_name: ${elasticAgentContainerName} 
     entrypoint: "/sbin/init"
     platform: ${stackPlatform:-linux/amd64}
     privileged: true

--- a/cli/config/compose/services/elastic-agent/docker-compose.yml
+++ b/cli/config/compose/services/elastic-agent/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2.4'
 services:
   elastic-agent:
     image: "docker.elastic.co/${elasticAgentDockerNamespace:-beats}/elastic-agent${elasticAgentDockerImageSuffix}:${elasticAgentTag:-8.0.0-SNAPSHOT}"
-    container_name: ${elasticAgentContainerName}
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -376,9 +376,6 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleetWithInstallerAndFleetServer(i
 		agentService,
 	}
 
-	containerName := fmt.Sprintf("%s_%s_%d", common.FleetProfileName, common.ElasticAgentServiceName, agentService.Scale)
-	common.ProfileEnv["elasticAgentContainerName"] = containerName
-
 	err = fts.deployer.Add(fts.currentContext, common.FleetProfileServiceRequest, services, common.ProfileEnv)
 	if err != nil {
 		return err
@@ -992,9 +989,6 @@ func (fts *FleetTestSuite) anAttemptToEnrollANewAgentFails() error {
 	services := []deploy.ServiceRequest{
 		agentService,
 	}
-
-	containerName := fmt.Sprintf("%s_%s_%d", common.FleetProfileName, common.ElasticAgentServiceName, agentService.Scale)
-	common.ProfileEnv["elasticAgentContainerName"] = containerName
 
 	err := fts.deployer.Add(fts.currentContext, common.FleetProfileServiceRequest, services, common.ProfileEnv)
 	if err != nil {

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -376,6 +376,9 @@ func (fts *FleetTestSuite) anAgentIsDeployedToFleetWithInstallerAndFleetServer(i
 		agentService,
 	}
 
+	containerName := fmt.Sprintf("%s_%s_%d", common.FleetProfileName, common.ElasticAgentServiceName, agentService.Scale)
+	common.ProfileEnv["elasticAgentContainerName"] = containerName
+
 	err = fts.deployer.Add(fts.currentContext, common.FleetProfileServiceRequest, services, common.ProfileEnv)
 	if err != nil {
 		return err
@@ -989,6 +992,9 @@ func (fts *FleetTestSuite) anAttemptToEnrollANewAgentFails() error {
 	services := []deploy.ServiceRequest{
 		agentService,
 	}
+
+	containerName := fmt.Sprintf("%s_%s_%d", common.FleetProfileName, common.ElasticAgentServiceName, agentService.Scale)
+	common.ProfileEnv["elasticAgentContainerName"] = containerName
 
 	err := fts.deployer.Add(fts.currentContext, common.FleetProfileServiceRequest, services, common.ProfileEnv)
 	if err != nil {

--- a/e2e/_suites/fleet/stand-alone.go
+++ b/e2e/_suites/fleet/stand-alone.go
@@ -126,7 +126,6 @@ func (fts *FleetTestSuite) startStandAloneAgent(image string, flavour string, en
 
 	containerName := fmt.Sprintf("%s_%s_%d", common.FleetProfileName, common.ElasticAgentServiceName, 1)
 
-	common.ProfileEnv["elasticAgentContainerName"] = containerName
 	common.ProfileEnv["elasticAgentTag"] = dockerImageTag
 
 	for k, v := range env {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR avoids overridding the `container_name` of the elastic-agent service in a Docker Compose file, which avoids not needed calculations.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
I found an error while running the tests against a local version of the stack, and after debugging, found that if the DEV_MODE is enabled (services are not destroyed) the local Docker daemon is not able to recreate the containers properly.

I've not found an open issue related to this in the Compose repo, but I upgraded my local Docker engine very recently.

```shell
$ docker --version
Docker version 20.10.7, build f0df350

$ docker-compose --version
Docker Compose version v2.0.0-beta.6
```

I could have downgraded my local version and have tested again, but I consider this change (delegating the container name to Docker) should cover this use case.


On the other hand, when running the tests in DEVELOPER_MODE=true, I noticed Docker is not able to recreate containers properly. To reproduce it:

1. Run `TAGS="fleet_mode_agent && revoke-token && debian"   TIMEOUT_FACTOR=5    LOG_LEVEL=TRACE    DEVELOPER_MODE=true    ELASTIC_APM_ACTIVE=false make -C e2e/_suites/fleet functional-test`
2. Run same command again: `TAGS="fleet_mode_agent && revoke-token && debian"   TIMEOUT_FACTOR=5    LOG_LEVEL=TRACE    DEVELOPER_MODE=true    ELASTIC_APM_ACTIVE=false make -C e2e/_suites/fleet functional-test`

Because the services are not stopped, the second execution should fail with:

> could not run compose file: [/Users/mdelapenya/.op/compose/profiles/fleet/docker-compose.yml /Users/mdelapenya/.op/compose/services/elastic-agent/debian/docker-compose.yml] - Local Docker compose exited abnormally whilst running docker-compose: [up -d]. exit status 2



<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Important: disable DEVELOPER_MODE!!!

```shell
TAGS="fleet_mode_agent && revoke-token"   TIMEOUT_FACTOR=5    LOG_LEVEL=TRACE    DEVELOPER_MODE=false    ELASTIC_APM_ACTIVE=false make -C e2e/_suites/fleet functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Discovered while testing #1323

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->