### PR TITLE
fix: add resiliency when an integration cannot be added to a policy

### DIFF
--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -1010,7 +1010,8 @@ func theIntegrationIsOperatedInThePolicy(ctx context.Context, client *kibana.Cli
 			log.WithFields(log.Fields{
 				"err":       err,
 				"packageDS": packageDataStream,
-			}).Fatal("Unable to add integration to policy")
+			}).Error("Unable to add integration to policy")
+			return err
 		}
 	} else if strings.ToLower(action) == actionREMOVED {
 		packageDataStream, err := client.GetIntegrationFromAgentPolicy(ctx, integration.Name, policy)

--- a/internal/kibana/integrations.go
+++ b/internal/kibana/integrations.go
@@ -60,6 +60,8 @@ func (c *Client) AddIntegrationToPolicy(ctx context.Context, packageDS PackageDa
 			}).Warn("Could not add package to policy. Retrying")
 
 			retryCount++
+
+			return err			
 		}
 
 		if statusCode != 200 {

--- a/internal/kibana/integrations.go
+++ b/internal/kibana/integrations.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Jeffail/gabs/v2"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/elastic/e2e-testing/internal/utils"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"go.elastic.co/apm"
@@ -22,24 +25,65 @@ type IntegrationPackage struct {
 
 // AddIntegrationToPolicy adds an integration to policy
 func (c *Client) AddIntegrationToPolicy(ctx context.Context, packageDS PackageDataStream) error {
-	span, _ := apm.StartSpanOptions(ctx, "Adding integration to policy", "fleet.package.add-to-policy", apm.SpanOptions{
-		Parent: apm.SpanFromContext(ctx).TraceContext(),
-	})
-	defer span.End()
+	maxTimeout := time.Duration(utils.TimeoutFactor) * time.Minute
+	retryCount := 1
 
-	reqBody, err := json.Marshal(packageDS)
+	exp := utils.GetExponentialBackOff(maxTimeout)
+
+	addIntegrationFn := func() error {
+		span, _ := apm.StartSpanOptions(ctx, "Adding integration to policy", "fleet.package.add-to-policy", apm.SpanOptions{
+			Parent: apm.SpanFromContext(ctx).TraceContext(),
+		})
+		defer span.End()
+
+		reqBody, err := json.Marshal(packageDS)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"elapsedTime": exp.GetElapsedTime(),
+				"err":         err,
+				"package":     packageDS,
+				"retry":       retryCount,
+			}).Warn("Could not convert policy-package (request) to JSON. Retrying")
+
+			retryCount++
+
+			return err
+		}
+
+		statusCode, respBody, err := c.post(ctx, fmt.Sprintf("%s/package_policies", FleetAPI), reqBody)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"elapsedTime": exp.GetElapsedTime(),
+				"err":         err,
+				"package":     packageDS,
+				"retry":       retryCount,
+			}).Warn("Could not add package to policy. Retrying")
+
+			retryCount++
+		}
+
+		if statusCode != 200 {
+			log.WithFields(log.Fields{
+				"elapsedTime": exp.GetElapsedTime(),
+				"err":         err,
+				"statusCode":  statusCode,
+				"response":    respBody,
+				"package":     packageDS,
+				"retry":       retryCount,
+			}).Warn("could not add package to policy because of HTTP code is not 200")
+
+			retryCount++
+			return fmt.Errorf("could not add package to policy; API status code = %d; response body = %s", statusCode, respBody)
+		}
+
+		return nil
+	}
+
+	err := backoff.Retry(addIntegrationFn, exp)
 	if err != nil {
-		return errors.Wrap(err, "could not convert policy-package (request) to JSON")
+		return err
 	}
 
-	statusCode, respBody, err := c.post(ctx, fmt.Sprintf("%s/package_policies", FleetAPI), reqBody)
-	if err != nil {
-		return errors.Wrap(err, "could not add package to policy")
-	}
-
-	if statusCode != 200 {
-		return fmt.Errorf("could not add package to policy; API status code = %d; response body = %s", statusCode, respBody)
-	}
 	return nil
 }
 

--- a/internal/kibana/integrations.go
+++ b/internal/kibana/integrations.go
@@ -61,7 +61,7 @@ func (c *Client) AddIntegrationToPolicy(ctx context.Context, packageDS PackageDa
 
 			retryCount++
 
-			return err			
+			return err
 		}
 
 		if statusCode != 200 {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It does two things: 

1. changes log.Fatal to log.Error on failures when adding an integration to a policy
1. adds a retry with maxTimeout option to the addIntegrationToPolicy method, so that we are covered on errors in the staging environment of the package-registry

```
[2021-12-16T05:41:55.069Z] FATA[2021-12-16T05:41:53Z] Unable to add integration to policy           err="could not add package to policy; API status code = 500; response body = {\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":\"'502 Bad Gateway' error response from package registry at https://epr-staging.elastic.co/package/endpoint/1.4.0\"}" packageDS="{ endpoint-50fff084-9495-4633-b1a7-0a817b61d6bc Endpoint Security default cdd3d370-5e32-11ec-9ece-534be1f506d0 true  [] { endpoint Endpoint Security 1.4.0}}"

```
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Resiliency in the pipeline execution

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->


<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
