### PR TITLE
automate: release bump

### DIFF
--- a/.ci/bump-stack-release-version.sh
+++ b/.ci/bump-stack-release-version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Given the stack version this script will bump the release version.
+#
+# This script is executed by the automation we are putting in place
+# and it requires the git add/commit commands.
+#
+# Parameters:
+#	$1 -> the minor version to be bumped. Mandatory.
+#	$1 -> the major version to be bumped. Mandatory.
+#
+set -euo pipefail
+MSG="parameter missing."
+VERSION_RELEASE=${1:?$MSG}
+VERSION_DEV=${2:?$MSG}
+
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+
+if [ "${OS}" == "darwin" ] ; then
+	SED="sed -i .bck"
+else
+	SED="sed -i"
+fi
+
+MAJOR_MINOR_RELEASE=$(cut -d '.' -f 1,2 <<< "$VERSION_RELEASE")
+
+echo "Update stack with versions ${VERSION_RELEASE} and ${VERSION_DEV}"
+${SED} -E -e "s#'[0-9]+\.[0-9]+-SNAPSHOT'#'${MAJOR_MINOR_RELEASE}-SNAPSHOT'#g" .ci/Jenkinsfile
+${SED} -E -e "s#(var AgentStaleVersion = \")[0-9]+\.[0-9]+-SNAPSHOT#\1${MAJOR_MINOR_RELEASE}-SNAPSHOT#g" internal/common/defaults.go
+git add internal/common/defaults.go .ci/Jenkinsfile
+git diff --staged --quiet || git commit -m "[Automation] Update elastic stack release version to ${VERSION_RELEASE} and ${VERSION_DEV}"
+git --no-pager log -1
+
+echo "You can now push and create a Pull Request"


### PR DESCRIPTION
## What does this PR do?

Automate https://github.com/elastic/e2e-testing/pull/2198

## Why is it important?

No more manual automations

## Test

Given 

```bash.ci/bump-stack-release-version.sh 7.18 8.3                   
Update stack with versions 7.18 and 8.3

```

Then


```diff
diff --git a/.ci/Jenkinsfile b/.ci/Jenkinsfile
index f3727743..e8ee5d65 100644
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     string(name: 'ELASTIC_AGENT_DOWNLOAD_URL', defaultValue: '', description: 'If present, it will override the download URL for the Elastic agent artifact. (I.e. https://snapshots.elastic.co/8.0.0-59098054/downloads/beats/elastic-agent/elastic-agent-8.0.0-SNAPSHOT-linux-x86_64.tar.gz')
     string(name: 'ELASTIC_AGENT_VERSION', defaultValue: '8.2.0-d02c907a-SNAPSHOT', description: 'SemVer version of the Elastic Agent to be used for the tests. You can use here the tag of your PR to test your changes')
     string(name: 'BEAT_VERSION', defaultValue: '8.2.0-d02c907a-SNAPSHOT', description: 'SemVer version of the Beat to be used for the tests. You can use here the tag of your PR to test your changes')
-    string(name: 'ELASTIC_AGENT_STALE_VERSION', defaultValue: '7.17-SNAPSHOT', description: 'SemVer version of the stale stand-alone elastic-agent to be used for Fleet upgrade tests.')
+    string(name: 'ELASTIC_AGENT_STALE_VERSION', defaultValue: '7.18-SNAPSHOT', description: 'SemVer version of the stale stand-alone elastic-agent to be used for Fleet upgrade tests.')
     choice(name: 'LOG_LEVEL', choices: ['TRACE', 'DEBUG', 'INFO'], description: 'Log level to be used')
     choice(name: 'TIMEOUT_FACTOR', choices: ['5', '3', '7', '11'], description: 'Max number of minutes for timeout backoff strategies')
     string(name: 'KIBANA_VERSION', defaultValue: '', description: 'Docker tag of the kibana to be used for the tests. It will refer to an image related to a Kibana PR, under the Observability-CI namespace')
diff --git a/internal/common/defaults.go b/internal/common/defaults.go
index 88375f46..db106552 100644
--- a/internal/common/defaults.go
+++ b/internal/common/defaults.go
@@ -33,7 +33,7 @@ const FleetServerAgentServiceName = "fleet-server"
 
 // AgentStaleVersion is the version of the agent to use as a base during upgrade
 // It can be overriden by ELASTIC_AGENT_STALE_VERSION env var. Using latest GA as a default.
-var AgentStaleVersion = "7.17-SNAPSHOT"
+var AgentStaleVersion = "7.18-SNAPSHOT"
 
 // BeatVersionBase is the base version of the Beat to use
 var BeatVersionBase = "8.2.0-d02c907a-SNAPSHOT"


```