### PR TITLE
ci: use withAPMEnv

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -483,7 +483,7 @@ def generateFunctionalTestStep(Map args = [:]){
           // This step will help to send the APM traces to the
           // withOtelEnv is the one that uses the APM service defined by the Otel Jenkins plugin.
           // withAPMEnv uses Vault to prepare the context.
-					// IMPORTANT: withAPMEnv is now the one in used since withOtelEnv uses a specific Opentelemetry Collector at the moment.
+          // IMPORTANT: withAPMEnv is now the one in used since withOtelEnv uses a specific Opentelemetry Collector at the moment.
           // TODO: This will need to be integrated into the provisioned VMs
           withAPMEnv() {
             // Start node, capture ip address

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -481,9 +481,11 @@ def generateFunctionalTestStep(Map args = [:]){
         unstash 'sourceEnvModified'
         withEnv(envContext) {
           // This step will help to send the APM traces to the
-          // APM service defined by the Otel Jenkins plugin.
+          // withOtelEnv is the one that uses the APM service defined by the Otel Jenkins plugin.
+          // withAPMEnv uses Vault to prepare the context.
+					// IMPORTANT: withAPMEnv is now the one in used since withOtelEnv uses a specific Opentelemetry Collector at the moment.
           // TODO: This will need to be integrated into the provisioned VMs
-          withOtelEnv() {
+          withAPMEnv() {
             // Start node, capture ip address
             ansible("${env.WORKSPACE}",
                     runId,


### PR DESCRIPTION
## What does this PR do?

Use the APM specific endpoint rather than the one provided by the Jenkins OpenTelemetry plugin.

## Why is it important?

The Jenkins OTEL plugin uses the OpenTelemetry Collector, therefore it's OTEL specific, while in the past it was APM Server (which allows dual protocols: elastic apm specific and otel). 

Let's fallback to the APM specific approach.

## Follow ups

- If the instrumentation should be elastic specific or otel?

