### PR TITLE
action: Sync main with feature-arch-v2

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -1,0 +1,25 @@
+# Synchronize all pushes to 'main' branch with 'feature-arch-v2' branch
+name: Sync main with feature-arch-v2
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync_latest_from_upstream:
+    runs-on: ubuntu-latest
+    name: Sync latest commits from main branch
+    steps:
+      - name: Checkout target repo
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.0
+        with:
+          target_sync_branch: feature-arch-v2
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          upstream_sync_branch: main
+          upstream_sync_repo: elastic/e2e-testing

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -23,3 +23,24 @@ jobs:
           target_repo_token: ${{ secrets.GITHUB_TOKEN }}
           upstream_sync_branch: main
           upstream_sync_repo: elastic/e2e-testing
+
+      - name: Create PR
+        id: pr-create
+        if: steps.sync.outputs.has_new_commits == 'true'
+        uses: thomaseizinger/create-pull-request@1.2.2
+        with:
+           head: main
+           base: feature-arch-v2
+           title: "🤖 Merge upstream"
+           body: ":robot: Generated PR to keep feature-arch-v2 feature branch up to date"
+           labels: "automation,gh-automerge"
+           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable github auto-merge
+        id: enable-automerge
+        if: steps.pr-create.outputs.created == 'true'
+        uses: reitermarkus/automerge@v2.1.2
+        with:
+           required-labels: gh-automerge
+           pull-request: ${{ steps.pr-create.outputs.number }}
+           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Use https://github.com/aormsby/Fork-Sync-With-Upstream-action to sync `feature-arch-v2` with the latest changes in main

## Why is it important?

Since `feature-arch-v2` and `main` are functional equivalent this automation will help to keep those branches in sync.

This particular action has been used at Elastic in some other repositories 