### PR TITLE
ci: support MacOS12

### DIFF
--- a/.ci/e2eTestingMacosDaily.groovy
+++ b/.ci/e2eTestingMacosDaily.groovy
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'darwin && orka && x86_64' }
+  agent { label 'macos12 && x86_64' }
   environment {
     REPO = 'e2e-testing'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"


### PR DESCRIPTION
### What does this PR do?
Add Mac OS 12 as part of the tested Operating system

### Why

Originally requested https://github.com/elastic/e2e-testing/pull/2336 but closed since the implementation was change to use Orka ephemeral workers in https://github.com/elastic/e2e-testing/pull/2626


### Test


This [build](https://beats-ci.elastic.co/blue/organizations/jenkins/e2e-tests%2Fe2e-testing-macos-daily-mbp/detail/PR-2684/2/pipeline)

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/2871786/175258195-30b548d8-f8a6-49a0-b255-c95cbef71893.png">
