### PR TITLE
Add metadata tags

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -98,7 +98,7 @@ pipeline {
             githubCheckNotify('PENDING')  // we want to notify the upstream about the e2e the soonest
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             setEnvVar("GO_VERSION", readFile("${env.WORKSPACE}/${env.BASE_DIR}/.go-version").trim())
-            setEnvVar("LABELS_STRING", "buildURL=${env.BUILD_URL} gitSha=${env.GIT_BASE_COMMIT} build=${env.BUILD_ID} repo=${env.REPO} branch=${env.BRANCH_NAME.toLowerCase()} environment=ci")
+            setEnvVar("LABELS_STRING", "buildURL=${env.BUILD_URL} gitSha=${env.GIT_BASE_COMMIT} build=${env.BUILD_ID} repo=${env.REPO} branch=${env.BRANCH_NAME.toLowerCase()} type=ci")
             checkSkipTests()
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -98,7 +98,7 @@ pipeline {
             githubCheckNotify('PENDING')  // we want to notify the upstream about the e2e the soonest
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             setEnvVar("GO_VERSION", readFile("${env.WORKSPACE}/${env.BASE_DIR}/.go-version").trim())
-            setEnvVar("LABELS_STRING", "buildURL=${env.BUILD_URL} gitSha=${env.GIT_BASE_COMMIT}")
+            setEnvVar("LABELS_STRING", "buildURL=${env.BUILD_URL} gitSha=${env.GIT_BASE_COMMIT} build=${env.BUILD_ID} repo=${env.REPO} branch=${env.BRANCH_NAME.toLowerCase()} environment=ci")
             checkSkipTests()
           }
         }
@@ -337,7 +337,7 @@ def sshexec(workspace, connection, cmd){
 }
 
 def scpr(workspace, connection, remote_src, local_dst){
-  retryWithSleep(retries: 3, seconds: 5, backoff: true){ 
+  retryWithSleep(retries: 3, seconds: 5, backoff: true){
     sh "scp -r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${workspace}/e2essh ${connection.user}@${connection.ip}:${remote_src} ${local_dst}"
   }
 }

--- a/.ci/ansible/playbook.yml
+++ b/.ci/ansible/playbook.yml
@@ -1,6 +1,6 @@
 - name: Create test environment
   hosts: localhost
-  gather_facts: no
+  gather_facts: yes
   vars:
     ansible_user: "{{nodeUser}}"
   tasks:

--- a/.ci/ansible/tasks/runners.yml
+++ b/.ci/ansible/tasks/runners.yml
@@ -8,8 +8,10 @@
     tags:
       branch: "{{branch | default('Not running on CI')}}"
       build: "{{build | default('Not running on CI')}}"
+      build_url: "{{buildURL | default('Not running on CI') }}"
       created_date: "{{ansible_date_time.epoch}}"
       environment: "{{type | default('Not running on CI')}}"
+      git_sha: "{{ gitSha }}"
       repo: "{{repo | default('Not running on CI')}}"
   tags:
     - provision-stack
@@ -24,15 +26,15 @@
     image: '{{nodeImage}}'
     instance_type: '{{nodeInstanceType}}'
     instance_tags:
-      BuildURL: "{{buildURL | default('Not running on CI') }}"
-      GitSHA: "{{ gitSha }}"
-      Kind: "{{nodeLabel}}"
-      Name: "e2e-{{nodeLabel}}-{{runId}}"
-      ReaperMark: "e2e-testing-vm"
       branch: "{{branch | default('Not running on CI')}}"
       build: "{{build | default('Not running on CI')}}"
+      build_url: "{{buildURL | default('Not running on CI') }}"
       created_date: "{{ansible_date_time.epoch}}"
-      environment: "{{environment | default('Not running on CI')}}"
+      environment: "{{type | default('Not running on CI')}}"
+      git_sha: "{{ gitSha }}"
+      kind: "{{nodeLabel}}"
+      name: "e2e-{{nodeLabel}}-{{runId}}"
+      reaper_mark: "e2e-testing-vm"
       repo: "{{repo | default('Not running on CI')}}"
     count_tag:
       Name: "e2e-{{nodeLabel}}-{{runId}}"

--- a/.ci/ansible/tasks/runners.yml
+++ b/.ci/ansible/tasks/runners.yml
@@ -9,7 +9,7 @@
       branch: "{{branch | default('Not running on CI')}}"
       build: "{{build | default('Not running on CI')}}"
       created_date: "{{ansible_date_time.epoch}}"
-      environment: "{{environment | default('Not running on CI')}}"
+      environment: "{{type | default('Not running on CI')}}"
       repo: "{{repo | default('Not running on CI')}}"
   tags:
     - provision-stack

--- a/.ci/ansible/tasks/runners.yml
+++ b/.ci/ansible/tasks/runners.yml
@@ -5,6 +5,12 @@
     key_material: "{{ lookup('file', sshPublicKey) }}"
     region: us-east-2
     state: present
+    tags:
+      branch: "{{branch | default('Not running on CI')}}"
+      build: "{{build | default('Not running on CI')}}"
+      created_date: "{{ansible_date_time.epoch}}"
+      environment: "{{environment | default('Not running on CI')}}"
+      repo: "{{repo | default('Not running on CI')}}"
   tags:
     - provision-stack
     - start-node
@@ -23,6 +29,11 @@
       Kind: "{{nodeLabel}}"
       Name: "e2e-{{nodeLabel}}-{{runId}}"
       ReaperMark: "e2e-testing-vm"
+      branch: "{{branch | default('Not running on CI')}}"
+      build: "{{build | default('Not running on CI')}}"
+      created_date: "{{ansible_date_time.epoch}}"
+      environment: "{{environment | default('Not running on CI')}}"
+      repo: "{{repo | default('Not running on CI')}}"
     count_tag:
       Name: "e2e-{{nodeLabel}}-{{runId}}"
     volumes:

--- a/.ci/aws-instances-reaper.groovy
+++ b/.ci/aws-instances-reaper.groovy
@@ -11,7 +11,7 @@ pipeline {
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     AWS_PROVISIONER_SECRET = 'secret/observability-team/ci/elastic-observability-aws-account-auth'
     AWS_DEFAULT_REGION = 'us-east-2'
-    AWS_EC2_INSTANCES_TAG_NAME= 'ReaperMark'
+    AWS_EC2_INSTANCES_TAG_NAME= 'reaper_mark'
     AWS_EC2_INSTANCES_TAG_VALUE= 'e2e-testing-vm'
   }
   options {


### PR DESCRIPTION
## What does this PR do?

Standardise the below tags/labels in the terraform resources for AWS/GCP:

- `environment` => static value
- `repo`.              => static value
- `branch`           => dynamic value
- `build`              => dynamic value 
- `created_date` => dynamic value

## Why is it important?

Help with tearing down any of the ephemeral resources which were not successfully removed as part of the system tests.

## Implementation details

* Those tag/labels are lowercase based to be [GCP](https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements)/[AWS](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions) compliance
* `environment=ci` will allow to filter all those cloud resources which were created in the CI
* While `created_date` will help to filter those which were older than X days or X hours, since it's Unix epoch time based.
* `branch` and `build` will help to identify what build in the CI and what PR, Branch or Tag created those resources.

## Further details

> BUILD_ID
The current build ID, identical to BUILD_NUMBER for builds created in 1.597+, but a YYYY-MM-DD_hh-mm-ss timestamp for older builds.

> BRANCH_NAME
For a multibranch project, this will be set to the name of the branch being built, for example in case you wish to deploy to production from master but not from feature branches; if corresponding to some kind of change request, the name is generally arbitrary (refer to CHANGE_ID and CHANGE_TARGET).

## Test

<img width="830" alt="image" src="https://user-images.githubusercontent.com/2871786/164523125-91e6d757-0a8b-42b5-8350-ab7e5bfbb0ed.png">
