### PR TITLE
chore: read elastic-agent logs using native OS' log manager (#1368) backport for 7.x

### DIFF
--- a/internal/installer/elasticagent_deb.go
+++ b/internal/installer/elasticagent_deb.go
@@ -112,7 +112,8 @@ func (i *elasticAgentDEBPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentDEBPackage) Logs() error {
-	return i.deploy.Logs(i.service)
+	// TODO we could read "/var/lib/elastic-agent/data/elastic-agent-*/logs/elastic-agent-json.log"
+	return systemCtlLog(context.Background(), "debian", i.Exec)
 }
 
 // Postinstall executes operations after installing a DEB package

--- a/internal/installer/elasticagent_rpm.go
+++ b/internal/installer/elasticagent_rpm.go
@@ -113,7 +113,8 @@ func (i *elasticAgentRPMPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentRPMPackage) Logs() error {
-	return i.deploy.Logs(i.service)
+	// TODO we could read "/var/lib/elastic-agent/data/elastic-agent-*/logs/elastic-agent-json.log"
+	return systemCtlLog(context.Background(), "rpm", i.Exec)
 }
 
 // Postinstall executes operations after installing a RPM package

--- a/internal/installer/elasticagent_tar.go
+++ b/internal/installer/elasticagent_tar.go
@@ -95,7 +95,8 @@ func (i *elasticAgentTARPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentTARPackage) Logs() error {
-	return i.deploy.Logs(i.service)
+	// TODO: we could read "/opt/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log*"
+	return systemCtlLog(context.Background(), "tar", i.Exec)
 }
 
 // Postinstall executes operations after installing a TAR package

--- a/internal/installer/elasticagent_tar_macos.go
+++ b/internal/installer/elasticagent_tar_macos.go
@@ -92,6 +92,8 @@ func (i *elasticAgentTARDarwinPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentTARDarwinPackage) Logs() error {
+	// TODO: we need to find a way to read MacOS logs for a service (the agent is installed under /Library/LaunchDaemons)
+	// or we could read "/Library/Elastic/Agent/data/elastic-agent-*/logs/elastic-agent-json.log*"
 	return i.deploy.Logs(i.service)
 }
 

--- a/internal/installer/elasticagent_zip.go
+++ b/internal/installer/elasticagent_zip.go
@@ -89,6 +89,8 @@ func (i *elasticAgentZIPPackage) InstallCerts(ctx context.Context) error {
 
 // Logs prints logs of service
 func (i *elasticAgentZIPPackage) Logs() error {
+	// TODO: we need to find a way to read Winidows logs for the service
+	// or we could read "C:\Program Files\Elastic\Agent\data\elastic-agent-*\logs\elastic-agent-json.log*"
 	return i.deploy.Logs(i.service)
 }
 

--- a/internal/systemd/cmds.go
+++ b/internal/systemd/cmds.go
@@ -1,0 +1,22 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package systemd
+
+// LogCmds represents the command and base arguments to retrieve a unit's logs
+func LogCmds(unit string) []string {
+	// -m --merge	     Show entries from all available journals
+	// -u --unit=UNIT    Show logs from the specified unit
+	return []string{"journalctl", "-m", "-u", unit}
+}
+
+// RestartCmds represents the command and base arguments to restart a unit
+func RestartCmds(unit string) []string {
+	return []string{"systemctl", "restart", unit}
+}
+
+// StartCmds represents the command and base arguments to start a unit
+func StartCmds(unit string) []string {
+	return []string{"systemctl", "start", unit}
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - chore: read elastic-agent logs using native OS' log manager (#1368)