### PR TITLE
fix(ci): set base ref for kibana build

### DIFF
--- a/.ci/e2eKibana.groovy
+++ b/.ci/e2eKibana.groovy
@@ -151,6 +151,7 @@ def getDockerTagFromPayload() {
 
   if (!prID.isInteger()) {
     // in the case we are triggering the job for a branch (i.e master, 7.x) we directly use branch name as Docker tag
+    setEnvVar("BASE_REF", prID)
     return prID
   }
 
@@ -158,6 +159,9 @@ def getDockerTagFromPayload() {
 
   def pullRequest = githubApiCall(token: token, url: "https://api.github.com/repos/${env.ELASTIC_REPO}/pulls/${prID}")
   def baseRef = pullRequest?.base?.ref
+
+  setEnvVar("BASE_REF", baseRef)
+
   def headSha = pullRequest?.head?.sha
 
   // we are going to use the 'pr12345' tag as default
@@ -198,7 +202,7 @@ def runE2ETests(String suite) {
   log(level: 'DEBUG', text: "Triggering '${suite}' E2E tests for "+getBranch()+" using '${dockerTag}' as Docker tag")
 
   // Kibana's maintenance branches follow the 7.11, 7.12 schema.
-  def branchName = "${baseRef}"
+  def branchName = "${BASE_REF}"
   if (branchName != "master") {
     branchName += ".x"
   }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It sets the `BASE_REF` variable using the branch name if it's not a PR ID, or the baseRef attribute of the payload retrieved from the API call representing the PR ID.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Again, that variable was used but not set, failing with this stacktrace:

```stacktrace
[2021-10-01T16:01:54.982Z] ERROR: Unable to run e2e tests
[2021-10-01T16:01:54.983Z] groovy.lang.MissingPropertyException: No such property: baseRef for class: groovy.lang.Binding
[2021-10-01T16:01:54.983Z] 	at groovy.lang.Binding.getVariable(Binding.java:63)
[2021-10-01T16:01:54.983Z] 	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onGetProperty(SandboxInterceptor.java:271)
[2021-10-01T16:01:54.983Z] 	at org.kohsuke.groovy.sandbox.impl.Checker$7.call(Checker.java:353)
[2021-10-01T16:01:54.983Z] 	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:357)
[2021-10-01T16:01:54.983Z] 	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.getProperty(SandboxInvoker.java:29)
[2021-10-01T16:01:54.983Z] 	at com.cloudbees.groovy.cps.impl.PropertyAccessBlock.rawGet(PropertyAccessBlock.java:20)
[2021-10-01T16:01:54.983Z] 	at WorkflowScript.runE2ETests(WorkflowScript:201)
[2021-10-01T16:01:54.983Z] 	at WorkflowScript.run(WorkflowScript:107)
[2021-10-01T16:01:54.983Z] 	at ___cps.transform___(Native Method)
[2021-10-01T16:01:54.983Z] 	at com.cloudbees.groovy.cps.impl.PropertyishBlock$ContinuationImpl.get(PropertyishBlock.java:74)
[2021-10-01T16:01:54.983Z] 	at com.cloudbees.groovy.cps.LValueBlock$GetAdapter.receive(LValueBlock.java:30)
[2021-10-01T16:01:54.983Z] 	at com.cloudbees.groovy.cps.impl.PropertyishBlock$ContinuationImpl.fixName(PropertyishBlock.java:66)
[2021-10-01T16:01:54.983Z] 	at sun.reflect.GeneratedMethodAccessor968.invoke(Unknown Source)
[2021-10-01T16:01:54.983Z] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[2021-10-01T16:01:54.983Z] 	at java.lang.reflect.Method.invoke(Method.java:498)
[2021-10-01T16:01:54.983Z] 	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
[2021-10-01T16:01:54.983Z] 	at com.cloudbees.groovy.cps.impl.ConstantBlock.eval(ConstantBlock.java:21)
[2021-10-01T16:01:54.983Z] 	at com.cloudbees.groovy.cps.Next.step(Next.java:83)
[2021-10-01T16:01:54.983Z] 	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:174)
[2021-10-01T16:01:54.983Z] 	at com.cloudbees.groovy.cps.Continuable$1.call(Continuable.java:163)
[2021-10-01T16:01:54.983Z] 	at org.codehaus.groovy.runtime.GroovyCategorySupport$ThreadCategoryInfo.use(GroovyCategorySupport.java:129)
[2021-10-01T16:01:54.983Z] 	at org.codehaus.groovy.runtime.GroovyCategorySupport.use(GroovyCategorySupport.java:268)
[2021-10-01T16:01:54.983Z] 	at com.cloudbees.groovy.cps.Continuable.run0(Continuable.java:163)
[2021-10-01T16:01:54.983Z] 	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.access$001(SandboxContinuable.java:18)
[2021-10-01T16:01:54.983Z] 	at org.jenkinsci.plugins.workflow.cps.SandboxContinuable.run0(SandboxContinuable.java:51)
[2021-10-01T16:01:54.983Z] 	at org.jenkinsci.plugins.workflow.cps.CpsThread.runNextChunk(CpsThread.java:185)
[2021-10-01T16:01:54.983Z] 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.run(CpsThreadGroup.java:400)
[2021-10-01T16:01:54.983Z] 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.access$400(CpsThreadGroup.java:96)
[2021-10-01T16:01:54.983Z] 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:312)
[2021-10-01T16:01:54.983Z] 	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$2.call(CpsThreadGroup.java:276)
[2021-10-01T16:01:54.983Z] 	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$2.call(CpsVmExecutorService.java:67)
[2021-10-01T16:01:54.983Z] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2021-10-01T16:01:54.983Z] 	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:139)
[2021-10-01T16:01:54.984Z] 	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
[2021-10-01T16:01:54.984Z] 	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
[2021-10-01T16:01:54.984Z] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[2021-10-01T16:01:54.984Z] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2021-10-01T16:01:54.984Z] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2021-10-01T16:01:54.984Z] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2021-10-01T16:01:54.984Z] 	at java.lang.Thread.run(Thread.java:748)
```

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->