### PR TITLE
[bump] use unique branch id

### DIFF
--- a/.ci/bump-stack-version.sh
+++ b/.ci/bump-stack-version.sh
@@ -55,7 +55,7 @@ find . -name 'deployment.yaml' -print0 |
 
 echo "Commit changes"
 if [ "$CREATE_BRANCH" = "true" ]; then
-	git checkout -b "update-stack-version-$(date "+%Y%m%d%H%M%S")"
+	git checkout -b "update-stack-version-${VERSION}-$(date "+%Y%m%d%H%M%S")"
 else
 	echo "Branch creation disabled."
 fi


### PR DESCRIPTION
## What does this PR do?

Use unique branch id

## Why is it important?

Avoid clashing with an existing branch


https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fbump-stack-version-pipeline/detail/bump-stack-version-pipeline/144/pipeline/372

![image](https://user-images.githubusercontent.com/2871786/138291313-3447eb1e-5add-4d53-9a71-04aea31bbf2b.png)
