### PR TITLE
ci: publish cucumber reports as GitHub checks

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -603,7 +603,7 @@ def generateFunctionalTestStep(Map args = [:]){
           artifacts: "outputs/${testRunner.ip}/TEST-*${runId}*.xml, outputs/${testRunner.ip}/TEST-*${runId}*.json, ${cucumberFile}"
         // Create a GitHub check with the report
         if (fileExists(cucumberFile)) {
-          githubCheckNotify(name, 'neutral', cucumberFile)
+          githubCheckNotify(githubCheckName: "${name}-${runId}-cucumber", status: 'neutral', cucumberFile: cucumberFile)
         }
       }
     }
@@ -613,23 +613,23 @@ def generateFunctionalTestStep(Map args = [:]){
 /**
  Notify the GitHub check for the cucumber report
  **/
-def githubCheckNotify(name, status, cucumberFile) {
-  def description = "${name} ${status.toLowerCase()}"
-  def context = name
+def githubCheckNotify(Map args = [:]){
+  def description = "${args.githubCheckName} ${args.status.toLowerCase()}"
+  def githubCheckName = args.githubCheckName
   def url = "${env.RUN_DISPLAY_URL}"
   def repo = env.REPO
   def sha = env.GIT_BASE_COMMIT
   if (params.GITHUB_CHECK_NAME?.trim() && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim()) {
-    context = "${params.GITHUB_CHECK_NAME}-cucumber"
-    description = "${params.GITHUB_CHECK_NAME} ${status.toLowerCase()}"
+    githubCheckName = "${params.GITHUB_CHECK_NAME}-cucumber"
+    description = "${params.GITHUB_CHECK_NAME} ${args.status.toLowerCase()}"
     sha = params.GITHUB_CHECK_SHA1
     repo = params.GITHUB_CHECK_REPO
   }
-  githubCheck(name: context,
+  githubCheck(name: githubCheckName,
               description: description,
-              body: readFile(cucumberFile),
+              body: readFile(args.cucumberFile),
               repository: repo,
               commitId: sha,
-              status: status,
+              status: args.status,
               detailsUrl: url)
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -602,7 +602,9 @@ def generateFunctionalTestStep(Map args = [:]){
         archiveArtifacts allowEmptyArchive: true,
           artifacts: "outputs/${testRunner.ip}/TEST-*${runId}*.xml, outputs/${testRunner.ip}/TEST-*${runId}*.json, ${cucumberFile}"
         // Create a GitHub check with the report
-        if (fileExists(cucumberFile)) {
+        def files = findFiles(glob: cucumberFile)
+        echo "cucumber file - ${files[0]?.name} ${files[0]?.path} ${files[0]?.directory}"
+        if (files[0]?.path?.trim() && fileExists(files[0]?.path)) {
           githubCheckNotify(githubCheckName: "${name}-${runId}-cucumber", status: 'neutral', cucumberFile: cucumberFile)
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -598,14 +598,14 @@ def generateFunctionalTestStep(Map args = [:]){
         junit allowEmptyResults: true,
           keepLongStdio: true,
           testResults: "outputs/${testRunner.ip}/TEST-*${runId}*.xml"
-        def cucumberFile = "outputs/${testRunner.ip}/TEST-*${runId}*.json.html"
+        def cucumberFilePattern = "outputs/${testRunner.ip}/TEST-*${runId}*.json.html"
         archiveArtifacts allowEmptyArchive: true,
-          artifacts: "outputs/${testRunner.ip}/TEST-*${runId}*.xml, outputs/${testRunner.ip}/TEST-*${runId}*.json, ${cucumberFile}"
+          artifacts: "outputs/${testRunner.ip}/TEST-*${runId}*.xml, outputs/${testRunner.ip}/TEST-*${runId}*.json, ${cucumberFilePattern}"
         // Create a GitHub check with the report
-        def files = findFiles(glob: cucumberFile)
-        echo "cucumber file - ${files[0]?.name} ${files[0]?.path} ${files[0]?.directory}"
+        def files = findFiles(glob: cucumberFilePattern)
+        log(level: 'DEBUG', text: "githubCheckNotify: cucumber file - ${files[0]?.name} ${files[0]?.path} ${files[0]?.directory}")
         if (files[0]?.path?.trim() && fileExists(files[0]?.path)) {
-          githubCheckNotify(githubCheckName: "${name}-${runId}-cucumber", status: 'neutral', cucumberFile: cucumberFile)
+          githubCheckNotify(githubCheckName: "${name}-${runId}-cucumber", status: 'neutral', cucumberFile: files[0]?.path)
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -533,7 +533,7 @@ def generateFunctionalTestStep(Map args = [:]){
   def stackRunner = getNodeIp("${env.WORKSPACE}/${env.BASE_DIR}", 'stack')
 
   def runId = UUID.randomUUID().toString().split('-')[0]
-
+  def githubCheckStatus = 'failure'
   return {
     withNode(labels: 'ubuntu-20.04 && gobld/machineType:e2-small', forceWorkspace: true, forceWorker: true){
       try {
@@ -563,6 +563,7 @@ def generateFunctionalTestStep(Map args = [:]){
                     """sudo bash /home/${testRunner.user}/e2e-testing/.ci/scripts/functional-test.sh "${tags}" """)
           }
         }
+        githubCheckStatus = 'success'
       } finally {
         def testRunner = getNodeIp("${env.WORKSPACE}", platform)
         sh "mkdir -p outputs/${testRunner.ip} || true"
@@ -605,7 +606,7 @@ def generateFunctionalTestStep(Map args = [:]){
         def cucumberFiles = findFiles(glob: cucumberFilePattern)
         log(level: 'DEBUG', text: "githubCheckNotify: cucumber file - ${cucumberFiles[0]?.name} ${cucumberFiles[0]?.path}")
         if (cucumberFiles[0]?.path?.trim() && fileExists(cucumberFiles[0]?.path)) {
-          githubCheckNotify(githubCheckName: "${name}-${runId}-cucumber", status: 'neutral', cucumberFile: cucumberFiles[0]?.path)
+          githubCheckNotify(githubCheckName: "${suite}_${platform}_${tags}-cucumber", status: githubCheckStatus, cucumberFile: cucumberFiles[0]?.path)
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -95,7 +95,7 @@ pipeline {
             pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
             deleteDir()
             gitCheckout(basedir: BASE_DIR, githubNotifyFirstTimeContributor: true)
-            githubCheckNotify('PENDING')  // we want to notify the upstream about the e2e the soonest
+            githubCommitStatusNotify('PENDING')  // we want to notify the upstream about the e2e the soonest
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             setEnvVar("GO_VERSION", readFile("${env.WORKSPACE}/${env.BASE_DIR}/.go-version").trim())
             setEnvVar("LABELS_STRING", "buildURL=${env.BUILD_URL} gitSha=${env.GIT_BASE_COMMIT}")
@@ -452,7 +452,7 @@ def checkTestSuite(Map parallelTasks = [:], Map item = [:]) {
  * Sends out notification of the build result to Slack
  */
 def doNotifyBuildResult(boolean slackNotify) {
-  githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILURE')
+  githubCommitStatusNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILURE')
 
   def testsSuites = "${params.runTestsSuites}"
   if (testsSuites?.trim() == "") {
@@ -475,9 +475,9 @@ def doNotifyBuildResult(boolean slackNotify) {
 }
 
 /**
- Notify the GitHub check of the parent stream
+ Notify the GitHub commit status of the parent stream
  **/
-def githubCheckNotify(String status) {
+def githubCommitStatusNotify(String status) {
   if (params.GITHUB_CHECK_NAME?.trim() && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim()) {
     githubNotify context: "${params.GITHUB_CHECK_NAME}",
       description: "${params.GITHUB_CHECK_NAME} ${status.toLowerCase()}",
@@ -598,9 +598,38 @@ def generateFunctionalTestStep(Map args = [:]){
         junit allowEmptyResults: true,
           keepLongStdio: true,
           testResults: "outputs/${testRunner.ip}/TEST-*${runId}*.xml"
+        def cucumberFile = "outputs/${testRunner.ip}/TEST-*${runId}*.json.html"
         archiveArtifacts allowEmptyArchive: true,
-          artifacts: "outputs/${testRunner.ip}/TEST-*${runId}*.xml, outputs/${testRunner.ip}/TEST-*${runId}*.json, outputs/${testRunner.ip}/TEST-*${runId}*.json.html"
+          artifacts: "outputs/${testRunner.ip}/TEST-*${runId}*.xml, outputs/${testRunner.ip}/TEST-*${runId}*.json, ${cucumberFile}"
+        // Create a GitHub check with the report
+        if (fileExist(cucumberFile)) {
+          githubCheckNotify(name, 'neutral', cucumberFile)
+        }
       }
     }
   }
+}
+
+/**
+ Notify the GitHub check for the cucumber report
+ **/
+def githubCheckNotify(name, status, cucumberFile) {
+  def description = "${name} ${status.toLowerCase()}"
+  def context = name
+  def url = "${env.RUN_DISPLAY_URL}"
+  def repo = env.REPO
+  def sha = env.GIT_BASE_COMMIT
+  if (params.GITHUB_CHECK_NAME?.trim() && params.GITHUB_CHECK_REPO?.trim() && params.GITHUB_CHECK_SHA1?.trim()) {
+    context = "${params.GITHUB_CHECK_NAME}-cucumber"
+    description = "${params.GITHUB_CHECK_NAME} ${status.toLowerCase()}"
+    sha = params.GITHUB_CHECK_SHA1
+    repo = params.GITHUB_CHECK_REPO
+  }
+  githubCheck(name: context,
+              description: description,
+              body: readFile(cucumberFile),
+              repository: repo,
+              commitId: sha,
+              status: status,
+              detailsUrl: url)
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -602,7 +602,7 @@ def generateFunctionalTestStep(Map args = [:]){
         archiveArtifacts allowEmptyArchive: true,
           artifacts: "outputs/${testRunner.ip}/TEST-*${runId}*.xml, outputs/${testRunner.ip}/TEST-*${runId}*.json, ${cucumberFile}"
         // Create a GitHub check with the report
-        if (fileExist(cucumberFile)) {
+        if (fileExists(cucumberFile)) {
           githubCheckNotify(name, 'neutral', cucumberFile)
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -602,10 +602,10 @@ def generateFunctionalTestStep(Map args = [:]){
         archiveArtifacts allowEmptyArchive: true,
           artifacts: "outputs/${testRunner.ip}/TEST-*${runId}*.xml, outputs/${testRunner.ip}/TEST-*${runId}*.json, ${cucumberFilePattern}"
         // Create a GitHub check with the report
-        def files = findFiles(glob: cucumberFilePattern)
-        log(level: 'DEBUG', text: "githubCheckNotify: cucumber file - ${files[0]?.name} ${files[0]?.path} ${files[0]?.directory}")
-        if (files[0]?.path?.trim() && fileExists(files[0]?.path)) {
-          githubCheckNotify(githubCheckName: "${name}-${runId}-cucumber", status: 'neutral', cucumberFile: files[0]?.path)
+        def cucumberFiles = findFiles(glob: cucumberFilePattern)
+        log(level: 'DEBUG', text: "githubCheckNotify: cucumber file - ${cucumberFiles[0]?.name} ${cucumberFiles[0]?.path}")
+        if (cucumberFiles[0]?.path?.trim() && fileExists(cucumberFiles[0]?.path)) {
+          githubCheckNotify(githubCheckName: "${name}-${runId}-cucumber", status: 'neutral', cucumberFile: cucumberFiles[0]?.path)
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?

Publish GitHub checks with the cucumber report

## Why is it important?

Developers wont' need to go anywhere else but look at the GitHub checks.

It uses https://github.com/elastic/apm-pipeline-library/blob/main/vars/githubCheck.groovy