### PR TITLE
[mergify] notify to the assignee if PR was not merged yet

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -99,8 +99,11 @@ pull_request_rules:
           - backport-skip
   - name: notify the backport has not been merged yet
     conditions:
+      - -merged
+      - -closed
       - author=mergify[bot]
       - schedule=Mon-Fri 06:00-10:00[Europe/Paris]
+      #- created-at<3 days ago
     actions:
       comment:
         message: |

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -102,9 +102,10 @@ pull_request_rules:
       - -merged
       - -closed
       - author=mergify[bot]
+      - "#check-success>0"
       - schedule=Mon-Fri 06:00-10:00[Europe/Paris]
       #- created-at<3 days ago
     actions:
       comment:
         message: |
-          This pull request has not been merged yet. Could you please review it @{{assignee}}? 🙏
+          This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -97,3 +97,11 @@ pull_request_rules:
       label:
         add:
           - backport-skip
+  - name: notify the backport has not been merged yet
+    conditions:
+      - author=mergify[bot]
+      - schedule=Mon-Fri 06:00-10:00[Europe/Paris]
+    actions:
+      comment:
+        message: |
+          This pull request has not been merged yet. Could you please review it @{{assignee}}? 🙏


### PR DESCRIPTION
## What does this PR do?

PoC regarding the mergify notifications when backported PRs created by `mergify` have not been merged yet. 
This will verify only those PRs created by `mergify` every day and in case they have not been merged yet, then a GitHub comment will be added.

## Why is it important?

Ensure the notifications regarding missing merged backports are addressed.

## Question

- ~~Do we wanna enable this only after a certain period of time? -> See [example](https://docs.mergify.com/configuration/#relative-timestamp)~~ No, for the time being and we can use the `"#check-success>0"`
- ~~Does the `assignee` works in the comment template?~~ Yes