### PR TITLE
ci: provision e2-small workers

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -518,7 +518,7 @@ def generateFunctionalTestStep(Map args = [:]){
   def runId = UUID.randomUUID().toString().split('-')[0]
 
   return {
-    withNode(labels: 'flyweight && gobld/machineType:e2-small && gobld/image:family/elastic-beats-ci-ubuntu-1804-lts', forceWorkspace: true, forceWorker: true){
+    withNode(labels: 'ubuntu-20.04 && gobld/machineType:e2-small', forceWorkspace: true, forceWorker: true){
       try {
         deleteDir()
         unstash 'sourceEnvModified'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -518,7 +518,7 @@ def generateFunctionalTestStep(Map args = [:]){
   def runId = UUID.randomUUID().toString().split('-')[0]
 
   return {
-    withNode(labels: 'flyweight && gobld/machineType:e2-small', forceWorkspace: true, forceWorker: true){
+    withNode(labels: 'flyweight && gobld/machineType:e2-small && gobld/image:family/elastic-beats-ci-ubuntu-1804-lts', forceWorkspace: true, forceWorker: true){
       try {
         deleteDir()
         unstash 'sourceEnvModified'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -518,7 +518,7 @@ def generateFunctionalTestStep(Map args = [:]){
   def runId = UUID.randomUUID().toString().split('-')[0]
 
   return {
-    withNode(labels: 'flyweight', forceWorkspace: true, forceWorker: true){
+    withNode(labels: 'flyweight && gobld/machineType:e2-small', forceWorkspace: true, forceWorker: true){
       try {
         deleteDir()
         unstash 'sourceEnvModified'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -518,7 +518,7 @@ def generateFunctionalTestStep(Map args = [:]){
   def runId = UUID.randomUUID().toString().split('-')[0]
 
   return {
-    withNode(labels: 'ubuntu-20.04', forceWorkspace: true, forceWorker: true){
+    withNode(labels: 'flyweight', forceWorkspace: true, forceWorker: true){
       try {
         deleteDir()
         unstash 'sourceEnvModified'


### PR DESCRIPTION
## What does this PR do?

I wanna explore if a smaller CI workers for the existing parallel stages work as expected since the heavy-lift is done in the remote workers instead.

From `n1-highmem-8` to `e2-small`

<img width="1704" alt="image" src="https://user-images.githubusercontent.com/2871786/157243803-dab1e982-faa8-4f02-8e3f-8c805052ac89.png">

<img width="2268" alt="image" src="https://user-images.githubusercontent.com/2871786/157275937-48ec7b05-de89-4699-87e0-bd12c9901138.png">

<img width="2251" alt="image" src="https://user-images.githubusercontent.com/2871786/157275991-3843ccef-60d5-4540-b678-1677184f90a2.png">

## Why is it important?

Cheaper builds.




