### PR TITLE
[automation] update elastic stack version for testing 7.16.0-66ccea1a

### DIFF
--- a/.stack-version
+++ b/.stack-version
@@ -1,1 +1,1 @@
-7.16.0-a0af8f2a-SNAPSHOT
+7.16.0-66ccea1a-SNAPSHOT


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Sun, 31 Oct 2021 05:17:30 GMT, release_branch:7.16, prefix:, end_time:Sun, 31 Oct 2021 11:16:28 GMT, manifest_version:2.0.0, version:7.16.0-SNAPSHOT, branch:7.16, build_id:7.16.0-66ccea1a, build_duration_seconds:21538]