### PR TITLE
Update ingest notifications channel

### DIFF
--- a/.ci/e2eTestingFleetDaily.groovy
+++ b/.ci/e2eTestingFleetDaily.groovy
@@ -42,7 +42,7 @@ pipeline {
                testMatrixFile: '.ci/.e2e-tests-daily.yaml',
                notifyOnGreenBuilds: 'false',
                runTestsSuites: 'fleet',
-               slackChannel: 'elastic-agent',
+               slackChannel: 'ingest-notifications',
                propagate: true,
                wait: true)
       }

--- a/.ci/e2eTestingMacosDaily.groovy
+++ b/.ci/e2eTestingMacosDaily.groovy
@@ -98,7 +98,7 @@ pipeline {
     cleanup {
       notifyBuildResult(prComment: true,
                         slackHeader: "*Test Suite (MacOS)*: ${env.TAGS}",
-                        slackChannel: "elastic-agent",
+                        slackChannel: "ingest-notifications",
                         slackComment: true,
                         slackNotify: doSlackNotify())
     }


### PR DESCRIPTION
Move away from elastic-agent slack channel and use the dedicated ingest-notifications one.