### PR TITLE
fix: parse hashed version to download artifacts from Elastic

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -330,9 +330,11 @@ func GetElasticArtifactURL(artifactName string, artifact string, version string)
 	body := ""
 
 	tmpVersion := version
-	hasCommit := SnapshotHasCommit(version)
-	if hasCommit {
-		log.Trace("Removing SNAPSHOT from commit")
+	if SnapshotHasCommit(version) {
+		log.WithFields(log.Fields{
+			"version": version,
+		}).Trace("Removing SNAPSHOT from version including commit")
+
 		// remove the SNAPSHOT from the VERSION as the artifacts API supports commits in the version, but without the snapshot suffix
 		tmpVersion = strings.ReplaceAll(version, "-SNAPSHOT", "")
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It removes the SNAPSHOT suffix when downloading artifacts from Elastic's artifacts API for a version containing a commit (i.e. 8.0.0-abcdef-SNAPSHOT)

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The artifacts API supports passing the version and the commit, but removing the SNAPSHOT (i.e. 8.0.0-abcdef).

To complete an automated bump of the version, we have to include this check, which was not included in previous patches.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally
Passing a BEAT_VERSION that is available in the Artifacts API:
```shell
TAGS="apm_server" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE BEAT_VERSION=8.0.0-cf3e6139-SNAPSHOT DEVELOPER_MODE=true ELASTIC_APM_ACTIVE=false make -C e2e/_suites/fleet functional-test
```
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Completes #1406

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->