### PR TITLE
pkg/downloads: make sure nil resolvers are interpretted correctly

### DIFF
--- a/pkg/downloads/releases.go
+++ b/pkg/downloads/releases.go
@@ -29,7 +29,7 @@ type ArtifactURLResolver struct {
 }
 
 // NewArtifactURLResolver creates a new resolver for artifacts that are currently in development, from the artifacts API
-func NewArtifactURLResolver(fullName string, name string, version string) *ArtifactURLResolver {
+func NewArtifactURLResolver(fullName string, name string, version string) DownloadURLResolver {
 	// resolve version alias
 	resolvedVersion, err := GetElasticArtifactVersion(version)
 	if err != nil {

--- a/pkg/downloads/versions.go
+++ b/pkg/downloads/versions.go
@@ -6,6 +6,7 @@ package downloads
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -147,7 +148,9 @@ func GetCommitVersion(version string) string {
 // i.e. GetElasticArtifactURL("elastic-agent-$VERSION-linux-$ARCH.tar.gz", "elastic-agent","$VERSION")
 func GetElasticArtifactURL(artifactName string, artifact string, version string) (string, string, error) {
 	resolver := NewArtifactURLResolver(artifactName, artifact, version)
-
+	if resolver == nil {
+		return "", "", errors.New("nil resolver returned")
+	}
 	return resolver.Resolve()
 }
 
@@ -327,7 +330,6 @@ func buildArtifactName(artifact string, artifactVersion string, OS string, arch 
 	}
 
 	return fmt.Sprintf("%s-%s-%s-%s%s.%s", artifact, artifactVersion, OS, arch, dockerString, lowerCaseExtension)
-
 }
 
 // FetchBeatsBinary it downloads the binary and returns the location of the downloaded file


### PR DESCRIPTION
Previously, the returned values from NewArtifactURLResolver could be a
nil *ArtifactURLResolver. This was incorrectly being compared to nil in
the context of a DownloadURLResolver in getDownloadURLFromResolvers and
so being ignored, finally resulting in a nil pointer dereference when
the Resolve method was called. The change here makes the nil returned by
NewArtifactURLResolver be a nil DownloadURLResolver which will be
recognised in getDownloadURLFromResolvers and so not used.

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

This fixes an incorrect use of a nil in an interface context (equivalent to https://go.dev/doc/faq#nil_error).

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The existing code can panic in tests.
```
[2022-06-29T08:13:17.490Z]   Scenario Outline: Deploying the Elastic-Agent with enroll and then run on top of metricbeat # features/running_on_top_of_beats.feature:6
[2022-06-29T08:13:17.490Z]     Given an agent is deployed to Fleet on top of "metricbeat" # features/running_on_top_of_beats.feature:7
[2022-06-29T08:13:17.490Z]       Error: runtime error: invalid memory address or nil pointer dereference
[2022-06-29T08:13:17.490Z] runtime.gopanic
[2022-06-29T08:13:17.490Z] 	/usr/local/go/src/runtime/panic.go:1038
[2022-06-29T08:13:17.490Z] runtime.panicmem
[2022-06-29T08:13:17.490Z] 	/usr/local/go/src/runtime/panic.go:221
[2022-06-29T08:13:17.490Z] runtime.sigpanic
[2022-06-29T08:13:17.490Z] 	/usr/local/go/src/runtime/signal_unix.go:735
[2022-06-29T08:13:17.490Z] github.com/elastic/e2e-testing/pkg/downloads.(*ArtifactURLResolver).Resolve
[2022-06-29T08:13:17.490Z] 	/home/ec2-user/e2e-testing/pkg/downloads/releases.go:51
[2022-06-29T08:13:17.490Z] github.com/elastic/e2e-testing/pkg/downloads.getDownloadURLFromResolvers
[2022-06-29T08:13:17.491Z] 	/home/ec2-user/e2e-testing/pkg/downloads/versions.go:523
[2022-06-29T08:13:17.491Z] github.com/elastic/e2e-testing/pkg/downloads.FetchProjectBinaryForSnapshots
[2022-06-29T08:13:17.491Z] 	/home/ec2-user/e2e-testing/pkg/downloads/versions.go:492
[2022-06-29T08:13:17.491Z] github.com/elastic/e2e-testing/pkg/downloads.FetchElasticArtifactForSnapshots
[2022-06-29T08:13:17.491Z] 	/home/ec2-user/e2e-testing/pkg/downloads/versions.go:121
[2022-06-29T08:13:17.491Z] github.com/elastic/e2e-testing/internal/installer.(*elasticAgentTARPackage).Preinstall.func1
[2022-06-29T08:13:17.491Z] 	/home/ec2-user/e2e-testing/internal/installer/elasticagent_tar.go:151
[2022-06-29T08:13:17.491Z] github.com/elastic/e2e-testing/internal/installer.(*elasticAgentTARPackage).Preinstall
[2022-06-29T08:13:17.491Z] 	/home/ec2-user/e2e-testing/internal/installer/elasticagent_tar.go:191
[2022-06-29T08:13:17.491Z] github.com/elastic/e2e-testing/e2e/_suites/fleet.deployAgentToFleet
[2022-06-29T08:13:17.491Z] 	/home/ec2-user/e2e-testing/e2e/_suites/fleet/fleet.go:1610
[2022-06-29T08:13:17.491Z] github.com/elastic/e2e-testing/e2e/_suites/fleet.(*FleetTestSuite).anAgentIsDeployedToFleetWithInstallerAndFleetServer
[2022-06-29T08:13:17.491Z] 	/home/ec2-user/e2e-testing/e2e/_suites/fleet/fleet.go:627
[2022-06-29T08:13:17.491Z] github.com/elastic/e2e-testing/e2e/_suites/fleet.(*FleetTestSuite).anAgentIsDeployedToFleetOnTopOfBeat
[2022-06-29T08:13:17.491Z] 	/home/ec2-user/e2e-testing/e2e/_suites/fleet/fleet.go:530
[2022-06-29T08:13:17.491Z] reflect.Value.call
[2022-06-29T08:13:17.491Z] 	/usr/local/go/src/reflect/value.go:543
[2022-06-29T08:13:17.491Z] reflect.Value.Call
[2022-06-29T08:13:17.491Z] 	/usr/local/go/src/reflect/value.go:339
[2022-06-29T08:13:17.491Z] github.com/cucumber/godog/internal/models.(*StepDefinition).Run
[2022-06-29T08:13:17.491Z] 	/root/go/pkg/mod/github.com/cucumber/godog@v0.12.4/internal/models/stepdef.go:182
[2022-06-29T08:13:17.491Z] github.com/cucumber/godog.(*suite).runStep
[2022-06-29T08:13:17.491Z] 	/root/go/pkg/mod/github.com/cucumber/godog@v0.12.4/suite.go:183
[2022-06-29T08:13:17.491Z] github.com/cucumber/godog.(*suite).runSteps
[2022-06-29T08:13:17.491Z] 	/root/go/pkg/mod/github.com/cucumber/godog@v0.12.4/suite.go:391
[2022-06-29T08:13:17.491Z] github.com/cucumber/godog.(*suite).runPickle
[2022-06-29T08:13:17.491Z] 	/root/go/pkg/mod/github.com/cucumber/godog@v0.12.4/suite.go:463
[2022-06-29T08:13:17.491Z] github.com/cucumber/godog.(*runner).concurrent.func1
[2022-06-29T08:13:17.491Z] 	/root/go/pkg/mod/github.com/cucumber/godog@v0.12.4/run.go:122
[2022-06-29T08:13:17.491Z] github.com/cucumber/godog.(*runner).concurrent
[2022-06-29T08:13:17.491Z] 	/root/go/pkg/mod/github.com/cucumber/godog@v0.12.4/run.go:133
[2022-06-29T08:13:17.491Z] github.com/cucumber/godog.runWithOptions
[2022-06-29T08:13:17.491Z] 	/root/go/pkg/mod/github.com/cucumber/godog@v0.12.4/run.go:261
[2022-06-29T08:13:17.491Z] github.com/cucumber/godog.TestSuite.Run
[2022-06-29T08:13:17.491Z] 	/root/go/pkg/mod/github.com/cucumber/godog@v0.12.4/run.go:315
[2022-06-29T08:13:17.491Z] github.com/elastic/e2e-testing/e2e/_suites/fleet.TestMain
[2022-06-29T08:13:17.491Z] 	/home/ec2-user/e2e-testing/e2e/_suites/fleet/ingest_manager_test.go:235
[2022-06-29T08:13:17.491Z] main.main
[2022-06-29T08:13:17.491Z] 	_testmain.go:43
[2022-06-29T08:13:17.491Z] runtime.main
[2022-06-29T08:13:17.491Z] 	/usr/local/go/src/runtime/proc.go:255
[2022-06-29T08:13:17.491Z] runtime.goexit
[2022-06-29T08:13:17.491Z] 	/usr/local/go/src/runtime/asm_amd64.s:1581
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
