### PR TITLE
[mergify] conditions for notify backport message rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -72,7 +72,7 @@ pull_request_rules:
           - backport-skip
   - name: notify the backport policy
     conditions:
-      - -label~=^backport
+      - -label~=(^backport|^v7.*)
       - base=master
     actions:
       comment:


### PR DESCRIPTION
## What does this PR do?

Add missing condition in the notify message rule that also attaches the `backport-skip` label 

## Why is it important?

Otherwise, it won't work as expected