### PR TITLE
fix: poll for api key verification using backoff retry

### DIFF
--- a/e2e/_suites/fleet/api_keys.go
+++ b/e2e/_suites/fleet/api_keys.go
@@ -47,6 +47,8 @@ func (fts *FleetTestSuite) verifyDefaultAPIKey(status string) error {
 		logFields := log.Fields{
 			"new_default_api_key": newDefaultAPIKey,
 			"old_default_api_key": fts.DefaultAPIKey,
+			"retries":             retryCount,
+			"elapsedTime":         exp.GetElapsedTime(),
 		}
 
 		defaultAPIKeyHasChanged := (newDefaultAPIKey != fts.DefaultAPIKey)

--- a/e2e/_suites/fleet/api_keys.go
+++ b/e2e/_suites/fleet/api_keys.go
@@ -78,7 +78,5 @@ func (fts *FleetTestSuite) verifyDefaultAPIKey(status string) error {
 	}
 
 	err := backoff.Retry(checkAPIKeyFn, exp)
-	if err != nil {
-		return err
-	}
+	return err
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a retry-with-backoff strategy when checking whether an API key changed or not

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Before this change, the comparison was immediate, and because we are observing certain flakiness in the CI, we could identify a pattern: the tests run too fast and the change/no-change of the API key happens in the background asynchronously, that's why we are polling the resource for the default TimeOutFactor in minutes (3-5-7)

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
