### PR TITLE
chore(ci): propagate downstream build result to upstream

### DIFF
--- a/.ci/e2eKibana.groovy
+++ b/.ci/e2eKibana.groovy
@@ -206,7 +206,7 @@ def runE2ETests(String suite) {
 
   build(job: "${e2eTestsPipeline}",
     parameters: parameters,
-    propagate: false,
+    propagate: true,
     wait: false
   )
 

--- a/.ci/e2eTestingFleetDaily.groovy
+++ b/.ci/e2eTestingFleetDaily.groovy
@@ -49,7 +49,7 @@ pipeline {
             string(name: 'runTestsSuites', value: 'fleet'),
             string(name: 'SLACK_CHANNEL', value: "elastic-agent"),
           ],
-          propagate: false,
+          propagate: true,
           wait: false
         )
       }

--- a/.ci/e2eTestingHelmDaily.groovy
+++ b/.ci/e2eTestingHelmDaily.groovy
@@ -47,7 +47,7 @@ pipeline {
             string(name: 'runTestsSuites', value: 'helm'),
             string(name: 'SLACK_CHANNEL', value: "infra-release-notify,integrations"),
           ],
-          propagate: false,
+          propagate: true,
           wait: false
         )
       }

--- a/.ci/e2eTestingIntegrationsDaily.groovy
+++ b/.ci/e2eTestingIntegrationsDaily.groovy
@@ -48,7 +48,7 @@ pipeline {
             string(name: 'runTestsSuites', value: 'metricbeat'),
             string(name: 'SLACK_CHANNEL', value: "beats-build"),
           ],
-          propagate: false,
+          propagate: true,
           wait: false
         )
       }

--- a/.ci/e2eTestingK8SAutodiscoveryDaily.groovy
+++ b/.ci/e2eTestingK8SAutodiscoveryDaily.groovy
@@ -47,7 +47,7 @@ pipeline {
             string(name: 'runTestsSuites', value: 'kubernetes-autodiscover'),
             string(name: 'SLACK_CHANNEL', value: "integrations"),
           ],
-          propagate: false,
+          propagate: true,
           wait: false
         )
       }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It sets the `propagate` state of the modified jobs to the build result of the downstream/triggered job.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Because the downstream job is usually a helper pipeline used by many jobs, we cannot simply look up the state of the last build of the main, helper pipeline, as it could have been executed by another upstream job.

For that reason, we want to propagate the state of the downstream job to the upstream. In this case, we can monitor the state of the upstream builds (usually nightly builds) as it will keep the build state of the triggered job (now they're always green because they simply trigger the helper pipeline without failure).


<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] I assume that `wait: false` must be kept, as we do not want to wait for the result. But I wonder if the build state will be changed afterwards, or in the contrary we must wait so that the downstream state is propagated.


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #1376

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->