### PR TITLE
chore: double wait time for SSH

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -381,7 +381,9 @@ def getMachineInfo(workspace, platform){
 }
 
 def ansible(workspace, run_id, args){
-     pyrun("ansible-playbook --private-key=\"${workspace}/e2essh\" --extra-vars=\"workspace=${workspace}/ runId=${run_id} sshPublicKey=${workspace}/e2essh.pub\" --ssh-common-args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' ${workspace}/.ci/ansible/playbook.yml ${args}")
+  withOtelEnv() {
+    pyrun("ansible-playbook --private-key=\"${workspace}/e2essh\" --extra-vars=\"workspace=${workspace}/ runId=${run_id} sshPublicKey=${workspace}/e2essh.pub\" --ssh-common-args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' ${workspace}/.ci/ansible/playbook.yml ${args}")
+  }
 }
 
 

--- a/.ci/ansible/ansible.cfg
+++ b/.ci/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+callbacks_enabled = community.general.opentelemetry

--- a/.ci/ansible/tasks/wait_for_ssh.yml
+++ b/.ci/ansible/tasks/wait_for_ssh.yml
@@ -1,3 +1,7 @@
 ---
 - name: Wait for SSH to come up
-  wait_for: host={{ inventory_hostname }} port=22 delay=10 timeout=120
+  wait_for:
+    host: "{{ inventory_hostname }}"
+    port: 22
+    delay: 10
+    timeout: 120

--- a/.ci/ansible/tasks/wait_for_ssh.yml
+++ b/.ci/ansible/tasks/wait_for_ssh.yml
@@ -1,3 +1,3 @@
 ---
 - name: Wait for SSH to come up
-  wait_for: host={{ inventory_hostname }} port=22 delay=10 timeout=60
+  wait_for: host={{ inventory_hostname }} port=22 delay=10 timeout=120


### PR DESCRIPTION
It seems that for CentOS machines, SSH takes more than 1min to come

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It doubles the timeout period when waiting for SSH to come after the AWS instance has been created, from 60 seconds to 120
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We have noticed that it takes more than 1 minute only for CentOS, and I've double checked that SSH is enabled for the AMI used for CentOS, launching it from AWS console manually

```
[2022-01-28T05:09:35.845Z] TASK [Wait for SSH to come up] *************************************************
[2022-01-28T05:10:43.578Z] failed: [localhost] (item={'id': 'i-0c532060aaefd5c30', 'ami_launch_index': '0', 'private_ip': '172.31.13.135', 'private_dns_name': 'ip-172-31-13-135.us-east-2.compute.internal', 'public_ip': '3.145.48.242', 'dns_name': 'ec2-3-145-48-242.us-east-2.compute.amazonaws.com', 'public_dns_name': 'ec2-3-145-48-242.us-east-2.compute.amazonaws.com', 'state_code': 16, 'architecture': 'x86_64', 'image_id': 'ami-045b0a05944af45c1', 'key_name': 'e2essh-893fd0ca', 'placement': 'us-east-2a', 'region': 'us-east-2', 'kernel': None, 'ramdisk': None, 'launch_time': '2022-01-28T05:09:29.000Z', 'instance_type': 'c5.4xlarge', 'root_device_type': 'ebs', 'root_device_name': '/dev/sda1', 'state': 'running', 'hypervisor': 'xen', 'tags': {'BuildURL': 'https://beats-ci.elastic.co/job/e2e-tests/job/e2e-testing-mbp/job/7.17/181/', 'Name': 'e2e-centos8_amd64-893fd0ca', 'ReaperMark': 'e2e-testing-vm', 'Kind': 'centos8_amd64', 'GitSHA': 'd43198bb010c072d7f3a32884f897321c2df5967'}, 'groups': {'sg-0235f273e64143f28': 'e2e'}, 'virtualization_type': 'hvm', 'ebs_optimized': True, 'block_device_mapping': {'/dev/sda1': {'status': 'attached', 'volume_id': 'vol-0510dfd02a6696361', 'delete_on_termination': True}, '/dev/xvda': {'status': 'attached', 'volume_id': 'vol-0ca940b8fef614abc', 'delete_on_termination': True}}, 'tenancy': 'default'}) => {"ansible_loop_var": "nodeItem", "changed": false, "elapsed": 60, "msg": "Timeout when waiting for 3.145.48.242:22", "nodeItem": {"ami_launch_index": "0", "architecture": "x86_64", "block_device_mapping": {"/dev/sda1": {"delete_on_termination": true, "status": "attached", "volume_id": "vol-0510dfd02a6696361"}, "/dev/xvda": {"delete_on_termination": true, "status": "attached", "volume_id": "vol-0ca940b8fef614abc"}}, "dns_name": "ec2-3-145-48-242.us-east-2.compute.amazonaws.com", "ebs_optimized": true, "groups": {"sg-0235f273e64143f28": "e2e"}, "hypervisor": "xen", "id": "i-0c532060aaefd5c30", "image_id": "ami-045b0a05944af45c1", "instance_type": "c5.4xlarge", "kernel": null, "key_name": "e2essh-893fd0ca", "launch_time": "2022-01-28T05:09:29.000Z", "placement": "us-east-2a", "private_dns_name": "ip-172-31-13-135.us-east-2.compute.internal", "private_ip": "172.31.13.135", "public_dns_name": "ec2-3-145-48-242.us-east-2.compute.amazonaws.com", "public_ip": "3.145.48.242", "ramdisk": null, "region": "us-east-2", "root_device_name": "/dev/sda1", "root_device_type": "ebs", "state": "running", "state_code": 16, "tags": {"BuildURL": "https://beats-ci.elastic.co/job/e2e-tests/job/e2e-testing-mbp/job/7.17/181/", "GitSHA": "d43198bb010c072d7f3a32884f897321c2df5967", "Kind": "centos8_amd64", "Name": "e2e-centos8_amd64-893fd0ca", "ReaperMark": "e2e-testing-vm"}, "tenancy": "default", "virtualization_type": "hvm"}}
```

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] An instance using CentOS AMI has been manually created and SSH comes in time


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
