### PR TITLE
Separate ES workload from Agent spec and make it req for the scenarios

### DIFF
--- a/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
+++ b/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
@@ -116,8 +116,10 @@ func (m *podsManager) executeTemplateFor(podName string, writer io.Writer, optio
 }
 
 func (m *podsManager) configureDockerImage(podName string) error {
+	namespace := "beats"
+
 	if podName != "filebeat" && podName != "heartbeat" && podName != "metricbeat" && podName != "elastic-agent" && podName != "elasticsearch"{
-		log.Debugf("Not processing custom binaries for pod: %s. Only [filebeat, heartbeat, metricbeat, elastic-agent] will be processed", podName)
+		log.Debugf("Not processing custom binaries for pod: %s. Only [elasticsearch, filebeat, heartbeat, metricbeat, elastic-agent] will be processed", podName)
 		return nil
 	}
 
@@ -158,26 +160,16 @@ func (m *podsManager) configureDockerImage(podName string) error {
 			return err
 		}
 
-		if podName == "elastricsearch" {
-			// tag the image with the proper docker tag, including platform
-			err = deploy.TagImage(
-				"docker.elastic.co/elasticsearch/"+podName+":"+downloads.GetSnapshotVersion(common.BeatVersionBase),
-				"docker.elastic.co/observability-ci/"+podName+":"+beatVersion,
-			)
-			if err != nil {
-				return err
-			}
-		} else {
-			// tag the image with the proper docker tag, including platform
-			err = deploy.TagImage(
-				"docker.elastic.co/beats/"+podName+":"+downloads.GetSnapshotVersion(common.BeatVersionBase),
-				"docker.elastic.co/observability-ci/"+podName+":"+beatVersion,
-			)
-			if err != nil {
-				return err
-			}
+		if podName == "elasticsearch" {
+			namespace = "elasticsearch"
 		}
-
+		err = deploy.TagImage(
+			"docker.elastic.co/"+namespace+"/"+podName+":"+downloads.GetSnapshotVersion(common.BeatVersionBase),
+			"docker.elastic.co/observability-ci/"+podName+":"+beatVersion,
+		)
+		if err != nil {
+			return err
+		}
 		// load PR image into kind
 		err = cluster.LoadImage(m.ctx, "docker.elastic.co/observability-ci/"+podName+":"+beatVersion)
 		if err != nil {

--- a/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
+++ b/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
@@ -118,7 +118,7 @@ func (m *podsManager) executeTemplateFor(podName string, writer io.Writer, optio
 func (m *podsManager) configureDockerImage(podName string) error {
 	namespace := "beats"
 
-	if podName != "filebeat" && podName != "heartbeat" && podName != "metricbeat" && podName != "elastic-agent" && podName != "elasticsearch"{
+	if podName != "filebeat" && podName != "heartbeat" && podName != "metricbeat" && podName != "elastic-agent" && podName != "elasticsearch" {
 		log.Debugf("Not processing custom binaries for pod: %s. Only [elasticsearch, filebeat, heartbeat, metricbeat, elastic-agent] will be processed", podName)
 		return nil
 	}

--- a/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
+++ b/e2e/_suites/kubernetes-autodiscover/autodiscover_test.go
@@ -116,7 +116,7 @@ func (m *podsManager) executeTemplateFor(podName string, writer io.Writer, optio
 }
 
 func (m *podsManager) configureDockerImage(podName string) error {
-	if podName != "filebeat" && podName != "heartbeat" && podName != "metricbeat" && podName != "elastic-agent" {
+	if podName != "filebeat" && podName != "heartbeat" && podName != "metricbeat" && podName != "elastic-agent" && podName != "elasticsearch"{
 		log.Debugf("Not processing custom binaries for pod: %s. Only [filebeat, heartbeat, metricbeat, elastic-agent] will be processed", podName)
 		return nil
 	}
@@ -158,13 +158,24 @@ func (m *podsManager) configureDockerImage(podName string) error {
 			return err
 		}
 
-		// tag the image with the proper docker tag, including platform
-		err = deploy.TagImage(
-			"docker.elastic.co/beats/"+podName+":"+downloads.GetSnapshotVersion(common.BeatVersionBase),
-			"docker.elastic.co/observability-ci/"+podName+":"+beatVersion,
-		)
-		if err != nil {
-			return err
+		if podName == "elastricsearch" {
+			// tag the image with the proper docker tag, including platform
+			err = deploy.TagImage(
+				"docker.elastic.co/elasticsearch/"+podName+":"+downloads.GetSnapshotVersion(common.BeatVersionBase),
+				"docker.elastic.co/observability-ci/"+podName+":"+beatVersion,
+			)
+			if err != nil {
+				return err
+			}
+		} else {
+			// tag the image with the proper docker tag, including platform
+			err = deploy.TagImage(
+				"docker.elastic.co/beats/"+podName+":"+downloads.GetSnapshotVersion(common.BeatVersionBase),
+				"docker.elastic.co/observability-ci/"+podName+":"+beatVersion,
+			)
+			if err != nil {
+				return err
+			}
 		}
 
 		// load PR image into kind

--- a/e2e/_suites/kubernetes-autodiscover/features/elastic_agent_standalone.feature
+++ b/e2e/_suites/kubernetes-autodiscover/features/elastic_agent_standalone.feature
@@ -3,15 +3,16 @@
 Feature: elastic-agent standalone
   Use Kubernetes autodiscover features in elastic-agent standalone to collect logs and metrics
 
-Scenario: Logs collection from running pod
+Background: Setting up elasticsearch
   Given "elasticsearch" is running
-    And "elastic-agent" is running with "logs generic"
+
+Scenario: Logs collection from running pod
+  Given "elastic-agent" is running with "logs generic"
    When "a pod" is deployed
    Then "elastic-agent" collects events with "kubernetes.pod.name:a-pod"
 
 Scenario: Logs collection from a pod with an init container
-  Given "elasticsearch" is running
-    And "elastic-agent" is running with "logs generic init"
+  Given "elastic-agent" is running with "logs generic init"
    When "a pod" is deployed with "init container"
    Then "elastic-agent" collects events with "kubernetes.container.name:init-container"
     And "elastic-agent" collects events with "kubernetes.container.name:container-in-pod"
@@ -19,20 +20,17 @@ Scenario: Logs collection from a pod with an init container
 # This scenario explicitly waits for 60 seconds before doing checks
 # to be sure that at least one job has been executed.
 Scenario: Logs collection from short-living cronjobs
-  Given "elasticsearch" is running
-    And "elastic-agent" is running with "logs generic cronjob"
+  Given "elastic-agent" is running with "logs generic cronjob"
     And "a short-living cronjob" is deployed
    When "60s" have passed
    Then "elastic-agent" collects events with "kubernetes.container.name:cronjob-container"
 
 Scenario: Logs collection from failing pod
-  Given "elasticsearch" is running
-    And "elastic-agent" is running with "logs generic failing"
+  Given "elastic-agent" is running with "logs generic failing"
    When "a failing pod" is deployed
    Then "elastic-agent" collects events with "kubernetes.pod.name:a-failing-pod"
 
 Scenario: Metrics collection configured from targeted Redis Pod
-  Given "elasticsearch" is running
-    And "elastic-agent" is running with "redis info"
+  Given "elastic-agent" is running with "redis info"
    When "redis" is running
    Then "elastic-agent" collects events with "kubernetes.pod.name:redis"

--- a/e2e/_suites/kubernetes-autodiscover/features/elastic_agent_standalone.feature
+++ b/e2e/_suites/kubernetes-autodiscover/features/elastic_agent_standalone.feature
@@ -4,12 +4,14 @@ Feature: elastic-agent standalone
   Use Kubernetes autodiscover features in elastic-agent standalone to collect logs and metrics
 
 Scenario: Logs collection from running pod
-  Given "elastic-agent" is running with "logs generic"
+  Given "elasticsearch" is running
+    And "elastic-agent" is running with "logs generic"
    When "a pod" is deployed
    Then "elastic-agent" collects events with "kubernetes.pod.name:a-pod"
 
 Scenario: Logs collection from a pod with an init container
-  Given "elastic-agent" is running with "logs generic init"
+  Given "elasticsearch" is running
+    And "elastic-agent" is running with "logs generic init"
    When "a pod" is deployed with "init container"
    Then "elastic-agent" collects events with "kubernetes.container.name:init-container"
     And "elastic-agent" collects events with "kubernetes.container.name:container-in-pod"
@@ -17,17 +19,20 @@ Scenario: Logs collection from a pod with an init container
 # This scenario explicitly waits for 60 seconds before doing checks
 # to be sure that at least one job has been executed.
 Scenario: Logs collection from short-living cronjobs
-  Given "elastic-agent" is running with "logs generic cronjob"
+  Given "elasticsearch" is running
+    And "elastic-agent" is running with "logs generic cronjob"
     And "a short-living cronjob" is deployed
    When "60s" have passed
    Then "elastic-agent" collects events with "kubernetes.container.name:cronjob-container"
 
 Scenario: Logs collection from failing pod
-  Given "elastic-agent" is running with "logs generic failing"
+  Given "elasticsearch" is running
+    And "elastic-agent" is running with "logs generic failing"
    When "a failing pod" is deployed
    Then "elastic-agent" collects events with "kubernetes.pod.name:a-failing-pod"
 
 Scenario: Metrics collection configured from targeted Redis Pod
-  Given "elastic-agent" is running with "redis info"
+  Given "elasticsearch" is running
+    And "elastic-agent" is running with "redis info"
    When "redis" is running
    Then "elastic-agent" collects events with "kubernetes.pod.name:redis"

--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/elastic-agent.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/elastic-agent.yml.tmpl
@@ -145,15 +145,9 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
       - name: wait-for-elasticsearch
-        image: busybox
-        args:
-        - /bin/sh
-        - -c
-        - >
-          set -x;
-          while [ $(curl -sw '%{http_code}' --user elastic:changeme http://elasticsearch:9200/_cat/indices -o /dev/null) -ne 200 ]; do
-            sleep 15;
-          done
+        image: curlimages/curl:latest
+        command: ["/bin/sh","-c"]
+        args: ["while [ $(curl -sw '%{http_code}' http://elastic:changme@elasticsearch:9200/_cat/indices -o /dev/null) -ne 200 ]; do sleep 5; echo 'Waiting for Elasticsearch...'; done"]
       containers:
         - name: elastic-agent
           image: docker.elastic.co/{{ beats_namespace }}/elastic-agent:{{ beats_version }}

--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/elastic-agent.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/elastic-agent.yml.tmpl
@@ -143,11 +143,6 @@ spec:
       serviceAccountName: elastic-agent
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      initContainers:
-      - name: wait-for-elasticsearch
-        image: curlimages/curl:latest
-        command: ["/bin/sh","-c"]
-        args: ["while [ $(curl -sw '%{http_code}' http://elastic:changme@elasticsearch:9200/_cat/indices -o /dev/null) -ne 200 ]; do sleep 5; echo 'Waiting for Elasticsearch...'; done"]
       containers:
         - name: elastic-agent
           image: docker.elastic.co/{{ beats_namespace }}/elastic-agent:{{ beats_version }}
@@ -342,59 +337,3 @@ metadata:
   name: elastic-agent
   labels:
     k8s-app: elastic-agent
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: elasticsearch-config
-data:
-  ES_JAVA_OPTS: "-Xms1g -Xmx1g"
-  network.host: ""
-  transport.host: "127.0.0.1"
-  http.host: "0.0.0.0"
-  indices.id_field_data.enabled: 'true'
-  xpack.license.self_generated.type: "trial"
-  xpack.security.enabled: 'true'
-  xpack.security.authc.api_key.enabled: 'true'
-  ELASTIC_USERNAME: "elastic"
-  ELASTIC_PASSWORD: "changeme"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: elasticsearch
-  labels:
-    app: elasticsearch
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: elasticsearch
-  template:
-    metadata:
-      labels:
-        app: elasticsearch
-    spec:
-      containers:
-      - name: elasticsearch
-        image: docker.elastic.co/elasticsearch/elasticsearch:{{ beats_version }}
-        envFrom:
-          - configMapRef:
-              name: elasticsearch-config
-        ports:
-        - containerPort: 9200
-          name: client
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: elasticsearch
-  labels:
-    service: elasticsearch
-spec:
-  type: NodePort
-  ports:
-  - port: 9200
-    name: client
-  selector:
-    app: elasticsearch

--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/elastic-agent.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/elastic-agent.yml.tmpl
@@ -143,6 +143,17 @@ spec:
       serviceAccountName: elastic-agent
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
+      - name: wait-for-elasticsearch
+        image: busybox
+        args:
+        - /bin/sh
+        - -c
+        - >
+          set -x;
+          while [ $(curl -sw '%{http_code}' --user elastic:changeme http://elasticsearch:9200/_cat/indices -o /dev/null) -ne 200 ]; do
+            sleep 15;
+          done
       containers:
         - name: elastic-agent
           image: docker.elastic.co/{{ beats_namespace }}/elastic-agent:{{ beats_version }}

--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/elasticsearch.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/elasticsearch.yml.tmpl
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elasticsearch-config
+data:
+  ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+  network.host: ""
+  transport.host: "127.0.0.1"
+  http.host: "0.0.0.0"
+  indices.id_field_data.enabled: 'true'
+  xpack.license.self_generated.type: "trial"
+  xpack.security.enabled: 'true'
+  xpack.security.authc.api_key.enabled: 'true'
+  ELASTIC_USERNAME: "elastic"
+  ELASTIC_PASSWORD: "changeme"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch
+  labels:
+    k8s-app: elasticsearch
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: elasticsearch
+  template:
+    metadata:
+      labels:
+        k8s-app: elasticsearch
+    spec:
+      containers:
+      - name: elasticsearch
+        image: docker.elastic.co/elasticsearch/elasticsearch:{{ beats_version }}
+        envFrom:
+          - configMapRef:
+              name: elasticsearch-config
+        ports:
+        - containerPort: 9200
+          name: client
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  labels:
+    service: elasticsearch
+spec:
+  type: NodePort
+  ports:
+  - port: 9200
+    name: client
+  selector:
+    k8s-app: elasticsearch


### PR DESCRIPTION
## What does this PR do?

Separate ES workload from Agent spec and make it a requirement for the scenarios so as to ensure that deadlines because of download time are not hidden inside the scenario execution.