### PR TITLE
feat: add scheduled pipeline for k8s autodiscovery test suite (#1100)

### DIFF
--- a/.ci/e2eTestingK8SAutodiscoveryDaily.groovy
+++ b/.ci/e2eTestingK8SAutodiscoveryDaily.groovy
@@ -1,0 +1,61 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+@Library('apm@current') _
+
+pipeline {
+  agent none
+  environment {
+    JOB_GCS_BUCKET = credentials('gcs-bucket')
+    NOTIFY_TO = credentials('notify-to')
+    PIPELINE_LOG_LEVEL='INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  triggers {
+    cron('H H(4-5) * * 1-5')
+  }
+  stages {
+    stage('Run Tests') {
+      steps {
+        build(job: "e2e-tests/e2e-testing-mbp/${env.JOB_BASE_NAME}",
+          parameters: [
+            booleanParam(name: 'forceSkipGitChecks', value: true),
+            booleanParam(name: 'forceSkipPresubmit', value: true),
+            string(name: 'runTestsSuites', value: 'kubernetes-autodiscover'),
+            string(name: 'SLACK_CHANNEL', value: "integrations"),
+          ],
+          propagate: false,
+          wait: false
+        )
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}

--- a/.ci/jobs/e2e-testing-k8s-autodiscovery-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-k8s-autodiscovery-daily-mbp.yml
@@ -1,0 +1,47 @@
+---
+- job:
+    name: e2e-tests/e2e-testing-k8s-autodiscovery-daily-mbp
+    display-name: End-2-End tests for Observability K8S Autodiscovery Pipeline
+    description: Run E2E K8S Autodiscovery test suite daily, including maintenance branches
+    view: E2E
+    project-type: multibranch
+    script-path: .ci/e2eTestingK8SAutodiscoveryDaily.groovy
+    scm:
+      - github:
+          branch-discovery: no-pr
+          head-filter-regex: '(master|7\.x|7\.13\.x|7\.12\.x)'
+          discover-pr-forks-strategy: merge-current
+          discover-pr-forks-trust: permission
+          discover-pr-origin: merge-current
+          discover-tags: false
+          notification-context: 'beats-ci/e2e-testing'
+          disable-pr-notifications: true
+          repo: e2e-testing
+          repo-owner: elastic
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          property-strategies:
+            all-branches:
+              - suppress-scm-triggering: true
+          build-strategies:
+            - regular-branches: true
+            - change-request:
+                ignore-target-only-changes: true
+          clean:
+            after: true
+            before: true
+          prune: true
+          shallow-clone: true
+          depth: 3
+          do-not-fetch-tags: true
+          submodule:
+            disable: false
+            recursive: true
+            parent-credentials: true
+            timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: 'True'
+    triggers:
+      - timed: 'H H(4-5) * * 1-5'

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains:
         - APM Server
         - Filebeat
         - Metricbeat
+    - [Kubernetes Autodiscover](./e2e/_suites/kubernetes-autodiscover)
     - [Fleet](./e2e/_suites/fleet)
         - Stand-Alone mode
         - Fleet mode


### PR DESCRIPTION
Backports the following commits to 7.x:

- feat: add scheduled pipeline for k8s autodiscovery test suite (#1100)