### PR TITLE
fix: read Git variables

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -537,6 +537,8 @@ def generateFunctionalTestStep(Map args = [:]){
   // Setup environment for platform
   def envContext = []
   envContext.add("PROVIDER=${provider}")
+  envContext.add("GITHUB_CHECK_SHA1=${env.GITHUB_CHECK_SHA1}")
+  envContext.add("GITHUB_CHECK_REPO=${env.GITHUB_CHECK_REPO}")
   envContext.add("SUITE=${suite}")
   envContext.add("TAGS=${tags}")
   envContext.add("REPORT_PREFIX=${suite}_${platform}_${tags}")

--- a/internal/common/defaults.go
+++ b/internal/common/defaults.go
@@ -192,10 +192,15 @@ func InitVersions() {
 		}
 	}
 
+	downloads.GithubCommitSha1 = shell.GetEnv("GITHUB_CHECK_SHA1", "")
+	downloads.GithubRepository = shell.GetEnv("GITHUB_CHECK_REPO", "elastic-agent")
+
 	log.WithFields(log.Fields{
 		"BeatVersionBase":     BeatVersionBase,
 		"BeatVersion":         BeatVersion,
 		"ElasticAgentVersion": ElasticAgentVersion,
+		"GithubCommitSha":     downloads.GithubCommitSha1,
+		"GithubRepository":    downloads.GithubRepository,
 		"StackVersion":        StackVersion,
 		"KibanaVersion":       KibanaVersion,
 	}).Info("Initial artifact versions defined")

--- a/pkg/downloads/versions.go
+++ b/pkg/downloads/versions.go
@@ -290,6 +290,7 @@ func UseElasticAgentCISnapshots() bool {
 func useCISnapshots(repository string) bool {
 	log.WithFields(log.Fields{
 		"repository": repository,
+		"gitRepo":    GithubRepository,
 		"gitSha1":    GithubCommitSha1,
 	}).Trace("Use CI Snapshot")
 

--- a/pkg/downloads/versions.go
+++ b/pkg/downloads/versions.go
@@ -44,27 +44,19 @@ var GithubCommitSha1 string
 
 // GithubRepository represents the value of the "GITHUB_CHECK_REPO" environment variable
 // Default is "elastic-agent"
-var GithubRepository string
+var GithubRepository string = "elastic-agent"
 
 // The compiled version of the regex created at init() is cached here so it
 // only needs to be created once.
 var versionAliasRegex *regexp.Regexp
 
 func init() {
-	GithubCommitSha1 = shell.GetEnv("GITHUB_CHECK_SHA1", "")
-	GithubRepository = shell.GetEnv("GITHUB_CHECK_REPO", "elastic-agent")
-
 	BeatsLocalPath = shell.GetEnv("BEATS_LOCAL_PATH", BeatsLocalPath)
 	if BeatsLocalPath != "" {
 		log.Infof(`Beats local path will be used for artifacts. Please make sure all binaries are properly built in their "build/distributions" folder: %s`, BeatsLocalPath)
 	}
 
 	versionAliasRegex = regexp.MustCompile(`^([0-9]+)(\.[0-9]+)(-SNAPSHOT)?$`)
-
-	log.WithFields(log.Fields{
-		"GithubCommitSha":  GithubCommitSha1,
-		"GithubRepository": GithubRepository,
-	}).Info("Github commit versions defined")
 }
 
 // elasticVersion represents a version
@@ -296,6 +288,11 @@ func UseElasticAgentCISnapshots() bool {
 // useCISnapshots check if CI snapshots should be used, passing a function that evaluates the repository in which
 // the given Sha commit has context. I.e. a commit in the elastic-agent repository should pass a function that
 func useCISnapshots(repository string) bool {
+	log.WithFields(log.Fields{
+		"repository": repository,
+		"gitSha1":    GithubCommitSha1,
+	}).Trace("Use CI Snapshot")
+
 	if GithubCommitSha1 != "" && strings.EqualFold(GithubRepository, repository) {
 		return true
 	}


### PR DESCRIPTION
- fix: pass Git variables in Jenkinsfile
- fix: laxy initialisation of the Git variables

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It passes the GITHUB_CHECK_SHA1 and GITHUB_CHECK_REPO variables to the Jenkinsfile, so that the Ansible code is able to pass them to the generated `.env` file in the remote machine.

This `.env` file is driving the execution, for that reason it's important it contains the right variables and values.

Besides that, we detected that the initialisation of those two variables was happening too early, before the `.env` was loaded (it was placed in the init() method, which has no deterministic order). Therefore, we are moving it to the initialisation of the default variables.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
PRs from Beats, and eventually for the elastic-agent are not downloading the right artifacts, generated for the respective CIs when the packaging job of the repos happened.



<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #2739

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
