### PR TITLE
ci: fix null for shell_type by throwing an error

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -557,11 +557,16 @@ def generateFunctionalTestStep(Map args = [:]){
           // IMPORTANT: withAPMEnv is now the one in used since withOtelEnv uses a specific Opentelemetry Collector at the moment.
           // TODO: This will need to be integrated into the provisioned VMs
           withAPMEnv() {
+
+            def shellType = machine?.get('shell_type')
+            if (!shellType?.trim()) {
+              error("generateFunctionalTestStep: machine.get('shell_type') is null")
+            }
             // Start node, capture ip address
             ansible("${env.WORKSPACE}",
                     "playbook.yml",
                     runId,
-                    "-t provision-node --extra-vars=\"${LABELS_STRING} stackRunner=${stackRunner.ip} nodeShellType=${machine.shell_type} nodeUser=${machine.username} ansible_user=${machine.username} suite=${suite} nodeLabel=${platform} nodeImage=${machine.image} nodeInstanceType=${machine.instance_type}\"")
+                    "-t provision-node --extra-vars=\"${LABELS_STRING} stackRunner=${stackRunner.ip} nodeShellType=${shellType} nodeUser=${machine.username} ansible_user=${machine.username} suite=${suite} nodeLabel=${platform} nodeImage=${machine.image} nodeInstanceType=${machine.instance_type}\"")
 
             def testRunner = getNodeIp("${env.WORKSPACE}", platform)
 
@@ -577,13 +582,13 @@ def generateFunctionalTestStep(Map args = [:]){
             ansible("${env.WORKSPACE}",
                     "playbook.yml",
                     runId,
-                    "-i \"${testRunner.ip},\" -t setup-node --extra-vars=\"${LABELS_STRING} stackRunner=${stackRunner.ip} nodeShellType=${machine.shell_type} nodeUser=${machine.username} ansible_user=${machine.username} suite=${suite} nodeLabel=${platform} nodeImage=${machine.image} nodeInstanceType=${machine.instance_type}\"")
+                    "-i \"${testRunner.ip},\" -t setup-node --extra-vars=\"${LABELS_STRING} stackRunner=${stackRunner.ip} nodeShellType=${shellType} nodeUser=${machine.username} ansible_user=${machine.username} suite=${suite} nodeLabel=${platform} nodeImage=${machine.image} nodeInstanceType=${machine.instance_type}\"")
 
             // Configure test scripts
             ansible("${env.WORKSPACE}",
                     "run-tests.yml",
                     runId,
-                    "-i \"${testRunner.ip},\" -t run-tests --extra-vars=\"${LABELS_STRING} stackRunner=${stackRunner.ip} nodeShellType=${machine.shell_type} nodeUser=${machine.username} ansible_user=${machine.username} suite=${suite} nodeLabel=${platform} nodeImage=${machine.image} nodeInstanceType=${machine.instance_type}\"")
+                    "-i \"${testRunner.ip},\" -t run-tests --extra-vars=\"${LABELS_STRING} stackRunner=${stackRunner.ip} nodeShellType=${shellType} nodeUser=${machine.username} ansible_user=${machine.username} suite=${suite} nodeLabel=${platform} nodeImage=${machine.image} nodeInstanceType=${machine.instance_type}\"")
 
             if (platform.contains("windows")) {
               // using unix slashes on windows: https://www.ibm.com/docs/en/zvse/6.2?topic=SSB27H_6.2.0/fa2ad_use_forward_or_backward_slashes_under_windows.html

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -561,7 +561,7 @@ def generateFunctionalTestStep(Map args = [:]){
 
             def shellType = machine?.get('shell_type')
             if (!shellType?.trim()) {
-              error("generateFunctionalTestStep: machine.get('shell_type') is null")
+              error("generateFunctionalTestStep: machine.get('shell_type') is null. machine=${machine}")
             }
             // Start node, capture ip address
             ansible("${env.WORKSPACE}",

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -408,6 +408,7 @@ def getRemoteE2EPath(testRunner, platform) {
 def getMachineInfo(platform){
   def machineYaml = readYaml(file: "${env.WORKSPACE}/${env.BASE_DIR}/.ci/.e2e-platforms.yaml")
   def machines = machineYaml['PLATFORMS']
+  log(level: 'INFO', text: "getMachineInfo: machines.get(platform)=${machines.get(platform)}")
   return machines.get(platform)
 }
 


### PR DESCRIPTION
## What does this PR do?

Don't take for granted the data structure is in a good shape.

## Why is it important?

There are some errors with null values.

## Test

The `Deploy Test Infra` stage printed some information:

<img width="1639" alt="image" src="https://user-images.githubusercontent.com/2871786/176199929-38a8f0f5-c23a-473d-b4da-7ae94c38613b.png">
