### PR TITLE
Add error checks to string typecast

### DIFF
--- a/pkg/downloads/releases.go
+++ b/pkg/downloads/releases.go
@@ -141,8 +141,14 @@ func (r *ArtifactURLResolver) Resolve() (string, string, error) {
 		return "", "", fmt.Errorf("object not found in Artifact API")
 	}
 
-	downloadURL := downloadObject.Path("url").Data().(string)
-	downloadshaURL := downloadObject.Path("sha_url").Data().(string)
+	downloadURL, ok := downloadObject.Path("url").Data().(string)
+	if !ok {
+		return "", "", fmt.Errorf("key 'url' does not exist for artifact %s", artifact)
+	}
+	downloadshaURL, ok := downloadObject.Path("sha_url").Data().(string)
+	if !ok {
+		return "", "", fmt.Errorf("key 'sha_url' does not exist for artifact %s", artifact)
+	}
 
 	return downloadURL, downloadshaURL, nil
 }


### PR DESCRIPTION
## What does this PR do?

Hello from the elastic-agent team. I recently had an issue with `FetchElasticArtifact` where it tired to fetch an artifact that didn't exist, and rather than erroring out, it threw a really difficult to trace typecast panic. This appears to be an issue with how the API itself behaves when you ask for a non-existent package:
```
curl https://artifacts-api.elastic.co/v1/search/8.4.0-SNAPSHOT/elastic-agent-shipper\?x-elastic-no-kpi\=true
{"packages":[],"manifests":{"last-update-time":"Thu, 23 Jun 2022 17:38:20 UTC","seconds-since-last-update":134}}
```
We don't get an error, just an empty list. When we try to cast to string, we get an error. Not sure if there's a better way to do this, but I figured it would be at least nice to have.

## Why is it important?

This produces a very difficult to debug error. particularly when `e2e-testing` is imported from elsewhere.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally

