### PR TITLE
fix space in the configuration file 

### DIFF
--- a/.ci/.e2e-tests-beats.yaml
+++ b/.ci/.e2e-tests-beats.yaml
@@ -13,7 +13,7 @@ SUITES:
     scenarios:
       - name: "Fleet"
         tags: "fleet_mode_agent"
-        platforms: ["centos8_arm64", "centos8_amd64", " debian_10_arm64", "debian_10_amd64", "sles15"]
+        platforms: ["centos8_arm64", "centos8_amd64", "debian_10_arm64", "debian_10_amd64", "sles15"]
       - name: "Integrations"
         tags: "integrations"
         platforms: ["debian_10_arm64", "debian_10_amd64", "sles15"]

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -447,7 +447,9 @@ def checkTestSuite(Map parallelTasks = [:], Map item = [:]) {
     }
     def pullRequestFilter = scenario.containsKey('pullRequestFilter') ? scenario.pullRequestFilter : ''
     def tags = scenario.tags
-      platformsValue.each { platform ->
+      platformsValue.each { rawPlatform ->
+        // platform is not space based, so let's ensure no extra spaces can cause misbehaviours.
+        def platform = rawPlatform.trim()
         log(level: 'INFO', text: "Adding ${suite}:${platform}:${tags} test suite to the build execution")
         def machineInfo = getMachineInfo(platform)
         parallelTasks["${suite}_${platform}_${tags}"] = generateFunctionalTestStep(name: "${name}",


### PR DESCRIPTION
## What does this PR do?

Fix the extra space in the configuration file
Force trim to avoid future issues

## Why is it important?

Fix a broken configuration


Backport is not required since the original PR was not backported -> https://github.com/elastic/e2e-testing/pull/2603