### PR TITLE
Install jq tool in elastic-agent container to parse ES output

### DIFF
--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/elastic-agent.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/elastic-agent.yml.tmpl
@@ -7,6 +7,9 @@ metadata:
 data:
   writer.sh: |-
     #!/bin/sh
+    apt-get install jq -y
+    rm /var/lib/dpkg/lock
+    apt-get install jq -y
     sleep 10;
     while true;
     do


### PR DESCRIPTION
## What does this PR do?

Tests for `elastic-agent` were failing because of:
```
(23) Failed writing body
/etc/writer.sh: 12: jq: not found
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 13884  100 13884    0     0  1129k      0 --:--:-- --:--:-- --:--:-- 1129k
curl: (23) Failed writing body (0 != 13884)
```

Closes https://github.com/elastic/e2e-testing/issues/1992 