### PR TITLE
chore: read elastic-agent logs using native OS' log manager

### DIFF
--- a/internal/installer/base.go
+++ b/internal/installer/base.go
@@ -6,11 +6,14 @@ package installer
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"strings"
 
+	"github.com/elastic/e2e-testing/internal/common"
 	"github.com/elastic/e2e-testing/internal/deploy"
 	"github.com/elastic/e2e-testing/internal/shell"
+	"github.com/elastic/e2e-testing/internal/systemd"
 	log "github.com/sirupsen/logrus"
 	"go.elastic.co/apm"
 )
@@ -55,6 +58,25 @@ func Attach(ctx context.Context, deploy deploy.Deployment, service deploy.Servic
 	}
 
 	return nil, nil
+}
+
+func systemCtlLog(ctx context.Context, OS string, execFn func(ctx context.Context, args []string) (string, error)) error {
+	cmds := systemd.LogCmds(common.ElasticAgentServiceName)
+	span, _ := apm.StartSpanOptions(ctx, "Retrieving logs for the Elastic Agent service", "elastic-agent."+OS+".log", apm.SpanOptions{
+		Parent: apm.SpanFromContext(ctx).TraceContext(),
+	})
+	span.Context.SetLabel("arguments", cmds)
+	defer span.End()
+
+	logs, err := execFn(ctx, cmds)
+	if err != nil {
+		return err
+	}
+
+	// print logs as is, including tabs and line breaks
+	fmt.Println(logs)
+
+	return nil
 }
 
 func systemCtlPostInstall(ctx context.Context, linux string, artifact string, execFn func(ctx context.Context, args []string) (string, error)) error {

--- a/internal/installer/base.go
+++ b/internal/installer/base.go
@@ -80,7 +80,7 @@ func systemCtlLog(ctx context.Context, OS string, execFn func(ctx context.Contex
 }
 
 func systemCtlPostInstall(ctx context.Context, linux string, artifact string, execFn func(ctx context.Context, args []string) (string, error)) error {
-	cmds := []string{"systemctl", "restart", artifact}
+	cmds := systemd.RestartCmds(artifact)
 	span, _ := apm.StartSpanOptions(ctx, "Post-install operations for the "+artifact, artifact+"."+linux+".post-install", apm.SpanOptions{
 		Parent: apm.SpanFromContext(ctx).TraceContext(),
 	})
@@ -97,7 +97,7 @@ func systemCtlPostInstall(ctx context.Context, linux string, artifact string, ex
 }
 
 func systemCtlStart(ctx context.Context, linux string, artifact string, execFn func(ctx context.Context, args []string) (string, error)) error {
-	cmds := []string{"systemctl", "start", artifact}
+	cmds := systemd.StartCmds(artifact)
 	span, _ := apm.StartSpanOptions(ctx, "Starting "+artifact+" service", artifact+"."+linux+".start", apm.SpanOptions{
 		Parent: apm.SpanFromContext(ctx).TraceContext(),
 	})

--- a/internal/installer/elasticagent_deb.go
+++ b/internal/installer/elasticagent_deb.go
@@ -112,6 +112,7 @@ func (i *elasticAgentDEBPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentDEBPackage) Logs() error {
+	// TODO we could read "/var/lib/elastic-agent/data/elastic-agent-*/logs/elastic-agent-json.log"
 	return systemCtlLog(context.Background(), "debian", i.Exec)
 }
 

--- a/internal/installer/elasticagent_deb.go
+++ b/internal/installer/elasticagent_deb.go
@@ -112,7 +112,7 @@ func (i *elasticAgentDEBPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentDEBPackage) Logs() error {
-	return i.deploy.Logs(i.service)
+	return systemCtlLog(context.Background(), "debian", i.Exec)
 }
 
 // Postinstall executes operations after installing a DEB package

--- a/internal/installer/elasticagent_rpm.go
+++ b/internal/installer/elasticagent_rpm.go
@@ -113,7 +113,7 @@ func (i *elasticAgentRPMPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentRPMPackage) Logs() error {
-	return i.deploy.Logs(i.service)
+	return systemCtlLog(context.Background(), "rpm", i.Exec)
 }
 
 // Postinstall executes operations after installing a RPM package

--- a/internal/installer/elasticagent_rpm.go
+++ b/internal/installer/elasticagent_rpm.go
@@ -113,6 +113,7 @@ func (i *elasticAgentRPMPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentRPMPackage) Logs() error {
+	// TODO we could read "/var/lib/elastic-agent/data/elastic-agent-*/logs/elastic-agent-json.log"
 	return systemCtlLog(context.Background(), "rpm", i.Exec)
 }
 

--- a/internal/installer/elasticagent_tar.go
+++ b/internal/installer/elasticagent_tar.go
@@ -95,7 +95,7 @@ func (i *elasticAgentTARPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentTARPackage) Logs() error {
-	return i.deploy.Logs(i.service)
+	return systemCtlLog(context.Background(), "tar", i.Exec)
 }
 
 // Postinstall executes operations after installing a TAR package

--- a/internal/installer/elasticagent_tar.go
+++ b/internal/installer/elasticagent_tar.go
@@ -95,6 +95,7 @@ func (i *elasticAgentTARPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentTARPackage) Logs() error {
+	// TODO: we could read "/opt/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log*"
 	return systemCtlLog(context.Background(), "tar", i.Exec)
 }
 

--- a/internal/installer/elasticagent_tar_macos.go
+++ b/internal/installer/elasticagent_tar_macos.go
@@ -92,6 +92,8 @@ func (i *elasticAgentTARDarwinPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentTARDarwinPackage) Logs() error {
+	// TODO: we need to find a way to read MacOS logs for a service (the agent is installed under /Library/LaunchDaemons)
+	// or we could read "/Library/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log*"
 	return i.deploy.Logs(i.service)
 }
 

--- a/internal/installer/elasticagent_zip.go
+++ b/internal/installer/elasticagent_zip.go
@@ -89,6 +89,8 @@ func (i *elasticAgentZIPPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentZIPPackage) Logs() error {
+	// TODO: we need to find a way to read Winidows logs for the service
+	// or we could read "C:\Program Files\Elastic\Agent\data\elastic-agent-*\logs\elastic-agent-json.log*"
 	return i.deploy.Logs(i.service)
 }
 

--- a/internal/systemd/cmds.go
+++ b/internal/systemd/cmds.go
@@ -1,0 +1,12 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package systemd
+
+// LogCmds represents the command and base arguments to retrieve a unit's logs
+func LogCmds(unit string) []string {
+	// -m --merge	     Show entries from all available journals
+	// -u --unit=UNIT    Show logs from the specified unit
+	return []string{"journalctl", "-m", "-u", unit}
+}

--- a/internal/systemd/cmds.go
+++ b/internal/systemd/cmds.go
@@ -10,3 +10,13 @@ func LogCmds(unit string) []string {
 	// -u --unit=UNIT    Show logs from the specified unit
 	return []string{"journalctl", "-m", "-u", unit}
 }
+
+// RestartCmds represents the command and base arguments to restart a unit
+func RestartCmds(unit string) []string {
+	return []string{"systemctl", "restart", unit}
+}
+
+// StartCmds represents the command and base arguments to start a unit
+func StartCmds(unit string) []string {
+	return []string{"systemctl", "start", unit}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a method to read Linux's service manager (systemd) logs. In particular for Linux it uses `journalctl` CLI.

For Mac and Windows, we are adding a TODO until we clarify how do we want to read the log files: using native tools or directly reading the log files.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
For agents installed in plain Centos/Debian, using deb, rpm, tar files as installer, the elastic-agent log is not the container log. For that reason we need to have a manner to read agent logs and expose them to the developer (on CI or local).

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] @adam-stokes, I added TODOs for Mac and Windows. Let's coordinate to add that support in those platforms too.

## How to test this PR locally

Simply run any fleet test:

```shell
 TAGS="fleet_mode_agent && install"   TIMEOUT_FACTOR=3    LOG_LEVEL=INFO    DEVELOPER_MODE=true    ELASTIC_APM_ACTIVE=false make -C e2e/_suites/fleet functional-test
```

The log of the elastic-agent service must be printed in the console.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #742

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional -->
## Screenshots
<img width="1684" alt="Screenshot 2021-07-26 at 11 15 51" src="https://user-images.githubusercontent.com/951580/126965029-4eab174a-046f-4847-b1a8-472195f73fad.png">

<!-- 
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->