### PR TITLE
Added support for bulk api update change

### DIFF
--- a/e2e/_suites/fleet/api_keys.go
+++ b/e2e/_suites/fleet/api_keys.go
@@ -49,6 +49,8 @@ func (fts *FleetTestSuite) verifyPermissionHashStatus(status string) error {
 		hashes, _ := fts.getAgentPermissionHashes()
 
 		logFields := log.Fields{
+			"old_hashes":  fts.PermissionHashes,
+			"new_hashes":  hashes,
 			"retries":     retryCount,
 			"elapsedTime": exp.GetElapsedTime(),
 		}
@@ -71,18 +73,18 @@ func (fts *FleetTestSuite) verifyPermissionHashStatus(status string) error {
 				return fmt.Errorf("integration added and Output API Key did not change yet")
 			}
 
-			log.WithFields(logFields).Infof("Default API Key has %s when the Integration has been added", status)
+			log.WithFields(logFields).Infof("Output API Key has %s when the Integration has been added", status)
 			return nil
 		}
 
 		if status == "been updated" {
 			if !permissionHashUpdated {
 				retryCount++
-				log.WithFields(logFields).Warn("Integration added and Output API Key did not change yet")
-				return fmt.Errorf("integration added and Output API Key did not change yet")
+				log.WithFields(logFields).Warn("Integration added and Output API Key did not updated yet")
+				return fmt.Errorf("integration added and Output API Key did not updated yet")
 			}
 
-			log.WithFields(logFields).Infof("Default API Key has %s when the Integration has been added", status)
+			log.WithFields(logFields).Infof("Output API Key has %s when the Integration has been added", status)
 			return nil
 		}
 

--- a/e2e/_suites/fleet/api_keys.go
+++ b/e2e/_suites/fleet/api_keys.go
@@ -26,13 +26,88 @@ func (fts *FleetTestSuite) getAgentDefaultAPIKey() (string, error) {
 	return agent.DefaultAPIKey, nil
 }
 
+func (fts *FleetTestSuite) getAgentPermissionHashes() (map[string]string, error) {
+	agentService := deploy.NewServiceRequest(common.ElasticAgentServiceName)
+	manifest, _ := fts.getDeployer().GetServiceManifest(fts.currentContext, agentService)
+	agent, err := fts.kibanaClient.GetAgentByHostnameFromList(fts.currentContext, manifest.Hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	permissions := make(map[string]string)
+	for _, output := range agent.Outputs {
+		permissions[output.APIKeyID] = output.PermissionsHash
+	}
+
+	return permissions, nil
+}
+
 func (fts *FleetTestSuite) theAgentGetDefaultAPIKey() error {
 	defaultAPIKey, _ := fts.getAgentDefaultAPIKey()
 	log.WithFields(log.Fields{
 		"default_api_key": defaultAPIKey,
 	}).Info("The Agent is installed with Default Api Key")
 	fts.DefaultAPIKey = defaultAPIKey
+
+	hashes, _ := fts.getAgentPermissionHashes()
+	fts.PermissionHashes = hashes
+
 	return nil
+}
+
+func (fts *FleetTestSuite) verifyPermissionHashStatus(status string) error {
+	maxTimeout := time.Duration(utils.TimeoutFactor) * time.Minute
+	retryCount := 1
+
+	exp := utils.GetExponentialBackOff(maxTimeout)
+
+	checkHashFn := func() error {
+		hashes, _ := fts.getAgentPermissionHashes()
+
+		logFields := log.Fields{
+			"retries":     retryCount,
+			"elapsedTime": exp.GetElapsedTime(),
+		}
+
+		permissionHashChanged := len(fts.PermissionHashes) != len(hashes)
+		if !permissionHashChanged {
+			for oldHash, oldPerm := range fts.PermissionHashes {
+				newPerm, found := hashes[oldHash]
+				if !found || oldPerm != newPerm {
+					permissionHashChanged = true
+					break
+				}
+			}
+		}
+
+		if status == "changed" {
+			if !permissionHashChanged {
+				retryCount++
+				log.WithFields(logFields).Warn("Integration added and Output API Key did not change yet")
+				return fmt.Errorf("integration added and Output API Key did not change yet")
+			}
+
+			log.WithFields(logFields).Infof("Default API Key has %s when the Integration has been added", status)
+			return nil
+		}
+
+		if status == "not changed" {
+			if permissionHashChanged {
+				retryCount++
+				log.WithFields(logFields).Error("Integration updated and Output API Key is still changed")
+				return fmt.Errorf("integration updated and Output API Key is still changed")
+			}
+
+			log.WithFields(logFields).Infof("Output API Key has %s when the Integration has been updated", status)
+			return nil
+		}
+
+		log.Warnf("Status %s is not supported yet", status)
+		return godog.ErrPending
+	}
+
+	err := backoff.Retry(checkHashFn, exp)
+	return err
 }
 
 func (fts *FleetTestSuite) verifyDefaultAPIKey(status string) error {

--- a/e2e/_suites/fleet/api_keys.go
+++ b/e2e/_suites/fleet/api_keys.go
@@ -16,16 +16,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (fts *FleetTestSuite) getAgentDefaultAPIKey() (string, error) {
-	agentService := deploy.NewServiceRequest(common.ElasticAgentServiceName)
-	manifest, _ := fts.getDeployer().GetServiceManifest(fts.currentContext, agentService)
-	agent, err := fts.kibanaClient.GetAgentByHostnameFromList(fts.currentContext, manifest.Hostname)
-	if err != nil {
-		return "", err
-	}
-	return agent.DefaultAPIKey, nil
-}
-
 func (fts *FleetTestSuite) getAgentPermissionHashes() (map[string]string, error) {
 	agentService := deploy.NewServiceRequest(common.ElasticAgentServiceName)
 	manifest, _ := fts.getDeployer().GetServiceManifest(fts.currentContext, agentService)
@@ -43,12 +33,6 @@ func (fts *FleetTestSuite) getAgentPermissionHashes() (map[string]string, error)
 }
 
 func (fts *FleetTestSuite) theAgentGetDefaultAPIKey() error {
-	defaultAPIKey, _ := fts.getAgentDefaultAPIKey()
-	log.WithFields(log.Fields{
-		"default_api_key": defaultAPIKey,
-	}).Info("The Agent is installed with Default Api Key")
-	fts.DefaultAPIKey = defaultAPIKey
-
 	hashes, _ := fts.getAgentPermissionHashes()
 	fts.PermissionHashes = hashes
 
@@ -107,53 +91,5 @@ func (fts *FleetTestSuite) verifyPermissionHashStatus(status string) error {
 	}
 
 	err := backoff.Retry(checkHashFn, exp)
-	return err
-}
-
-func (fts *FleetTestSuite) verifyDefaultAPIKey(status string) error {
-	maxTimeout := time.Duration(utils.TimeoutFactor) * time.Minute
-	retryCount := 1
-
-	exp := utils.GetExponentialBackOff(maxTimeout)
-
-	checkAPIKeyFn := func() error {
-		newDefaultAPIKey, _ := fts.getAgentDefaultAPIKey()
-
-		logFields := log.Fields{
-			"new_default_api_key": newDefaultAPIKey,
-			"old_default_api_key": fts.DefaultAPIKey,
-			"retries":             retryCount,
-			"elapsedTime":         exp.GetElapsedTime(),
-		}
-
-		defaultAPIKeyHasChanged := (newDefaultAPIKey != fts.DefaultAPIKey)
-
-		if status == "changed" {
-			if !defaultAPIKeyHasChanged {
-				retryCount++
-				log.WithFields(logFields).Warn("Integration added and Default API Key did not change yet")
-				return fmt.Errorf("integration added and Default API Key did not change yet")
-			}
-
-			log.WithFields(logFields).Infof("Default API Key has %s when the Integration has been added", status)
-			return nil
-		}
-
-		if status == "not changed" {
-			if defaultAPIKeyHasChanged {
-				retryCount++
-				log.WithFields(logFields).Error("Integration updated and Default API Key is still changed")
-				return fmt.Errorf("integration updated and Default API Key is still changed")
-			}
-
-			log.WithFields(logFields).Infof("Default API Key has %s when the Integration has been updated", status)
-			return nil
-		}
-
-		log.Warnf("Status %s is not supported yet", status)
-		return godog.ErrPending
-	}
-
-	err := backoff.Retry(checkAPIKeyFn, exp)
 	return err
 }

--- a/e2e/_suites/fleet/api_keys.go
+++ b/e2e/_suites/fleet/api_keys.go
@@ -54,7 +54,7 @@ func (fts *FleetTestSuite) verifyPermissionHashStatus(status string) error {
 		}
 
 		permissionHashChanged := len(fts.PermissionHashes) != len(hashes)
-		permissionHashUpdated = false
+		permissionHashUpdated := false
 		for oldHash, oldPerm := range fts.PermissionHashes {
 			newPerm, found := hashes[oldHash]
 			if !found {

--- a/e2e/_suites/fleet/features/permission_output_change.feature
+++ b/e2e/_suites/fleet/features/permission_output_change.feature
@@ -8,11 +8,11 @@ Scenario Outline: Adding the Linux Integration to an Agent changing Default API 
     And the agent is listed in Fleet as "online"
   When the "Linux" integration is "added" in the policy
   Then a Linux data stream exists with some data
-    And the the output permissions has "been updated"
+    And the output permissions has "been updated"
 
 @update-system-metrics-integration
 Scenario Outline: Updating the Integration on an Agent not changing Default API key
   Given an agent is deployed to Fleet with "tar" installer
     And the agent is listed in Fleet as "online"
   When the policy is updated to have "system/metrics" set to "core"
-  Then the the output permissions has "been updated"
+  Then the output permissions has "been updated"

--- a/e2e/_suites/fleet/features/permission_output_change.feature
+++ b/e2e/_suites/fleet/features/permission_output_change.feature
@@ -8,11 +8,11 @@ Scenario Outline: Adding the Linux Integration to an Agent changing Default API 
     And the agent is listed in Fleet as "online"
   When the "Linux" integration is "added" in the policy
   Then a Linux data stream exists with some data
-    And the default API key has "changed"
+    And the the output permissions has "not changed"
 
 @update-system-metrics-integration
 Scenario Outline: Updating the Integration on an Agent not changing Default API key
   Given an agent is deployed to Fleet with "tar" installer
     And the agent is listed in Fleet as "online"
   When the policy is updated to have "system/metrics" set to "core"
-  Then the default API key has "not changed"
+  Then the the output permissions has "not changed"

--- a/e2e/_suites/fleet/features/permission_output_change.feature
+++ b/e2e/_suites/fleet/features/permission_output_change.feature
@@ -8,11 +8,11 @@ Scenario Outline: Adding the Linux Integration to an Agent changing Default API 
     And the agent is listed in Fleet as "online"
   When the "Linux" integration is "added" in the policy
   Then a Linux data stream exists with some data
-    And the output permissions has "been updated"
+    And the output permissions has "changed"
 
 @update-system-metrics-integration
 Scenario Outline: Updating the Integration on an Agent not changing Default API key
   Given an agent is deployed to Fleet with "tar" installer
     And the agent is listed in Fleet as "online"
   When the policy is updated to have "system/metrics" set to "core"
-  Then the output permissions has "been updated"
+  Then the output permissions has "not changed"

--- a/e2e/_suites/fleet/features/permission_output_change.feature
+++ b/e2e/_suites/fleet/features/permission_output_change.feature
@@ -8,11 +8,11 @@ Scenario Outline: Adding the Linux Integration to an Agent changing Default API 
     And the agent is listed in Fleet as "online"
   When the "Linux" integration is "added" in the policy
   Then a Linux data stream exists with some data
-    And the the output permissions has "not changed"
+    And the the output permissions has "been updated"
 
 @update-system-metrics-integration
 Scenario Outline: Updating the Integration on an Agent not changing Default API key
   Given an agent is deployed to Fleet with "tar" installer
     And the agent is listed in Fleet as "online"
   When the policy is updated to have "system/metrics" set to "core"
-  Then the the output permissions has "not changed"
+  Then the the output permissions has "been updated"

--- a/e2e/_suites/fleet/fleet.go
+++ b/e2e/_suites/fleet/fleet.go
@@ -40,6 +40,7 @@ type FleetTestSuite struct {
 	// instrumentation
 	currentContext    context.Context
 	DefaultAPIKey     string
+	PermissionHashes  map[string]string
 	ElasticAgentFlags string
 }
 

--- a/e2e/_suites/fleet/fleet_test.go
+++ b/e2e/_suites/fleet/fleet_test.go
@@ -425,7 +425,7 @@ func InitializeFleetTestScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^an agent is deployed to Fleet with "([^"]*)" installer$`, fts.anAgentIsDeployedToFleetWithInstaller)
 	ctx.Step(`^an agent is deployed to Fleet with "([^"]*)" installer and "([^"]*)" flags$`, fts.anAgentIsDeployedToFleetWithInstallerAndTags)
 	ctx.Step(`^the agent is listed in Fleet as "([^"]*)"$`, fts.theAgentIsListedInFleetWithStatus)
-	ctx.Step(`^the default API key has "([^"]*)"$`, fts.verifyDefaultAPIKey)
+	ctx.Step(`^the output permissions has "([^"]*)"$`, fts.verifyPermissionHashStatus)
 	ctx.Step(`^the host is restarted$`, fts.theHostIsRestarted)
 	ctx.Step(`^system package dashboards are listed in Fleet$`, fts.systemPackageDashboardsAreListedInFleet)
 	ctx.Step(`^the agent is un-enrolled$`, fts.theAgentIsUnenrolled)

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -178,7 +178,7 @@ type SecurityTokenResponse struct {
 		} `json:"lookup_realm"`
 		Metadata struct {
 			Reserved string `json:"_reserved"`
-		} `json:"lookup_realm"`
+		} `json:"metadata"`
 		Roles    []string `json:"roles"`
 		Username string   `json:"username"`
 	} `json:"authentication"`

--- a/internal/kibana/agents.go
+++ b/internal/kibana/agents.go
@@ -41,6 +41,36 @@ type Agent struct {
 		} `json:"elastic"`
 	} `json:"local_metadata"`
 	Status string `json:"status"`
+	// Outputs is the policy output data, mapping the output name to its data
+	Outputs map[string]*PolicyOutput `json:"outputs,omitempty"`
+}
+
+// PolicyOutput holds the needed data to manage the output API keys
+type PolicyOutput struct {
+	// API key the Elastic Agent uses to authenticate with elasticsearch
+	APIKey string `json:"api_key"`
+
+	// ID of the API key the Elastic Agent uses to authenticate with elasticsearch
+	APIKeyID string `json:"api_key_id"`
+
+	// The policy output permissions hash
+	PermissionsHash string `json:"permissions_hash"`
+
+	// API keys to be invalidated on next agent ack
+	ToRetireAPIKeyIds []ToRetireAPIKeyIdsItems `json:"to_retire_api_key_ids,omitempty"`
+
+	// Type is the output type. Currently only Elasticsearch is supported.
+	Type string `json:"type"`
+}
+
+// ToRetireAPIKeyIdsItems the Output API Keys that were replaced and should be retired
+type ToRetireAPIKeyIdsItems struct {
+
+	// API Key identifier
+	ID string `json:"id,omitempty"`
+
+	// Date/time the API key was retired
+	RetiredAt string `json:"retired_at,omitempty"`
 }
 
 // GetAgentByHostnameFromList get an agent by the local_metadata.host.name property, reading from the agents list

--- a/internal/kibana/agents.go
+++ b/internal/kibana/agents.go
@@ -40,8 +40,7 @@ type Agent struct {
 			} `json:"agent"`
 		} `json:"elastic"`
 	} `json:"local_metadata"`
-	Status string `json:"status"`
-	// Outputs is the policy output data, mapping the output name to its data
+	Status  string                   `json:"status"`
 	Outputs map[string]*PolicyOutput `json:"outputs,omitempty"`
 }
 


### PR DESCRIPTION
Addes support for bulk API key change which does not update api key for output

## What does this PR do?

Removes Default API key and operates on api key on output level

## Why is it important?

Keep in par with fleet server

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)
