### PR TITLE
backport: Add 8.4 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -7,8 +7,8 @@
     "multipleCommits": true,
     "prTitle": "{commitMessages} backport for {targetBranch}",
     "targetBranchChoices": [
-        { "name": "8.2", "checked": true },
-        { "name": "8.1", "checked": true },
+        { "name": "8.4", "checked": true },
+        { "name": "8.3", "checked": true },
         { "name": "7.17", "checked": true }
     ],
     "targetPRLabels": ["backport"],

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -128,3 +128,16 @@ pull_request_rules:
         message: |
           This pull request has been automatically closed by Mergify.
           There are likely new up-to-date and open pull requests.
+  - name: backport patches to 8.4 branch
+    conditions:
+      - merged
+      - label=backport-v8.4.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.4"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,6 +18,19 @@ pull_request_rules:
             git merge upstream/{{base}}
             git push upstream {{head}}
             ```
+  - name: backport patches to 8.4 branch
+    conditions:
+      - merged
+      - label=backport-v8.4.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.4"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.3 branch
     conditions:
       - merged
@@ -29,18 +42,6 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "8.3"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 8.2 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-v8.2.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.2"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 7.17 branch
     conditions:
@@ -128,16 +129,3 @@ pull_request_rules:
         message: |
           This pull request has been automatically closed by Mergify.
           There are likely new up-to-date and open pull requests.
-  - name: backport patches to 8.4 branch
-    conditions:
-      - merged
-      - label=backport-v8.4.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.4"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
Merge as soon as 8.4 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821