### PR TITLE
fix: send slack notifications for failed builds

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -452,7 +452,15 @@ def checkTestSuite(Map parallelTasks = [:], Map item = [:]) {
  * Sends out notification of the build result to Slack
  */
 def doNotifyBuildResult(boolean slackNotify) {
-  githubCheckNotify(currentBuild.currentResult == 'SUCCESS' ? 'SUCCESS' : 'FAILURE')
+  def doSlackNotify = true // always try to notify on failures
+  def githubCheckStatus = 'FAILURE'
+  if (currentBuild.currentResult == 'SUCCESS') {
+    githubCheckStatus = 'SUCCESS'
+    doSlackNotify = slackNotify // if the build status is success, read the parameter
+  }
+
+  githubCheckNotify(githubCheckStatus)
+
 
   def testsSuites = "${params.runTestsSuites}"
   if (testsSuites?.trim() == "") {
@@ -471,7 +479,7 @@ def doNotifyBuildResult(boolean slackNotify) {
                     slackHeader: header,
                     slackChannel: "${channels}",
                     slackComment: true,
-                    slackNotify: slackNotify)
+                    slackNotify: doSlackNotify)
 }
 
 /**


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It refactors the way we are sending slack notifications, which was using a Jenkins argument to control it. If the pipeline received a `false` value in the `notifyOnGreenBuilds` parameter, it was directly used.

With this change, we are always forcing a Slack notification, but if the build is successful, then delegate the notification to the parameter.

- a build is successful and the parameter is true -> send slack
- a build is successful and the parameter is false -> do not send slack
- a build is failed and the parameter is true or false -> send to slack

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We noticed that recent failures were not posted to the elastic-agent channel. Hopefully this will bring them back to work

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
