### PR TITLE
fix: update APT cache for both Debian and Ubuntu

### DIFF
--- a/.ci/ansible/playbook.yml
+++ b/.ci/ansible/playbook.yml
@@ -30,7 +30,7 @@
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
-      when: ansible_pkg_mgr == 'apt' or ansible_distribution in ["Debian", "Ubuntu"]
+      when: ansible_pkg_mgr == 'apt'
   roles:
     - role: geerlingguy.docker
       docker_daemon_options:
@@ -103,7 +103,7 @@
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
-      when: ansible_pkg_mgr == 'apt' or ansible_distribution in ["Debian", "Ubuntu"]
+      when: ansible_pkg_mgr == 'apt'
   roles:
     - role: geerlingguy.docker
       docker_daemon_options:

--- a/.ci/ansible/playbook.yml
+++ b/.ci/ansible/playbook.yml
@@ -30,7 +30,7 @@
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
-      when: ansible_os_family == 'Debian'
+      when: ansible_pkg_mgr == 'apt' or ansible_distribution in ["Debian", "Ubuntu"]
   roles:
     - role: geerlingguy.docker
       docker_daemon_options:
@@ -103,7 +103,7 @@
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
-      when: ansible_os_family == 'Debian'
+      when: ansible_pkg_mgr == 'apt' or ansible_distribution in ["Debian", "Ubuntu"]
   roles:
     - role: geerlingguy.docker
       docker_daemon_options:

--- a/.ci/ansible/tasks/install_deps.yml
+++ b/.ci/ansible/tasks/install_deps.yml
@@ -11,7 +11,7 @@
   register: package_install_res
   retries: 5
   until: package_install_res is success
-  when: ansible_pkg_mgr == 'apt' or ansible_distribution in ["Debian", "Ubuntu"]
+  when: ansible_pkg_mgr == 'apt'
 
 - name: Install dependencies (SUSE)
   zypper:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR makes a wider evaluation of variables to decide when to update APT's cache: instead of simply checking for Ansible Distribution == Debian, we are checking that the package manager is APT or the distribution is Debian OR Ubuntu

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We noticed that there were situations in which the AWS machine failed to receive the Docker role because of this failure:

```
[2022-02-08T08:49:41.951Z] TASK [geerlingguy.docker : Ensure additional dependencies are installed (on Ubuntu < 20.04 and any other systems).] ***
[2022-02-08T08:49:42.901Z] fatal: [3.14.83.35]: FAILED! => {"changed": false, "msg": "No package matching 'gnupg2' is available"}
```

There is a closed issue in the Ansible role for that: https://github.com/geerlingguy/ansible-role-docker/issues/263

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/geerlingguy/ansible-role-docker/issues/263


<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
