### PR TITLE
[automation] update elastic stack version for testing 7.15.3-ac0a2edb

### DIFF
--- a/.stack-version
+++ b/.stack-version
@@ -1,1 +1,1 @@
-7.15.3-d16f4bc8-SNAPSHOT
+7.15.3-ac0a2edb-SNAPSHOT


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Tue, 30 Nov 2021 17:22:06 GMT, release_branch:7.15, prefix:, end_time:Tue, 30 Nov 2021 23:20:38 GMT, manifest_version:2.0.0, version:7.15.3-SNAPSHOT, branch:7.15, build_id:7.15.3-ac0a2edb, build_duration_seconds:21512]