### PR TITLE
ci: customise test matrix file

### DIFF
--- a/.ci/.e2e-tests-for-elastic-agent.yaml
+++ b/.ci/.e2e-tests-for-elastic-agent.yaml
@@ -1,0 +1,41 @@
+---
+SUITES:
+  - suite: "fleet"
+    platforms:
+      - labels: "arm64"
+      - labels: "ubuntu-18.04"
+        provider: "elastic-package"
+    scenarios:
+      - name: "Fleet"
+        pullRequestFilter: " && ~debian"
+        tags: "fleet_mode_agent"
+        platforms:
+          - labels: "ubuntu-18.04"
+            provider: "elastic-package"
+      - name: "Integrations"
+        pullRequestFilter: " && ~debian"
+        tags: "integrations"
+      - name: "APM Integration"
+        pullRequestFilter: " && ~debian"
+        tags: "apm_server"
+      - name: "Linux Integration"
+        pullRequestFilter: " && ~debian"
+        tags: "linux_integration"
+      - name: "System Integration"
+        platforms:
+          - labels: "ubuntu-18.04"
+            provider: "elastic-package"
+        pullRequestFilter: " && ~debian"
+        tags: "system_integration"
+      - name: "Stand-alone"
+        platforms:
+          - labels: "ubuntu-18.04"
+            provider: "elastic-package"
+        pullRequestFilter: " && ~ubi8"
+        tags: "stand_alone_agent"
+      - name: "Backend Processes"
+        pullRequestFilter: " && ~debian"
+        tags: "backend_processes"
+      - name: "Beats Background Processes"
+        pullRequestFilter: " && ~debian"
+        tags: "running_on_beats"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
     JOB_GIT_CREDENTIALS = "2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken"
     DOCKER_ELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
+    TEST_MATRIX_FILE = "${params.testMatrixFile}"
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -36,6 +37,7 @@ pipeline {
     booleanParam(name: "SKIP_SCENARIOS", defaultValue: true, description: "If it's needed to skip those scenarios marked as @skip. Default true")
     booleanParam(name: "NIGHTLY_SCENARIOS", defaultValue: false, description: "If it's needed to include the scenarios marked as @nightly in the test execution. Default false")
     string(name: 'runTestsSuites', defaultValue: '', description: 'A comma-separated list of test suites to run (default: empty to run all test suites)')
+    string(name: 'testMatrixFile', defaultValue: '.ci/.e2e-tests.yaml', description: 'The file with the test suite and scenarios to be tested.')
     booleanParam(name: "forceSkipGitChecks", defaultValue: false, description: "If it's needed to check for Git changes to filter by modified sources")
     booleanParam(name: "forceSkipPresubmit", defaultValue: false, description: "If it's needed to execute the pre-submit tests: unit and precommit.")
     booleanParam(name: "notifyOnGreenBuilds", defaultValue: false, description: "If it's needed to notify to Slack with green builds.")
@@ -191,7 +193,7 @@ pipeline {
               dir("${BASE_DIR}") {
                 script {
                   def suitesParam = params.runTestsSuites
-                  def existingSuites = readYaml(file: '.ci/.e2e-tests.yaml')
+                  def existingSuites = readYaml(file: "${TEST_MATRIX_FILE}")
                   def parallelTasks = [:]
 
                   if (suitesParam == "") {


### PR DESCRIPTION
## What does this PR do?

Allow to customise the pipeline with the file that contains the suites and scenarios

## Why is it important?

Allow to define different suites/scenarios in files. https://github.com/elastic/beats/pull/24112#pullrequestreview-777587574 could benefit from, for instance, if we enable the e2e-testing as part of the process in the Beats main pipeline, then we can start with supporting a minimal subset and then incrementally add more scenarios.