### PR TITLE
[mergify] report open backported PRs once a week

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -103,7 +103,7 @@ pull_request_rules:
       - -closed
       - author=mergify[bot]
       - "#check-success>0"
-      - schedule=Mon-Fri 06:00-10:00[Europe/Paris]
+      - schedule=Mon-Mon 06:00-10:00[Europe/Paris]
       #- created-at<3 days ago
     actions:
       comment:


### PR DESCRIPTION
## What does this PR do?

Notify to the `assignees` when an **automated** backport Pull Request has not been merged yet.

When?:
- Once a week (Mondays)
- PR was created by `mergify`
- It has at least one GitHub check. (We want to notify regardless of the GitHub check status)

## Why is it important?

Avoid missing backports.

## Issue

Similar to https://github.com/elastic/beats/pull/28964

## UI

See https://github.com/elastic/apm-pipeline-library/pull/1380#issuecomment-968886593

![image](https://user-images.githubusercontent.com/2871786/141786749-501d5d7e-d06e-454c-be59-b424eadad495.png)
