### PR TITLE
ci: notify test failures for MacOS nightly builds

### DIFF
--- a/.ci/e2eTestingMacosDaily.groovy
+++ b/.ci/e2eTestingMacosDaily.groovy
@@ -93,7 +93,7 @@ pipeline {
     }
     cleanup {
       notifyBuildResult(prComment: true,
-                        slackHeader: "*Test Suite*: ${env.TAGS}",
+                        slackHeader: "*Test Suite (MacOS)*: ${env.TAGS}",
                         slackChannel: "elastic-agent",
                         slackComment: true,
                         slackNotify: doSlackNotify())


### PR DESCRIPTION
## What does this PR do?

Notify if test failures to the `elastic-agent` team so they can track any MacOS test failures easily.

## Why is it important?

As requested by the team