### PR TITLE
[mergify] more generic regex for branches and backport policy

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -75,3 +75,25 @@ pull_request_rules:
         - files~=docker-compose\.yml$
     actions:
       delete_head_branch:
+  - name: remove-backport label
+    conditions:
+      - label~=^v7.*
+    actions:
+      label:
+        remove:
+          - backport-skip
+  - name: notify the backport policy
+    conditions:
+      - -label~=^backport
+      - base=master
+    actions:
+      comment:
+        message: |
+          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you need to add the backport labels for the needed
+          branches, such as:
+          * `v./d./d./d` is the label to automatically backport to the `7./d` branch. `/d` is the digit
+          **NOTE**: `backport-skip` has been added to this pull request.
+      label:
+        add:
+          - backport-skip


### PR DESCRIPTION
## What does this PR do?

Delete branches with a more generic/open regex
Add backport notification policy and remove `backport-skip` when a backport tag has been added.

## Why is it important?

Same user experience for the obs11 projects and tidy up branches in the origin.