### PR TITLE
ci: schedule builds for the feature-arch-v2 branch

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -20,8 +20,8 @@ pipeline {
   stages {
     stage('Nighly e2e builds') {
       steps {
-        runBuilds(quietPeriodFactor: 100, branches: ['main', '8.<minor>', '8.<next-patch>', '8.<next-minor>', '8.<minor-1>', '7.<minor>'])
-        runMacosBuilds(branches: ['main', '8.<minor>'])
+        runBuilds(quietPeriodFactor: 100, branches: ['main', '8.<minor>', '8.<next-patch>', '8.<next-minor>', '8.<minor-1>', '7.<minor>', 'feature-arch-v2'])
+        runMacosBuilds(branches: ['main', '8.<minor>', 'feature-arch-v2'])
       }
     }
   }


### PR DESCRIPTION

## What does this PR do?

Enable daily builds for certain scenarios targeting https://github.com/elastic/e2e-testing/tree/feature-arch-v2

## Why is it important?

If `feature-arch-v2` is not using the same functionality defined in `main`, both `e2e-testing` or the consumers (`beats`, `elastic-agent`

Otherwise, we don't need this feature

## Issue

Requires https://github.com/elastic/e2e-testing/pull/2976