### PR TITLE
fix: properly copy files from compose to elastic-package

### DIFF
--- a/internal/deploy/elastic_package.go
+++ b/internal/deploy/elastic_package.go
@@ -76,8 +76,7 @@ func (ep *EPServiceManager) Add(ctx context.Context, profile ServiceRequest, ser
 
 func checkElasticPackageProfile(ctx context.Context, kibanaProfile string) error {
 	// check compose profile
-	// The kibana config file is only valid in 8.0.0, for other maintenance branches it's kibana.config.default.yml
-	kibanaProfileFile := filepath.Join(config.OpDir(), "compose", "profiles", "fleet", kibanaProfile, "kibana.config.8x.yml")
+	kibanaProfileFile := filepath.Join(config.OpDir(), "compose", "profiles", "fleet", kibanaProfile, "kibana.config.yml")
 	found, err := io.Exists(kibanaProfileFile)
 	if !found || err != nil {
 		return err
@@ -111,7 +110,8 @@ func checkElasticPackageProfile(ctx context.Context, kibanaProfile string) error
 		log.Trace("Not creating a new Elastic Package profile for " + kibanaProfile + ". Kibana config will be overriden")
 	}
 
-	elasticPackageProfileFile := filepath.Join(elasticPackageProfile, "stack", "kibana.config.yml")
+	// The kibana config file is only valid in 8.0.0, for other maintenance branches it's kibana.config.default.yml
+	elasticPackageProfileFile := filepath.Join(elasticPackageProfile, "stack", "kibana.config.8x.yml")
 
 	// copy compose's kibana's config to elastic-package's config
 	err = io.CopyFile(kibanaProfileFile, elasticPackageProfileFile, 10000)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR reverts the SRC/TARGET file paths used to check and copy the kibana configs from our compose config dir when copying that kibana config to a newly created elastic-package profile.

The src file, which the code checks its existence, must always follow the `kibana.config.yml` file name, and the target file, where the code copies the src file to, must always follow the elastic-package naming-schema for the config: `kibana.config.8x.yml` for master or `kibana.config.default.yml`.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Whenever an scenario is using a profile different than `default`, as we do in the preconfigured-policies feature file, the code will incorrectly check for the existence under the compose config dir of a '8x' file, which does not exist, causing in the following error thrown by elastic-package:

```shell
[2021-11-03T05:48:41.518Z] time="2021-11-03T05:48:40Z" level=info msg="Running kibana with preconfigured-policies profile"
[2021-11-03T05:48:46.816Z] time="2021-11-03T05:48:46Z" level=error msg="Error executing command" args="[run github.com/elastic/elastic-package stack up --daemon --verbose --version 8.1.0-2fdb91c4-SNAPSHOT --services elasticsearch,fleet-server,kibana -p preconfigured-policies]" baseDir=. command=go env="map[kibanaDockerNamespace:kibana kibanaProfile:preconfigured-policies kibanaVersion:8.1.0-2fdb91c4-SNAPSHOT stackPlatform:linux/amd64 stackVersion:8.1.0-2fdb91c4-SNAPSHOT]" error="exit status 1" stderr="2021/11/03 05:48:46  WARN CommitHash is undefined, in both /var/lib/jenkins/workspace/master-1926-cab5847d-fcd3-40ed-8bc3-57f46e878e9f/.elastic-package/version and the compiled binary, config may be out of date.\n2021/11/03 05:48:46 DEBUG Enable verbose logging\n2021/11/03 05:48:46 DEBUG Distribution built without a version tag, can't determine release chronology. Please consider using official releases at https://github.com/elastic/elastic-package/releases\nBoot up the Elastic stack\nError: preconfigured-policies is not a valid profile, known profiles are: [default]\nexit status 1\n"
```

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Caused by #1738

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Follow-ups
Backports must be fixed, as when backporting this PR to any maintenance branch, the `elastic_package.go:L114` must be updated to `kiban.config.default.yml`.

<!-- Optional

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
