### PR TITLE
fix: build each repository in the right branch

### DIFF
--- a/.ci/e2eFleetServer.groovy
+++ b/.ci/e2eFleetServer.groovy
@@ -151,6 +151,8 @@ def getE2EBaseBranch() {
   def prID = getID()
 
   if (!prID.isInteger()) {
+    // we are building a branch on Fleet Server
+    setEnvVar('BASE_REF', prID)
     // in the case we are triggering the job for a branch (i.e master, 7.x) we directly use branch name as Docker tag
     return getMaintenanceBranch(prID)
   }
@@ -159,6 +161,7 @@ def getE2EBaseBranch() {
 
   def pullRequest = githubApiCall(token: token, url: "https://api.github.com/repos/${env.ELASTIC_REPO}/pulls/${prID}")
   def baseRef = pullRequest?.base?.ref
+  setEnvVar('BASE_REF', baseRef)
   //def headSha = pullRequest?.head?.sha
 
   return getMaintenanceBranch(baseRef)
@@ -174,7 +177,6 @@ def getID(){
 
 def getMaintenanceBranch(String branch){
   if (branch == 'master' || branch == 'main') {
-    setEnvVar('BASE_REF', branch)
     return branch
   }
 
@@ -183,7 +185,6 @@ def getMaintenanceBranch(String branch){
     branch += '.x'
   }
 
-  setEnvVar('BASE_REF', branch)
   return branch
 }
 

--- a/.ci/e2eFleetServer.groovy
+++ b/.ci/e2eFleetServer.groovy
@@ -77,7 +77,7 @@ pipeline {
             stage('Build Fleet Server') {
               options { skipDefaultCheckout() }
               steps {
-                gitCheckout(basedir: BASE_DIR, branch: 'master', githubNotifyFirstTimeContributor: true, repo: "git@github.com:${env.ELASTIC_REPO}.git", credentialsId: env.JOB_GIT_CREDENTIALS)
+                gitCheckout(basedir: BASE_DIR, branch: 'master', repo: "git@github.com:${env.ELASTIC_REPO}.git", credentialsId: env.JOB_GIT_CREDENTIALS)
                 dir("${BASE_DIR}") {
                   withGoEnv(){
                     sh(label: 'Build Fleet Server', script: "make release")
@@ -89,7 +89,7 @@ pipeline {
             stage('Build Elastic Agent Dependencies') {
               options { skipDefaultCheckout() }
               steps {
-                gitCheckout(basedir: BEATS_BASE_DIR, branch: 'master', githubNotifyFirstTimeContributor: true, repo: "git@github.com:${env.BEATS_ELASTIC_REPO}.git", credentialsId: env.JOB_GIT_CREDENTIALS)
+                gitCheckout(basedir: BEATS_BASE_DIR, branch: 'master', repo: "git@github.com:${env.BEATS_ELASTIC_REPO}.git", credentialsId: env.JOB_GIT_CREDENTIALS)
                 dir("${BEATS_BASE_DIR}/x-pack/elastic-agent") {
                   withGoEnv(){
                     sh(label: 'Build Fleet Server', script: 'DEV=true SNAPSHOT=true PLATFORMS="+all linux/amd64" mage package')
@@ -117,7 +117,7 @@ pipeline {
         stage('Run E2E Tests') {
           options { skipDefaultCheckout() }
           steps {
-            gitCheckout(basedir: E2E_BASE_DIR, branch: "${env.E2E_BASE_BRANCH}", githubNotifyFirstTimeContributor: true, repo: 'git@github.com:elastic/e2e-testing.git', credentialsId: env.JOB_GIT_CREDENTIALS)
+            gitCheckout(basedir: E2E_BASE_DIR, branch: "${env.E2E_BASE_BRANCH}", repo: 'git@github.com:elastic/e2e-testing.git', credentialsId: env.JOB_GIT_CREDENTIALS)
             dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
             dir("${E2E_BASE_DIR}") {
               withGoEnv(){

--- a/.ci/e2eFleetServer.groovy
+++ b/.ci/e2eFleetServer.groovy
@@ -89,7 +89,7 @@ pipeline {
             stage('Build Elastic Agent Dependencies') {
               options { skipDefaultCheckout() }
               steps {
-                gitCheckout(basedir: BEATS_BASE_DIR, branch: 'master', repo: "git@github.com:${env.BEATS_ELASTIC_REPO}.git", credentialsId: env.JOB_GIT_CREDENTIALS)
+                gitCheckout(basedir: BEATS_BASE_DIR, branch: "${BASE_REF}", repo: "git@github.com:${env.BEATS_ELASTIC_REPO}.git", credentialsId: env.JOB_GIT_CREDENTIALS)
                 dir("${BEATS_BASE_DIR}/x-pack/elastic-agent") {
                   withGoEnv(){
                     sh(label: 'Build Fleet Server', script: 'DEV=true SNAPSHOT=true PLATFORMS="+all linux/amd64" mage package')
@@ -174,13 +174,15 @@ def getID(){
 
 def getMaintenanceBranch(String branch){
   if (branch == 'master' || branch == 'main') {
+    setEnvVar('BASE_REF', branch)
     return branch
   }
 
   if (!branch.endsWith('.x')) {
     // use maintenance branches mode (i.e. 7.16 translates to 7.16.x)
-    return branch + '.x'
+    branch += '.x'
   }
 
+  setEnvVar('BASE_REF', branch)
   return branch
 }

--- a/.ci/e2eFleetServer.groovy
+++ b/.ci/e2eFleetServer.groovy
@@ -77,7 +77,7 @@ pipeline {
             stage('Build Fleet Server') {
               options { skipDefaultCheckout() }
               steps {
-                gitCheckout(basedir: BASE_DIR, branch: 'master', repo: "git@github.com:${env.ELASTIC_REPO}.git", credentialsId: env.JOB_GIT_CREDENTIALS)
+                gitCheckout(basedir: BASE_DIR, branch: getFleetServerBranch(), repo: "git@github.com:${env.ELASTIC_REPO}.git", credentialsId: env.JOB_GIT_CREDENTIALS)
                 dir("${BASE_DIR}") {
                   withGoEnv(){
                     sh(label: 'Build Fleet Server', script: "make release")
@@ -185,4 +185,14 @@ def getMaintenanceBranch(String branch){
 
   setEnvVar('BASE_REF', branch)
   return branch
+}
+
+def getFleetServerBranch(){
+  def fleetServerBranch = getID()
+
+  if (!fleetServerBranch.isInteger()) {
+    return fleetServerBranch
+  }
+
+  return 'PR/'+fleetServerBranch
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR builds the affected repos in the right branches:

- fleet-server: if there is a payload comming from a PR in the repo (via GH comment), it will build the 'PR/#ID' branch. Same if it's manually triggered using a PR ID as input     paramenter. If a branch is used as input parameter (i.e. `master`, `7.16`, `7.x`) the the branch will be used as is.
- beats: it will use what comes in the `$BASE_REF` variable, which is set in the first stage of the pipeline, within the `getE2EBaseBranch()` helper method. This method will       internally set the env var to the baseRef attribute of the payload retrieved by our API call, which uses what comes from the webhook or in the input parameter. If a branch is used as an input parameter, it will build the same Beats branch.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Build what is right

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR
Manually trigger the https://beats-ci.elastic.co/job/e2e-tests/job/e2e-testing-fleet-server/ job, using a fleet-server PR (or a branch) as parameter.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Continues #1628 

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->