### PR TITLE
chore(ci): propagate downstream build result to upstream (#1377)

### DIFF
--- a/.ci/e2eKibana.groovy
+++ b/.ci/e2eKibana.groovy
@@ -126,7 +126,7 @@ def runE2ETests(String suite) {
 
   build(job: "${e2eTestsPipeline}",
     parameters: parameters,
-    propagate: false,
+    propagate: true,
     wait: false
   )
 

--- a/.ci/e2eTestingFleetDaily.groovy
+++ b/.ci/e2eTestingFleetDaily.groovy
@@ -49,7 +49,7 @@ pipeline {
             string(name: 'runTestsSuites', value: 'fleet'),
             string(name: 'SLACK_CHANNEL', value: "elastic-agent"),
           ],
-          propagate: false,
+          propagate: true,
           wait: false
         )
       }

--- a/.ci/e2eTestingHelmDaily.groovy
+++ b/.ci/e2eTestingHelmDaily.groovy
@@ -47,7 +47,7 @@ pipeline {
             string(name: 'runTestsSuites', value: 'helm'),
             string(name: 'SLACK_CHANNEL', value: "infra-release-notify,integrations"),
           ],
-          propagate: false,
+          propagate: true,
           wait: false
         )
       }

--- a/.ci/e2eTestingIntegrationsDaily.groovy
+++ b/.ci/e2eTestingIntegrationsDaily.groovy
@@ -48,7 +48,7 @@ pipeline {
             string(name: 'runTestsSuites', value: 'metricbeat'),
             string(name: 'SLACK_CHANNEL', value: "beats-build"),
           ],
-          propagate: false,
+          propagate: true,
           wait: false
         )
       }

--- a/.ci/e2eTestingK8SAutodiscoveryDaily.groovy
+++ b/.ci/e2eTestingK8SAutodiscoveryDaily.groovy
@@ -47,7 +47,7 @@ pipeline {
             string(name: 'runTestsSuites', value: 'kubernetes-autodiscover'),
             string(name: 'SLACK_CHANNEL', value: "integrations"),
           ],
-          propagate: false,
+          propagate: true,
           wait: false
         )
       }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - chore(ci): propagate downstream build result to upstream (#1377)