### PR TITLE
ci: periodic builds for the last two minor versions

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -20,7 +20,7 @@ pipeline {
   stages {
     stage('Nighly e2e builds') {
       steps {
-        runBuilds(quietPeriodFactor: 100, branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
+        runBuilds(quietPeriodFactor: 100, branches: ['main', '8.<minor>', '8.<next-patch>', '8.<minor-1>', '7.<minor>'])
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Support the previous minor one

## Why is it important?

Run the tests for the previous minor one was a requirement.

## Issues

https://github.com/elastic/apm-pipeline-library/pull/1595 changed the branch and 8.0 was not anymore tested. 

Regression from https://github.com/elastic/e2e-testing/pull/2159