### PR TITLE
fixed failed tests

### DIFF
--- a/cli/config/kubernetes/base/elasticsearch/configmap.yaml
+++ b/cli/config/kubernetes/base/elasticsearch/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: elasticsearch-config
 data:
   ES_JAVA_OPTS: "-Xms1g -Xmx1g"
-  network.host: ""
+  network.host: "0.0.0.0"
   transport.host: "127.0.0.1"
   http.host: "0.0.0.0"
   indices.id_field_data.enabled: 'true'

--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/elasticsearch.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/elasticsearch.yml.tmpl
@@ -4,7 +4,7 @@ metadata:
   name: elasticsearch-config
 data:
   ES_JAVA_OPTS: "-Xms1g -Xmx1g"
-  network.host: ""
+  network.host: "0.0.0.0"
   transport.host: "127.0.0.1"
   http.host: "0.0.0.0"
   indices.id_field_data.enabled: 'true'


### PR DESCRIPTION
## What does this PR do?

Fixed a config `network.host=0.0.0.0` that was causing the ElasticSearch pod to not start properly and 5 scenarios to fail in the tests

## Why is it important?

Fix failing tests within kubernetes-autodiscover

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have run the Unit tests (`make unit-test`), and they are passing locally~~
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- ~~[ ] I have noticed new Go dependencies (run `make notice` in the proper directory)~~

## How to test this PR locally

```bash
TAGS="elastic-agent" TIMEOUT_FACTOR=3 LOG_LEVEL=TRACE DEVELOPER_MODE=true ELASTIC_APM_ACTIVE=false make -C e2e/_suites/kubernetes-autodiscover functional-test
```

## Related issues

- Closes #2434 
- Relates [#360](https://github.com/elastic/elastic-agent/pull/360)
