### PR TITLE
fix: agent directories must belong to root

### DIFF
--- a/internal/deploy/base.go
+++ b/internal/deploy/base.go
@@ -71,6 +71,7 @@ type ServiceManifest struct {
 
 // ServiceInstallerMetadata information about the installer
 type ServiceInstallerMetadata struct {
+	AgentPath     string
 	Arch          string
 	Docker        bool
 	FileExtension string

--- a/internal/installer/base.go
+++ b/internal/installer/base.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/elastic/e2e-testing/internal/common"
 	"github.com/elastic/e2e-testing/internal/deploy"
+	"github.com/elastic/e2e-testing/internal/io"
 	"github.com/elastic/e2e-testing/internal/systemd"
 	"github.com/elastic/e2e-testing/pkg/downloads"
 	log "github.com/sirupsen/logrus"
@@ -111,6 +112,28 @@ func doUpgrade(ctx context.Context, so deploy.ServiceOperator) error {
 	if err != nil {
 		return fmt.Errorf("failed to upgrade the agent with subcommand: %v", err)
 	}
+	return nil
+}
+
+// createAgentDirectories makes sure the agent directories belong to the root user
+func createAgentDirectories(ctx context.Context, i deploy.ServiceOperator, osArgs []string) error {
+	agentPath := i.PkgMetadata().AgentPath
+
+	err := io.MkdirAll(agentPath)
+	if err != nil {
+		return err
+	}
+
+	output, err := i.Exec(ctx, osArgs)
+	if err != nil {
+		return err
+	}
+
+	log.WithFields(log.Fields{
+		"args":   osArgs,
+		"output": output,
+		"path":   agentPath,
+	}).Debug("Agent directories will belong to root")
 	return nil
 }
 

--- a/internal/installer/elasticagent_deb.go
+++ b/internal/installer/elasticagent_deb.go
@@ -30,6 +30,7 @@ func AttachElasticAgentDEBPackage(d deploy.Deployment, service deploy.ServiceReq
 			service: service,
 			deploy:  d,
 			metadata: deploy.ServiceInstallerMetadata{
+				AgentPath:     "/var/lib/elastic-agent",
 				PackageType:   "deb",
 				Os:            "linux",
 				Arch:          utils.GetArchitecture(),
@@ -55,7 +56,7 @@ func (i *elasticAgentDEBPackage) AddFiles(ctx context.Context, files []string) e
 // Inspect returns info on package
 func (i *elasticAgentDEBPackage) Inspect() (deploy.ServiceOperatorManifest, error) {
 	return deploy.ServiceOperatorManifest{
-		WorkDir:    "/var/lib/elastic-agent",
+		WorkDir:    i.metadata.AgentPath,
 		CommitFile: "/etc/elastic-agent/.elastic-agent.active.commit",
 	}, nil
 }

--- a/internal/installer/elasticagent_deb.go
+++ b/internal/installer/elasticagent_deb.go
@@ -142,6 +142,11 @@ func (i *elasticAgentDEBPackage) Postinstall(ctx context.Context) error {
 
 // Preinstall executes operations before installing a DEB package
 func (i *elasticAgentDEBPackage) Preinstall(ctx context.Context) error {
+	err := createAgentDirectories(ctx, i, []string{"sudo", "chown", "-R", "root:root", i.metadata.AgentPath})
+	if err != nil {
+		return err
+	}
+
 	installArtifactFn := func(ctx context.Context, artifact string, version string, useCISnapshots bool) error {
 		span, _ := apm.StartSpanOptions(ctx, "Pre-install "+artifact, artifact+".debian.pre-install", apm.SpanOptions{
 			Parent: apm.SpanFromContext(ctx).TraceContext(),

--- a/internal/installer/elasticagent_docker.go
+++ b/internal/installer/elasticagent_docker.go
@@ -28,6 +28,7 @@ func AttachElasticAgentDockerPackage(d deploy.Deployment, service deploy.Service
 			service: service,
 			deploy:  d,
 			metadata: deploy.ServiceInstallerMetadata{
+				AgentPath:     "/usr/share/elastic-agent",
 				PackageType:   "docker",
 				Os:            "linux",
 				Arch:          utils.GetArchitecture(),
@@ -53,7 +54,7 @@ func (i *elasticAgentDockerPackage) AddFiles(ctx context.Context, files []string
 // Inspect returns info on package
 func (i *elasticAgentDockerPackage) Inspect() (deploy.ServiceOperatorManifest, error) {
 	return deploy.ServiceOperatorManifest{
-		WorkDir:    "/usr/share/elastic-agent",
+		WorkDir:    i.metadata.AgentPath,
 		CommitFile: "/usr/share/elastic-agent/.elastic-agent.active.commit",
 	}, nil
 }

--- a/internal/installer/elasticagent_rpm.go
+++ b/internal/installer/elasticagent_rpm.go
@@ -35,6 +35,7 @@ func AttachElasticAgentRPMPackage(d deploy.Deployment, service deploy.ServiceReq
 			service: service,
 			deploy:  d,
 			metadata: deploy.ServiceInstallerMetadata{
+				AgentPath:     "/var/lib/elastic-agent",
 				PackageType:   "rpm",
 				Os:            "linux",
 				Arch:          arch,
@@ -60,7 +61,7 @@ func (i *elasticAgentRPMPackage) AddFiles(ctx context.Context, files []string) e
 // Inspect returns info on package
 func (i *elasticAgentRPMPackage) Inspect() (deploy.ServiceOperatorManifest, error) {
 	return deploy.ServiceOperatorManifest{
-		WorkDir:    "/var/lib/elastic-agent",
+		WorkDir:    i.metadata.AgentPath,
 		CommitFile: "/etc/elastic-agent/.elastic-agent.active.commit",
 	}, nil
 }

--- a/internal/installer/elasticagent_rpm.go
+++ b/internal/installer/elasticagent_rpm.go
@@ -148,6 +148,11 @@ func (i *elasticAgentRPMPackage) Postinstall(ctx context.Context) error {
 
 // Preinstall executes operations before installing a RPM package
 func (i *elasticAgentRPMPackage) Preinstall(ctx context.Context) error {
+	err := createAgentDirectories(ctx, i, []string{"sudo", "chown", "-R", "root:root", i.metadata.AgentPath})
+	if err != nil {
+		return err
+	}
+
 	installArtifactFn := func(ctx context.Context, artifact string, version string, useCISnapshots bool) error {
 		span, _ := apm.StartSpanOptions(ctx, "Pre-install "+artifact, artifact+".rpm.pre-install", apm.SpanOptions{
 			Parent: apm.SpanFromContext(ctx).TraceContext(),

--- a/internal/installer/elasticagent_tar.go
+++ b/internal/installer/elasticagent_tar.go
@@ -123,6 +123,11 @@ func (i *elasticAgentTARPackage) Postinstall(ctx context.Context) error {
 
 // Preinstall executes operations before installing a TAR package
 func (i *elasticAgentTARPackage) Preinstall(ctx context.Context) error {
+	err := createAgentDirectories(ctx, i, []string{"sudo", "chown", "-R", "root:root", i.metadata.AgentPath})
+	if err != nil {
+		return err
+	}
+
 	installArtifactFn := func(ctx context.Context, artifact string, version string, useCISnapshots bool) error {
 		span, _ := apm.StartSpanOptions(ctx, "Pre-install "+artifact, artifact+".tar.pre-install", apm.SpanOptions{
 			Parent: apm.SpanFromContext(ctx).TraceContext(),

--- a/internal/installer/elasticagent_tar.go
+++ b/internal/installer/elasticagent_tar.go
@@ -37,6 +37,7 @@ func AttachElasticAgentTARPackage(d deploy.Deployment, service deploy.ServiceReq
 			service: service,
 			deploy:  d,
 			metadata: deploy.ServiceInstallerMetadata{
+				AgentPath:     "/opt/Elastic/Agent",
 				PackageType:   "tar",
 				Os:            "linux",
 				Arch:          arch,
@@ -62,7 +63,7 @@ func (i *elasticAgentTARPackage) AddFiles(ctx context.Context, files []string) e
 // Inspect returns info on package
 func (i *elasticAgentTARPackage) Inspect() (deploy.ServiceOperatorManifest, error) {
 	return deploy.ServiceOperatorManifest{
-		WorkDir:    "/opt/Elastic/Agent",
+		WorkDir:    i.metadata.AgentPath,
 		CommitFile: "elastic-agent/.elastic-agent.active.commit",
 	}, nil
 }

--- a/internal/installer/elasticagent_tar_macos.go
+++ b/internal/installer/elasticagent_tar_macos.go
@@ -124,6 +124,11 @@ func (i *elasticAgentTARDarwinPackage) Preinstall(ctx context.Context) error {
 	span.Context.SetLabel("runtime", runtime.GOOS)
 	defer span.End()
 
+	err := createAgentDirectories(ctx, i, []string{"sudo", "chown", "-R", "root:root", i.metadata.AgentPath})
+	if err != nil {
+		return err
+	}
+
 	artifact := "elastic-agent"
 
 	metadata := i.metadata

--- a/internal/installer/elasticagent_tar_macos.go
+++ b/internal/installer/elasticagent_tar_macos.go
@@ -35,6 +35,7 @@ func AttachElasticAgentTARDarwinPackage(d deploy.Deployment, service deploy.Serv
 			service: service,
 			deploy:  d,
 			metadata: deploy.ServiceInstallerMetadata{
+				AgentPath:     "/opt/Elastic/Agent",
 				PackageType:   "tar",
 				Os:            "darwin",
 				Arch:          arch,
@@ -54,7 +55,7 @@ func (i *elasticAgentTARDarwinPackage) AddFiles(ctx context.Context, files []str
 // Inspect returns info on package
 func (i *elasticAgentTARDarwinPackage) Inspect() (deploy.ServiceOperatorManifest, error) {
 	return deploy.ServiceOperatorManifest{
-		WorkDir:    "/opt/Elastic/Agent",
+		WorkDir:    i.metadata.AgentPath,
 		CommitFile: "/elastic-agent/.elastic-agent.active.commit",
 	}, nil
 }

--- a/internal/installer/elasticagent_zip.go
+++ b/internal/installer/elasticagent_zip.go
@@ -29,6 +29,7 @@ func AttachElasticAgentZIPPackage(d deploy.Deployment, service deploy.ServiceReq
 			service: service,
 			deploy:  d,
 			metadata: deploy.ServiceInstallerMetadata{
+				AgentPath:     "C:\\Program Files\\Elastic\\Agent",
 				PackageType:   "zip",
 				Os:            "windows",
 				Arch:          "x86_64",
@@ -48,7 +49,7 @@ func (i *elasticAgentZIPPackage) AddFiles(ctx context.Context, files []string) e
 // Inspect returns info on package
 func (i *elasticAgentZIPPackage) Inspect() (deploy.ServiceOperatorManifest, error) {
 	return deploy.ServiceOperatorManifest{
-		WorkDir:    "C:\\Program Files\\Elastic\\Agent",
+		WorkDir:    i.metadata.AgentPath,
 		CommitFile: "C:\\elastic-agent\\.elastic-agent.active.commit",
 	}, nil
 }


### PR DESCRIPTION
- chore: store agent pat into the metadata struct of the agent package
- chore: create agent directories for UNIX-based agent installers

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a new field in the struct representing the agent metadata to store the base path where the agent will be installed under Linux/Darwin systems.

This path will be created in the target system at the PreInstall phase, so that it has the right permissions beforehand.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
This agent path, according to https://github.com/elastic/elastic-agent/pull/398, must belong to `root`. And this applies only to 8.3 and main.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Consequence of https://github.com/elastic/elastic-agent/pull/398
- Discovered while testing #2585 and #2586


<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
