### PR TITLE
chore: split stack configuration and start into two tasks

### DIFF
--- a/.ci/ansible/playbook.yml
+++ b/.ci/ansible/playbook.yml
@@ -70,12 +70,17 @@
     tags:
       - setup-stack
 
-  - name: Start stack
+  - name: Configure stack files
     shell: |
       sed -i '' -e 's,http://elasticsearch,http://{{inventory_hostname}},g' /home/{{ansible_user}}/e2e-testing/cli/config/compose/profiles/fleet/default/kibana.config.yml
       sed -i '' -e 's,http://fleet-server,http://{{inventory_hostname}},g' /home/{{ansible_user}}/e2e-testing/cli/config/compose/profiles/fleet/default/kibana.config.yml
       sed -i '' -e 's,http://package-registry:8080,https://epr-staging.elastic.co,g' /home/{{ansible_user}}/e2e-testing/cli/config/compose/profiles/fleet/default/kibana.config.yml
-      sudo docker-compose -f /home/{{ansible_user}}/e2e-testing/cli/config/compose/profiles/fleet/docker-compose.yml up -d
+    tags:
+      - setup-stack
+
+  - name: Start stack
+    become: true
+    shell: docker-compose -f /home/{{ansible_user}}/e2e-testing/cli/config/compose/profiles/fleet/docker-compose.yml up -d
     tags:
       - setup-stack
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It separates the configuration of the files and the start of the stack into two Ansible task

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We are seeing the following error:

CI Build: https://beats-ci.elastic.co/blue/organizations/jenkins/e2e-tests%2Fe2e-testing-mbp/detail/PR-2043/1/pipeline/

>[2022-01-19T05:28:42.603Z] fatal: [18.221.0.131]: FAILED! => {"changed": true, "cmd": "sed -i '' -e 's,http://elasticsearch,http://18.221.0.131,g' /home/admin/e2e-testing/cli/config/compose/profiles/fleet/default/kibana.config.yml\nsed -i '' -e 's,http://fleet-server,http://18.221.0.131,g' /home/admin/e2e-testing/cli/config/compose/profiles/fleet/default/kibana.config.yml\nsed -i '' -e 's,http://package-registry:8080,https://epr-staging.elastic.co,g' /home/admin/e2e-testing/cli/config/compose/profiles/fleet/default/kibana.config.yml\nsudo docker-compose -f /home/admin/e2e-testing/cli/config/compose/profiles/fleet/docker-compose.yml up -d\n", "delta": "0:00:10.095906", "end": "2022-01-19 05:28:41.011431", "msg": "non-zero return code", "rc": 1, "start": "2022-01-19 05:28:30.915525", "stderr": "sed: can't read : No such file or directory\nsed: can't read : No such file or directory\nsed: can't read : No such file or directory\nfleet_elasticsearch_1 is up-to-date\nStarting fleet_kibana_1 ... \r\n\u001b[1A\u001b[2K\rStarting fleet_kibana_1 ... \u001b[32mdone\u001b[0m\r\u001b[1B\nERROR: for fleet-server  Container \"fafceed4afe9\" is unhealthy.\nEncountered errors while bringing up the project.", "stderr_lines": ["sed: can't read : No such file or directory", "sed: can't read : No such file or directory", "sed: can't read : No such file or directory", "fleet_elasticsearch_1 is up-to-date", "Starting fleet_kibana_1 ... ", "\u001b[1A\u001b[2K", "Starting fleet_kibana_1 ... \u001b[32mdone\u001b[0m", "\u001b[1B", "ERROR: for fleet-server  Container \"fafceed4afe9\" is unhealthy.", "Encountered errors while bringing up the project."], "stdout": "", "stdout_lines": []}

Even though the error relates to sed, I was able to SSH into the running machine and checked that the kibana config file was indeed modified:

```shell
$ cat /home/admin/e2e-testing/cli/config/compose/profiles/fleet/default/kibana.config.yml 
---
server.name: kibana
server.host: "0.0.0.0"

telemetry.enabled: false

elasticsearch.hosts: [ "http://3.145.95.35:9200" ]
elasticsearch.username: elastic
elasticsearch.password: changeme
xpack.monitoring.ui.container.elasticsearch.enabled: true

xpack.fleet.registryUrl: "https://epr-staging.elastic.co"
xpack.fleet.agents.enabled: true
xpack.fleet.agents.elasticsearch.host: "http://3.145.95.35:9200"
xpack.fleet.agents.fleet_server.hosts: ["http://3.145.95.35:8220"]

xpack.encryptedSavedObjects.encryptionKey: "12345678901234567890123456789012"
xpack.fleet.agents.tlsCheckDisabled: true
```

So I'd like to separate the configuration of the files and the start into two separate Ansible tasks, to better troubleshoot the issue.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Discovered while testing #2043 

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
