### PR TITLE
jjbb: support for feature flags

### DIFF
--- a/.ci/jobs/e2e-testing-fleet-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-fleet-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|8\.\d|7\.17)'
+          head-filter-regex: '(main|8\.\d|7\.17|feature-.*)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-helm-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-helm-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|8\.\d|7\.17)'
+          head-filter-regex: '(main|8\.\d|7\.17|feature-.*)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-k8s-autodiscovery-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-k8s-autodiscovery-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|8\.\d|7\.17)'
+          head-filter-regex: '(main|8\.\d|7\.17|feature-.*)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-macos-mbp.yml
+++ b/.ci/jobs/e2e-testing-macos-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|8\.\d|7\.17|PR-.*)'
+          head-filter-regex: '(main|8\.\d|7\.17|PR-.*|feature-.*)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -14,7 +14,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|PR-.*|8\.\d+|7\.17)'
+          head-filter-regex: '(main|PR-.*|8\.\d+|7\.17|feature-.*)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current


### PR DESCRIPTION
## What does this PR do?

Enable feature branches with the naming `feature-.*`, such as `feature-arch-v2`

## Why is it important?

Consumers are using this approach:

> We need the Beats [feature-arch-v2](https://github.com/elastic/beats/tree/feature-arch-v2) branch paired with the Elastic agent [feature-arch-v2](https://github.com/elastic/elastic-agent/tree/feature-arch-v2) branch for E2E test runs. This should be the same situation as the release branches in both repositories, just with a feature branch instead.

## Issues

Supersedes https://github.com/elastic/apm-pipeline-library/pull/1850