### PR TITLE
chore: calculate version in context (#1459) backport for 7.13.x

### DIFF
--- a/e2e/_suites/metricbeat/metricbeat_test.go
+++ b/e2e/_suites/metricbeat/metricbeat_test.go
@@ -18,6 +18,7 @@ import (
 	messages "github.com/cucumber/messages-go/v10"
 	"github.com/elastic/e2e-testing/cli/config"
 	"github.com/elastic/e2e-testing/e2e/steps"
+	elasticversion "github.com/elastic/e2e-testing/internal"
 	"github.com/elastic/e2e-testing/internal/common"
 	"github.com/elastic/e2e-testing/internal/deploy"
 	"github.com/elastic/e2e-testing/internal/elasticsearch"
@@ -77,7 +78,7 @@ func (mts *MetricbeatTestSuite) setEventModule(eventModule string) {
 // and because of the ILM is configured on metricbeat side, then we can use an asterisk for the index name:
 // each scenario outline will be namespaced, so no collitions between different test cases should appear
 func (mts *MetricbeatTestSuite) setIndexName() {
-	mVersion := strings.ReplaceAll(mts.Version, "-SNAPSHOT", "")
+	mVersion := elasticversion.GetCommitVersion(mts.Version)
 
 	var index string
 	if mts.ServiceName != "" {

--- a/internal/installer/elasticagent_tar.go
+++ b/internal/installer/elasticagent_tar.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	elasticversion "github.com/elastic/e2e-testing/internal"
 	"github.com/elastic/e2e-testing/internal/common"
 	"github.com/elastic/e2e-testing/internal/deploy"
 	"github.com/elastic/e2e-testing/internal/kibana"
@@ -137,7 +138,7 @@ func (i *elasticAgentTARPackage) Preinstall(ctx context.Context) error {
 		return err
 	}
 
-	output, _ := i.Exec(ctx, []string{"mv", fmt.Sprintf("/%s-%s-%s-%s", artifact, common.BeatVersion, os, arch), "/elastic-agent"})
+	output, _ := i.Exec(ctx, []string{"mv", fmt.Sprintf("/%s-%s-%s-%s", artifact, elasticversion.GetSnapshotVersion(common.BeatVersion), os, arch), "/elastic-agent"})
 	log.WithField("output", output).Trace("Moved elastic-agent")
 	return nil
 }

--- a/internal/installer/elasticagent_tar_macos.go
+++ b/internal/installer/elasticagent_tar_macos.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"runtime"
 
+	elasticversion "github.com/elastic/e2e-testing/internal"
 	"github.com/elastic/e2e-testing/internal/common"
 	"github.com/elastic/e2e-testing/internal/deploy"
 	"github.com/elastic/e2e-testing/internal/kibana"
@@ -136,7 +137,7 @@ func (i *elasticAgentTARDarwinPackage) Preinstall(ctx context.Context) error {
 		return err
 	}
 
-	output, _ = i.Exec(ctx, []string{"mv", fmt.Sprintf("/%s-%s-%s-%s", artifact, common.BeatVersion, os, arch), "/elastic-agent"})
+	output, _ = i.Exec(ctx, []string{"mv", fmt.Sprintf("/%s-%s-%s-%s", artifact, elasticversion.GetSnapshotVersion(common.BeatVersion), os, arch), "/elastic-agent"})
 	log.WithField("output", output).Trace("Moved elastic-agent")
 	return nil
 }

--- a/internal/installer/elasticagent_zip.go
+++ b/internal/installer/elasticagent_zip.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	elasticversion "github.com/elastic/e2e-testing/internal"
 	"github.com/elastic/e2e-testing/internal/common"
 	"github.com/elastic/e2e-testing/internal/deploy"
 	"github.com/elastic/e2e-testing/internal/kibana"
@@ -129,7 +130,7 @@ func (i *elasticAgentZIPPackage) Preinstall(ctx context.Context) error {
 		return err
 	}
 
-	output, _ = i.Exec(ctx, []string{"powershell.exe", "Move-Item", fmt.Sprintf("C:\\%s-%s-%s-%s", artifact, common.BeatVersion, os, arch), "C:\\elastic-agent"})
+	output, _ = i.Exec(ctx, []string{"powershell.exe", "Move-Item", fmt.Sprintf("C:\\%s-%s-%s-%s", artifact, elasticversion.GetSnapshotVersion(common.BeatVersion), os, arch), "C:\\elastic-agent"})
 	log.WithField("output", output).Trace("Moved elastic-agent")
 	return nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Jeffail/gabs/v2"
 	backoff "github.com/cenkalti/backoff/v4"
+	elasticversion "github.com/elastic/e2e-testing/internal"
 	curl "github.com/elastic/e2e-testing/internal/curl"
 	internalio "github.com/elastic/e2e-testing/internal/io"
 	"github.com/elastic/e2e-testing/internal/shell"
@@ -49,6 +50,8 @@ func buildArtifactName(artifact string, artifactVersion string, OS string, arch 
 	if isDocker {
 		dockerString = ".docker"
 	}
+
+	artifactVersion = elasticversion.GetSnapshotVersion(artifactVersion)
 
 	lowerCaseExtension := strings.ToLower(extension)
 
@@ -247,7 +250,7 @@ func GetElasticArtifactVersion(version string) (string, error) {
 		return val, nil
 	}
 
-	if SnapshotHasCommit(version) {
+	if elasticversion.SnapshotHasCommit(version) {
 		elasticVersionsCache[cacheKey] = version
 		return version, nil
 	}
@@ -330,13 +333,14 @@ func GetElasticArtifactURL(artifactName string, artifact string, version string)
 	body := ""
 
 	tmpVersion := version
-	if SnapshotHasCommit(version) {
+	hasCommit := elasticversion.SnapshotHasCommit(version)
+	if hasCommit {
 		log.WithFields(log.Fields{
 			"version": version,
 		}).Trace("Removing SNAPSHOT from version including commit")
 
 		// remove the SNAPSHOT from the VERSION as the artifacts API supports commits in the version, but without the snapshot suffix
-		tmpVersion = strings.ReplaceAll(version, "-SNAPSHOT", "")
+		tmpVersion = elasticversion.GetCommitVersion(version)
 	}
 
 	apiStatus := func() error {
@@ -393,6 +397,11 @@ func GetElasticArtifactURL(artifactName string, artifact string, version string)
 		"elapsedTime":  exp.GetElapsedTime(),
 		"version":      tmpVersion,
 	}).Trace("Artifact found")
+
+	if hasCommit {
+		// remove commit from the artifact as it comes like this: elastic-agent-8.0.0-abcdef-SNAPSHOT-darwin-x86_64.tar.gz
+		artifactName = elasticversion.RemoveCommitFromSnapshot(artifactName)
+	}
 
 	packagesObject := jsonParsed.Path("packages")
 	// we need to get keys with dots using Search instead of Path
@@ -657,14 +666,6 @@ func Sleep(duration time.Duration) error {
 	time.Sleep(duration)
 
 	return nil
-}
-
-// SnapshotHasCommit returns true if the snapshot version contains a commit format
-func SnapshotHasCommit(s string) bool {
-	// regex = X.Y.Z-commit-SNAPSHOT
-	re := regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-\b[0-9a-f]{5,40}\b)(-SNAPSHOT)`)
-
-	return re.MatchString(s)
 }
 
 // GetDockerNamespaceEnvVar returns the Docker namespace whether we use one of the CI snapshots or

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -51,6 +51,19 @@ func TestBuildArtifactName(t *testing.T) {
 	OS := "linux"
 	version := testVersion
 
+	t.Run("For Git commits in version", func(t *testing.T) {
+		arch := "x86_64"
+		extension := "rpm"
+		expectedFileName := "elastic-agent-1.2.3-SNAPSHOT-x86_64.rpm"
+		versionWithCommit := "1.2.3-abcdef-SNAPSHOT"
+
+		artifactName := buildArtifactName(artifact, versionWithCommit, OS, arch, extension, false)
+		assert.Equal(t, expectedFileName, artifactName)
+
+		artifactName = buildArtifactName(artifact, versionWithCommit, OS, arch, "RPM", false)
+		assert.Equal(t, expectedFileName, artifactName)
+	})
+
 	t.Run("For RPM (amd64)", func(t *testing.T) {
 		arch := "x86_64"
 		extension := "rpm"
@@ -685,15 +698,4 @@ func TestProcessBucketSearchPage_SnapshotsNotFound(t *testing.T) {
 	mediaLink, err := processBucketSearchPage(snapshotsJSON, 1, bucket, snapshots, object)
 	assert.NotNil(t, err)
 	assert.True(t, mediaLink == "")
-}
-
-func TestSnapshotHasCommit(t *testing.T) {
-	t.Run("Returns true with commits in snapshots", func(t *testing.T) {
-		assert.True(t, SnapshotHasCommit("8.0.0-a12345-SNAPSHOT"))
-	})
-
-	t.Run("Returns false with commits in snapshots", func(t *testing.T) {
-		assert.False(t, SnapshotHasCommit("7.x-SNAPSHOT"))
-		assert.False(t, SnapshotHasCommit("8.0.0-SNAPSHOT"))
-	})
 }

--- a/internal/versions.go
+++ b/internal/versions.go
@@ -1,0 +1,67 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package internal
+
+import (
+	"regexp"
+	"strings"
+)
+
+// elasticVersion represents a version
+type elasticVersion struct {
+	Version         string // 8.0.0
+	FullVersion     string // 8.0.0-abcdef-SNAPSHOT
+	HashedVersion   string // 8.0.0-abcdef
+	SnapshotVersion string // 8.0.0-SNAPSHOT
+}
+
+func newElasticVersion(version string) *elasticVersion {
+	versionWithoutCommit := RemoveCommitFromSnapshot(version)
+	versionWithoutSnapshot := strings.ReplaceAll(version, "-SNAPSHOT", "")
+	versionWithoutCommitAndSnapshot := strings.ReplaceAll(versionWithoutCommit, "-SNAPSHOT", "")
+
+	return &elasticVersion{
+		FullVersion:     version,
+		HashedVersion:   versionWithoutSnapshot,
+		SnapshotVersion: versionWithoutCommit,
+		Version:         versionWithoutCommitAndSnapshot,
+	}
+}
+
+// GetCommitVersion returns a version including the version and the git commit, if it exists
+func GetCommitVersion(version string) string {
+	return newElasticVersion(version).HashedVersion
+}
+
+// GetFullVersion returns a version including the full version: version, git commit and snapshot
+func GetFullVersion(version string) string {
+	return newElasticVersion(version).FullVersion
+}
+
+// GetSnapshotVersion returns a version including the snapshot version: version and snapshot
+func GetSnapshotVersion(version string) string {
+	return newElasticVersion(version).SnapshotVersion
+}
+
+// GetVersion returns a version without snapshot or commit
+func GetVersion(version string) string {
+	return newElasticVersion(version).Version
+}
+
+// RemoveCommitFromSnapshot removes the commit from a version including commit and SNAPSHOT
+func RemoveCommitFromSnapshot(s string) string {
+	// regex = X.Y.Z-commit-SNAPSHOT
+	re := regexp.MustCompile(`-\b[0-9a-f]{5,40}\b`)
+
+	return re.ReplaceAllString(s, "")
+}
+
+// SnapshotHasCommit returns true if the snapshot version contains a commit format
+func SnapshotHasCommit(s string) bool {
+	// regex = X.Y.Z-commit-SNAPSHOT
+	re := regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-\b[0-9a-f]{5,40}\b)(-SNAPSHOT)`)
+
+	return re.MatchString(s)
+}

--- a/internal/versions_test.go
+++ b/internal/versions_test.go
@@ -1,0 +1,108 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewElasticVersion(t *testing.T) {
+	t.Run("newElasticVersion without git commit", func(t *testing.T) {
+		v := newElasticVersion("1.2.3-SNAPSHOT")
+
+		assert.Equal(t, "1.2.3", v.Version, "Version should not include SNAPSHOT nor commit")
+		assert.Equal(t, "1.2.3-SNAPSHOT", v.FullVersion, "Full version should include SNAPSHOT")
+		assert.Equal(t, "1.2.3", v.HashedVersion, "Hashed version should not include SNAPSHOT")
+		assert.Equal(t, "1.2.3-SNAPSHOT", v.SnapshotVersion, "Snapshot version should include SNAPSHOT")
+	})
+
+	t.Run("newElasticVersion with git commit", func(t *testing.T) {
+		v := newElasticVersion("1.2.3-abcdef-SNAPSHOT")
+
+		assert.Equal(t, "1.2.3", v.Version, "Version should not include SNAPSHOT nor commit")
+		assert.Equal(t, "1.2.3-abcdef-SNAPSHOT", v.FullVersion, "Full version should include commit and SNAPSHOT")
+		assert.Equal(t, "1.2.3-abcdef", v.HashedVersion, "Hashed version should include commit but no SNAPSHOT")
+		assert.Equal(t, "1.2.3-SNAPSHOT", v.SnapshotVersion, "Snapshot version should include SNAPSHOT but no commit")
+	})
+}
+
+func Test_GetCommitVersion(t *testing.T) {
+	t.Run("GetCommitVersion without git commit", func(t *testing.T) {
+		v := GetCommitVersion("1.2.3-SNAPSHOT")
+
+		assert.Equal(t, "1.2.3", v, "Version should not include SNAPSHOT nor commit")
+	})
+
+	t.Run("GetCommitVersion with git commit", func(t *testing.T) {
+		v := GetCommitVersion("1.2.3-abcdef-SNAPSHOT")
+
+		assert.Equal(t, "1.2.3-abcdef", v, "Version should not include SNAPSHOT nor commit")
+	})
+}
+
+func Test_GetFullVersion(t *testing.T) {
+	t.Run("GetFullVersion without git commit", func(t *testing.T) {
+		v := GetFullVersion("1.2.3-SNAPSHOT")
+
+		assert.Equal(t, "1.2.3-SNAPSHOT", v, "Version should not include SNAPSHOT nor commit")
+	})
+
+	t.Run("GetFullVersion with git commit", func(t *testing.T) {
+		v := GetFullVersion("1.2.3-abcdef-SNAPSHOT")
+
+		assert.Equal(t, "1.2.3-abcdef-SNAPSHOT", v, "Version should not include SNAPSHOT nor commit")
+	})
+}
+
+func Test_GetSnapshotVersion(t *testing.T) {
+	t.Run("GetSnapshotVersion without git commit", func(t *testing.T) {
+		v := GetSnapshotVersion("1.2.3-SNAPSHOT")
+
+		assert.Equal(t, "1.2.3-SNAPSHOT", v, "Version should include SNAPSHOT but no commit")
+	})
+
+	t.Run("GetCommitVersion with git commit", func(t *testing.T) {
+		v := GetSnapshotVersion("1.2.3-abcdef-SNAPSHOT")
+
+		assert.Equal(t, "1.2.3-SNAPSHOT", v, "Version should include SNAPSHOT but no commit")
+	})
+}
+
+func Test_GetVersion(t *testing.T) {
+	t.Run("GetVersion without git commit", func(t *testing.T) {
+		v := GetVersion("1.2.3-SNAPSHOT")
+
+		assert.Equal(t, "1.2.3", v, "Version should not include SNAPSHOT nor commit")
+	})
+
+	t.Run("GetVersion with git commit", func(t *testing.T) {
+		v := GetVersion("1.2.3-abcdef-SNAPSHOT")
+
+		assert.Equal(t, "1.2.3", v, "Version should not include SNAPSHOT nor commit")
+	})
+}
+
+func TestRemoveCommitFromSnapshot(t *testing.T) {
+	assert.Equal(t, "elastic-agent-8.0.0-SNAPSHOT-darwin-x86_64.tar.gz", RemoveCommitFromSnapshot("elastic-agent-8.0.0-abcdef-SNAPSHOT-darwin-x86_64.tar.gz"))
+	assert.Equal(t, "8.0.0-SNAPSHOT", RemoveCommitFromSnapshot("8.0.0-a12345-SNAPSHOT"))
+	assert.Equal(t, "7.x-SNAPSHOT", RemoveCommitFromSnapshot("7.x-a12345-SNAPSHOT"))
+	assert.Equal(t, "7.14.x-SNAPSHOT", RemoveCommitFromSnapshot("7.14.x-a12345-SNAPSHOT"))
+	assert.Equal(t, "8.0.0-SNAPSHOT", RemoveCommitFromSnapshot("8.0.0-SNAPSHOT"))
+	assert.Equal(t, "7.x-SNAPSHOT", RemoveCommitFromSnapshot("7.x-SNAPSHOT"))
+	assert.Equal(t, "7.14.x-SNAPSHOT", RemoveCommitFromSnapshot("7.14.x-SNAPSHOT"))
+}
+
+func TestSnapshotHasCommit(t *testing.T) {
+	t.Run("Returns true with commits in snapshots", func(t *testing.T) {
+		assert.True(t, SnapshotHasCommit("8.0.0-a12345-SNAPSHOT"))
+	})
+
+	t.Run("Returns false with commits in snapshots", func(t *testing.T) {
+		assert.False(t, SnapshotHasCommit("7.x-SNAPSHOT"))
+		assert.False(t, SnapshotHasCommit("8.0.0-SNAPSHOT"))
+	})
+}


### PR DESCRIPTION
Backports the following commits to 7.13.x:
 - chore: calculate version in context (#1459)