### PR TITLE
Turn off all tests but Fleet mode and upgrade for Beats and Agent pipelines

### DIFF
--- a/.ci/.e2e-tests-beats.yaml
+++ b/.ci/.e2e-tests-beats.yaml
@@ -13,25 +13,29 @@ SUITES:
     scenarios:
       - name: "Fleet"
         tags: "fleet_mode"
-        platforms: ["centos8_arm64", "centos8_amd64", "debian_10_arm64", "debian_10_amd64", "sles15"]
-      - name: "Integrations"
-        tags: "integrations"
-        platforms: ["debian_11_amd64"]
-      - name: "APM Integration"
-        tags: "apm_server"
-        platforms: ["debian_10_amd64"]
-      - name: "Linux Integration"
-        tags: "linux_integration"
-        platforms: ["debian_10_arm64", "debian_10_amd64", "sles15"]
-      - name: "Permissions Output change"
-        tags: "permission_change"
-        platforms: ["debian_10_arm64", "debian_10_amd64", "sles15"]
-      - name: "Backend Processes"
-        tags: "backend_processes"
-        platforms: ["debian_10_arm64", "debian_10_amd64", "sles15"]
-      - name: "Beats Background Processes"
-        tags: "running_on_beats"
-        platforms: ["debian_10_arm64", "debian_10_amd64", "oracle_linux8", "sles15"]
+        platforms: ["ubuntu_22_04_amd64"]
+        # platforms: ["centos8_arm64", "centos8_amd64", "debian_10_arm64", "debian_10_amd64", "sles15"]
+      # - name: "Integrations"
+      #   tags: "integrations"
+      #   platforms: ["debian_11_amd64"]
+      # - name: "APM Integration"
+      #   tags: "apm_server"
+      #   platforms: ["debian_10_amd64"]
+      # - name: "Linux Integration"
+      #   tags: "linux_integration"
+      #   platforms: ["debian_10_arm64", "debian_10_amd64", "sles15"]
+      # - name: "Permissions Output change"
+      #   tags: "permission_change"
+      #   platforms: ["debian_10_arm64", "debian_10_amd64", "sles15"]
+      # - name: "Backend Processes"
+      #   tags: "backend_processes"
+      #   platforms: ["debian_10_arm64", "debian_10_amd64", "sles15"]
+      # - name: "Beats Background Processes"
+      #   tags: "running_on_beats"
+      #   platforms: ["debian_10_arm64", "debian_10_amd64", "oracle_linux8", "sles15"]
+      - name: "Upgrade Agent"
+        tags: "upgrade_agent"
+        platforms: ["ubuntu_22_04_amd64"]
   - suite: "kubernetes-autodiscover"
     provider: "docker"
     scenarios:

--- a/.ci/.e2e-tests-for-elastic-agent.yaml
+++ b/.ci/.e2e-tests-for-elastic-agent.yaml
@@ -4,31 +4,35 @@ SUITES:
     scenarios:
       - name: "Fleet"
         tags: "fleet_mode"
-        platforms: ["centos8_arm64", "centos8_amd64", "debian_10_arm64", "debian_11_amd64", "ubuntu_22_04_amd64", "debian_10_amd64", "sles15", "windows2019"]
-      - name: "Integrations"
-        tags: "integrations"
-        platforms: ["debian_11_amd64"]
-      - name: "APM Integration"
-        tags: "apm_server"
-        platforms: ["debian_10_amd64"]
-      - name: "Linux Integration"
-        tags: "linux_integration"
-        platforms: ["debian_10_arm64", "debian_10_amd64", "debian_11_amd64", "ubuntu_22_04_amd64", "sles15"]
-      - name: "Permissions Output change"
-        tags: "permission_change"
-        platforms: ["debian_10_arm64", "debian_10_amd64", "sles15"]
-      - name: "System Integration"
-        tags: "system_integration"
-        platforms: ["debian_10_arm64", "debian_10_amd64", "debian_11_amd64", "ubuntu_22_04_amd64", "sles15"]
-      - name: "Stand-alone"
-        tags: "stand_alone_mode"
-        platforms: ["debian_10_arm64", "debian_10_amd64"]
-      - name: "Backend Processes"
-        tags: "backend_processes"
-        platforms: ["debian_10_arm64", "debian_10_amd64", "debian_11_amd64", "ubuntu_22_04_amd64", "sles15"]
-      - name: "Beats Background Processes"
-        tags: "running_on_beats"
-        platforms: ["debian_10_arm64", "debian_10_amd64", "debian_11_amd64", "ubuntu_22_04_amd64", "oracle_linux8", "sles15"]
+        platforms: ["ubuntu_22_04_amd64"]
+        # platforms: ["centos8_arm64", "centos8_amd64", "debian_10_arm64", "debian_11_amd64", "ubuntu_22_04_amd64", "debian_10_amd64", "sles15", "windows2019"]
+      # - name: "Integrations"
+      #   tags: "integrations"
+      #   platforms: ["debian_11_amd64"]
+      # - name: "APM Integration"
+      #   tags: "apm_server"
+      #   platforms: ["debian_10_amd64"]
+      # - name: "Linux Integration"
+      #   tags: "linux_integration"
+      #   platforms: ["debian_10_arm64", "debian_10_amd64", "debian_11_amd64", "ubuntu_22_04_amd64", "sles15"]
+      # - name: "Permissions Output change"
+      #   tags: "permission_change"
+      #   platforms: ["debian_10_arm64", "debian_10_amd64", "sles15"]
+      # - name: "System Integration"
+      #   tags: "system_integration"
+      #   platforms: ["debian_10_arm64", "debian_10_amd64", "debian_11_amd64", "ubuntu_22_04_amd64", "sles15"]
+      # - name: "Stand-alone"
+      #   tags: "stand_alone_mode"
+      #   platforms: ["debian_10_arm64", "debian_10_amd64"]
+      # - name: "Backend Processes"
+      #   tags: "backend_processes"
+      #   platforms: ["debian_10_arm64", "debian_10_amd64", "debian_11_amd64", "ubuntu_22_04_amd64", "sles15"]
+      # - name: "Beats Background Processes"
+      #   tags: "running_on_beats"
+      #   platforms: ["debian_10_arm64", "debian_10_amd64", "debian_11_amd64", "ubuntu_22_04_amd64", "oracle_linux8", "sles15"]
+      - name: "Upgrade Agent"
+        tags: "upgrade_agent"
+        platforms: ["ubuntu_22_04_amd64"]
   - suite: "kubernetes-autodiscover"
     provider: "docker"
     scenarios:


### PR DESCRIPTION
## What does this PR do?

Replicates the changes from https://github.com/elastic/e2e-testing/pull/3054 to the other pipelines