### PR TITLE
jjbb: enable 8.1 and disable 7.16

### DIFF
--- a/.ci/jobs/e2e-testing-fleet-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-fleet-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|8\.0|7\.17|7\.16)'
+          head-filter-regex: '(main|8\.1|8\.0|7\.17)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-helm-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-helm-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|8\.0|7\.17|7\.16)'
+          head-filter-regex: '(main|8\.1|8\.0|7\.17)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-k8s-autodiscovery-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-k8s-autodiscovery-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|8\.0|7\.17|7\.16)'
+          head-filter-regex: '(main|8\.1|8\.0|7\.17)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -14,7 +14,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|PR-.*|v\d\.d\.d|8\.0|7\.17|7\.16)'
+          head-filter-regex: '(main|PR-.*|v\d+\.\d+\.\d+|8\.\d+|7\.17)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current


### PR DESCRIPTION
## What does this PR do?

`7.16` is not an active branch.
`8.1` is an active branch.

## Why is it important?

Otherwise consumers cannot test the e2e

## Issues

Notifies https://github.com/elastic/beats/pull/30404