### PR TITLE
chore(ci): listen for 7.14 branch, retiring 7.12 (#1300) backport for 7.x

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -7,8 +7,9 @@
     "multipleCommits": true,
     "prTitle": "{commitMessages} backport for {targetBranch}",
     "targetBranchChoices": [
-        { "name": "7.10.x", "checked": true },
-        { "name": "7.9.x", "checked": true }
+        { "name": "7.x", "checked": true },
+        { "name": "7.14.x", "checked": true },
+        { "name": "7.13.x", "checked": true }
     ],
     "targetPRLabels": ["backport"],
     "upstream": "elastic/e2e-testing"

--- a/.ci/jobs/e2e-testing-fleet-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-fleet-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(master|\d+\.\d+\.x)'
+          head-filter-regex: '(master|7\.x|7\.14\.x|7\.13\.x)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-helm-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-helm-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(master|\d+\.\d+\.x)'
+          head-filter-regex: '(master|7\.x|7\.14\.x|7\.13\.x)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-integrations-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-integrations-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(master|\d+\.\d+\.x)'
+          head-filter-regex: '(master|7\.x|7\.14\.x|7\.13\.x)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-k8s-autodiscovery-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-k8s-autodiscovery-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(master|7\.x|7\.13\.x|7\.12\.x)'
+          head-filter-regex: '(master|7\.x|7\.14\.x|7\.13\.x)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -10,7 +10,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(master|PR-.*|v\d\.d\.d|7\.x|7\.11\.x|7\.10\.x)'
+          head-filter-regex: '(master|PR-.*|v\d\.d\.d|7\.x|7\.14\.x|7\.13\.x)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current


### PR DESCRIPTION
Backports the following commits to 7.x:
 - chore(ci): listen for 7.14 branch, retiring 7.12 (#1300)