### PR TITLE
fix: run heartbeat not as uid 1000

### DIFF
--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/heartbeat.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/heartbeat.yml.tmpl
@@ -70,6 +70,8 @@ spec:
           "-e",
         ]
         env:
+        - name: BEAT_SETUID_AS
+          value: ""
         - name: NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
In the k8s-autodiscover test suite, it sets an env var in heartbeat deployment to not hearbeat process as 1000, returning back to use root.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
I think it's better explained here: https://github.com/elastic/beats/issues/28570

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] @jsoriano, what are the implication of running this pod as root again?

## How to test this PR locally

```shell
kind delete clusters --all && \
TAGS="heartbeat" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true \
GITHUB_CHECK_SHA1=81c38fc4c009348d57c92ae85920aed35297a89e \
ELASTIC_APM_ACTIVE=false make -C e2e/_suites/kubernetes-autodiscover functional-test
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/issues/28570

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->