### PR TITLE
[automation] update elastic stack version for testing 7.15.0-514bcfaf

### DIFF
--- a/.stack-version
+++ b/.stack-version
@@ -1,1 +1,1 @@
-7.x-SNAPSHOT
+7.15.0-514bcfaf-SNAPSHOT


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Sun, 25 Jul 2021 05:17:29 GMT, release_branch:7.x, prefix:, end_time:Sun, 25 Jul 2021 10:41:09 GMT, manifest_version:2.0.0, version:7.15.0-SNAPSHOT, branch:7.x, build_id:7.15.0-514bcfaf, build_duration_seconds:19420]