### PR TITLE
[automation] update elastic stack version for testing 7.15.3-a2dc0d3c

### DIFF
--- a/.stack-version
+++ b/.stack-version
@@ -1,1 +1,1 @@
-7.15.3-a6aad1c6-SNAPSHOT
+7.15.3-a2dc0d3c-SNAPSHOT


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 17 Nov 2021 17:22:18 GMT, release_branch:7.15, prefix:, end_time:Thu, 18 Nov 2021 00:01:50 GMT, manifest_version:2.0.0, version:7.15.3-SNAPSHOT, branch:7.15, build_id:7.15.3-a2dc0d3c, build_duration_seconds:23972]