### PR TITLE
[automation] update elastic stack version for testing 7.16.0-f4fa0a64

### DIFF
--- a/.stack-version
+++ b/.stack-version
@@ -1,1 +1,1 @@
-7.16.0-fbd5fab2-SNAPSHOT
+7.16.0-f4fa0a64-SNAPSHOT


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 13 Sep 2021 05:14:31 GMT, release_branch:7.x, prefix:, end_time:Mon, 13 Sep 2021 11:50:59 GMT, manifest_version:2.0.0, version:7.16.0-SNAPSHOT, branch:7.x, build_id:7.16.0-f4fa0a64, build_duration_seconds:23788]