### PR TITLE
ci: daily pipeline to use main branch

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -1,4 +1,4 @@
-@Library('apm@current') _
+@Library('apm@main') _
 
 pipeline {
   agent none

--- a/internal/common/defaults.go
+++ b/internal/common/defaults.go
@@ -5,6 +5,8 @@
 package common
 
 import (
+	"regexp"
+
 	"github.com/elastic/e2e-testing/internal/shell"
 	"github.com/elastic/e2e-testing/pkg/downloads"
 	log "github.com/sirupsen/logrus"
@@ -64,6 +66,10 @@ var Provider = "docker"
 // It can be overriden by STACK_VERSION env var
 var StackVersion = BeatVersionBase
 
+// The compiled version of the regex created at init() is cached here so it
+// only needs to be created once.
+var versionRegex *regexp.Regexp
+
 func init() {
 	DeveloperMode = shell.GetEnvBool("DEVELOPER_MODE")
 	if DeveloperMode {
@@ -79,6 +85,8 @@ func init() {
 			"apm-environment": shell.GetEnv("ELASTIC_APM_ENVIRONMENT", "local"),
 		}).Info("Current execution will be instrumented 🛠")
 	}
+
+	versionRegex = regexp.MustCompile("^([0-9]+)(\\.[0-9]+)(-SNAPSHOT)?$")
 }
 
 // InitVersions initialise default versions. We do not want to do it in the init phase
@@ -96,15 +104,23 @@ func InitVersions() {
 
 	BeatVersion = shell.GetEnv("BEAT_VERSION", BeatVersionBase)
 
-	// check if version is an alias
-	v, err = downloads.GetElasticArtifactVersion(BeatVersion)
-	if err != nil {
+	// check if version is an alias. For compatibility versions let's
+	// support aliases in the format major.minor
+	m := versionRegex.FindStringSubmatch(BeatVersion)
+	if m != nil {
+		v, err = downloads.GetElasticArtifactVersion(BeatVersion)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error":   err,
+				"version": BeatVersion,
+			}).Fatal("Failed to get Beat version, aborting")
+		}
+		BeatVersion = v
+	} else {
 		log.WithFields(log.Fields{
-			"error":   err,
 			"version": BeatVersion,
-		}).Fatal("Failed to get Beat version, aborting")
+		}).Trace("Version is not an alias.")
 	}
-	BeatVersion = v
 
 	// detects if the BeatVersion is set by the GITHUB_CHECK_SHA1 variable
 	fallbackVersion := BeatVersionBase

--- a/internal/common/defaults.go
+++ b/internal/common/defaults.go
@@ -86,7 +86,7 @@ func init() {
 		}).Info("Current execution will be instrumented 🛠")
 	}
 
-	versionRegex = regexp.MustCompile("^([0-9]+)(\\.[0-9]+)(-SNAPSHOT)?$")
+	versionRegex = regexp.MustCompile(`^([0-9]+)(\.[0-9]+)(-SNAPSHOT)?$`)
 }
 
 // InitVersions initialise default versions. We do not want to do it in the init phase


### PR DESCRIPTION
### What

Aliases for releases are defined in the apm-pipeline-library, those versions are automatically bumped, but the apm-pipeline-library releases are not based on CD but manually released.

So by using the main then versions will be the correct one


### Issue

Closes https://github.com/elastic/e2e-testing/issues/2515