### PR TITLE
chore: provision stack if and only if fleet test suite is present

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -193,10 +193,12 @@ pipeline {
           }
           when {
             beforeAgent true
-            anyOf {
-              expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
+            allOf {
+              anyOf {
+                expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
+                expression { return env.SKIP_TESTS == "false" }
+              }
               expression { return env.IS_FLEET_SUITE == "true" }
-              expression { return env.SKIP_TESTS == "false" }
             }
           }
           steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -543,7 +543,13 @@ def generateFunctionalTestStep(Map args = [:]){
   envContext.add("REPORT_PREFIX=${suite}_${platform}_${tags}")
   envContext.add("ELASTIC_APM_GLOBAL_LABELS=branch_name=${BRANCH_NAME},build_pr=${isPR()},build_id=${env.BUILD_ID},go_arch=${goArch},beat_version=${env.BEAT_VERSION},elastic_agent_version=${env.ELASTIC_AGENT_VERSION},stack_version=${env.STACK_VERSION}")
 
-  def stackRunner = getNodeIp("${env.WORKSPACE}/${env.BASE_DIR}", 'stack')
+  def stackRunner = ''
+  def stackRunnerVariable = ''
+  if ("${env.IS_FLEET_SUITE}" == 'true') {
+    // only populate it for Fleet test suite
+    stackRunner = getNodeIp("${env.WORKSPACE}/${env.BASE_DIR}", 'stack')
+    stackRunnerVariable = "stackRunner=${stackRunner.ip} "
+  }
 
   def runId = UUID.randomUUID().toString().split('-')[0]
 
@@ -562,14 +568,14 @@ def generateFunctionalTestStep(Map args = [:]){
             // Start node, capture ip address
             ansible("${env.WORKSPACE}",
                     runId,
-                    "-t start-node --extra-vars=\"${LABELS_STRING} stackRunner=${stackRunner.ip} nodeUser=${machine.username} suite=${suite} nodeLabel=${platform} nodeImage=${machine.image} nodeInstanceType=${machine.instance_type}\"")
+                    "-t start-node --extra-vars=\"${LABELS_STRING} ${stackRunnerVariable} nodeUser=${machine.username} suite=${suite} nodeLabel=${platform} nodeImage=${machine.image} nodeInstanceType=${machine.instance_type}\"")
 
             def testRunner = getNodeIp("${env.WORKSPACE}", platform)
 
             // Configure node for testing
             ansible("${env.WORKSPACE}",
                     runId,
-                    "-i \"${testRunner.ip},\" -t setup-node --extra-vars=\"${LABELS_STRING} stackRunner=${stackRunner.ip} nodeUser=${machine.username} suite=${suite} nodeLabel=${platform} nodeImage=${machine.image} nodeInstanceType=${machine.instance_type}\"")
+                    "-i \"${testRunner.ip},\" -t setup-node --extra-vars=\"${LABELS_STRING} ${stackRunnerVariable} nodeUser=${machine.username} suite=${suite} nodeLabel=${platform} nodeImage=${machine.image} nodeInstanceType=${machine.instance_type}\"")
 
             sshexec("${env.WORKSPACE}",
                     testRunner,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -99,6 +99,7 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             setEnvVar("GO_VERSION", readFile("${env.WORKSPACE}/${env.BASE_DIR}/.go-version").trim())
             setEnvVar("LABELS_STRING", "buildURL=${env.BUILD_URL} gitSha=${env.GIT_BASE_COMMIT}")
+            setEnvVar("IS_FLEET_SUITE", isFleetSuite())
             checkSkipTests()
           }
         }
@@ -194,6 +195,7 @@ pipeline {
             beforeAgent true
             anyOf {
               expression { return env.FORCE_SKIP_GIT_CHECKS == "true" }
+              expression { return env.IS_FLEET_SUITE == "true" }
               expression { return env.SKIP_TESTS == "false" }
             }
           }
@@ -448,6 +450,14 @@ def checkTestSuite(Map parallelTasks = [:], Map item = [:]) {
   }
 }
 
+/*
+ * returns if the fleet test suite must be executed, which implies the Elastic Stack node must be provisioned
+ */
+def isFleetSuite() {
+  def testsSuites = "${params.runTestsSuites}"
+
+  return ((testsSuites == '') || (testsSuites?.contains('fleet')))
+}
 /*
  * Sends out notification of the build result to Slack
  */


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a boolean check when creating the stack node in Jenkins, adding a condition to not run it when the fleet test suite is not present.

This condition evals to true when:
- the `runTestsSuites` param is empty (all suites), used while developing the test framework
- the `runTestsSuites` contains the `fleet` test suite, because it was triggered by a nightly build, i.e

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
When running the nightly builds for helm and k8s-autodiscover test suites, we are running the stack node, which means:
- 1 jenkins worker + provisioning time
- 1 AWS worker
- almost 10 minutes starting the stack (es, kibana, fleet-server) on the remote VM 

We'd like to avoid that for builds not using the fleet test suite.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand area
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


## Screenshots

The Helm test suite does not need the stack (~9 min):

<img width="1791" alt="Screenshot 2022-03-28 at 17 43 33" src="https://user-images.githubusercontent.com/951580/160436294-4b5b3a34-03c2-4b0f-b0eb-ff8736bc6086.png">

The k8s-autodiscover test suite does not need the stack (~9 min):

<img width="1791" alt="Screenshot 2022-03-28 at 17 45 22" src="https://user-images.githubusercontent.com/951580/160436465-8ec67793-25c8-44fe-a38d-7acd53689344.png">


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
