### PR TITLE
fix: check if the snapshot version contains a commit

### DIFF
--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -647,6 +647,10 @@ func TestIsCommit(t *testing.T) {
 		assert.False(t, IsCommit("7.11.x"))
 		assert.False(t, IsCommit("pr12345"))
 	})
+
+	t.Run("Returns false with commits in snapshots", func(t *testing.T) {
+		assert.False(t, IsCommit("8.0.0-a12345-SNAPSHOT"))
+	})
 }
 
 func TestProcessBucketSearchPage_CommitFound(t *testing.T) {
@@ -681,4 +685,15 @@ func TestProcessBucketSearchPage_SnapshotsNotFound(t *testing.T) {
 	mediaLink, err := processBucketSearchPage(snapshotsJSON, 1, bucket, snapshots, object)
 	assert.NotNil(t, err)
 	assert.True(t, mediaLink == "")
+}
+
+func TestSnapshotHasCommit(t *testing.T) {
+	t.Run("Returns true with commits in snapshots", func(t *testing.T) {
+		assert.True(t, SnapshotHasCommit("8.0.0-a12345-SNAPSHOT"))
+	})
+
+	t.Run("Returns false with commits in snapshots", func(t *testing.T) {
+		assert.False(t, SnapshotHasCommit("7.x-SNAPSHOT"))
+		assert.False(t, SnapshotHasCommit("8.0.0-SNAPSHOT"))
+	})
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
When checking the version using Elastic's versions API, this PR adds a verification for the version to have a commit sha between the semver version and the SNAPSHOT suffix. If it does contain it, then the API is not looked up. To achieve it we added a helper method as an utility, where we use a regex that checks for `X.Y.Z-sha-SNAPSHOT`. We added unit tests verifying the new behaviour.

On the same hand, we noticed that the existing `IsCommit` method would return true for this hashed snapshots, so when checking Kibana version we used that method to change the Docker namespace for the image. With the previous implementation the method would return true, changing the namespace to `observability-ci`. For that reason we improved the regex in there to check for commits from the first position in the checked string.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The automation to bump the versions replaces the current version with i.e. `8.0.0-abcdef-SNAPSHOT`. That version was used to look up the versions API, and because it does not exist, the tests fails with a log.Fatal: because the stack (ES, Kibana, Fleet-Server) is considered a runtime dependency, we cannot run the tests without it. With this change, we simply use the version as it is, without the versions API (which is used to resolve version aliases).

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] regex masters, can you review the new regex? :pray:

## How to test this PR locally

```shell
# run unit tests
$ make unit-test

# run e2e tests with a hashed version
$ TAGS="apm_server" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEAT_VERSION="8.0.0-ae1e1c3b-SNAPSHOT" DEVELOPER_MODE=true ELASTIC_APM_ACTIVE=false make -C e2e/_suites/fleet functional-test

# run e2e tests with a fixed version without commit
$ TAGS="apm_server" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEAT_VERSION="8.0.0-SNAPSHOT" STACK_VERSION=8.0.0-SNAPSHOT DEVELOPER_MODE=true ELASTIC_APM_ACTIVE=false make -C e2e/_suites/fleet functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #1405
- Unblocks any automated bump PR: #1391 #1403

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->