### PR TITLE
fix ineffassign for the version when using tar on MacOS

### DIFF
--- a/internal/installer/elasticagent_tar_macos.go
+++ b/internal/installer/elasticagent_tar_macos.go
@@ -177,7 +177,7 @@ func (i *elasticAgentTARDarwinPackage) Preinstall(ctx context.Context) error {
 		}
 	}
 
-	srcPath := common.GetElasticAgentWorkingPath(fmt.Sprintf("%s-%s-%s-%s", artifact, downloads.GetSnapshotVersion(common.ElasticAgentVersion), metadata.Os, metadata.Arch))
+	srcPath := common.GetElasticAgentWorkingPath(fmt.Sprintf("%s-%s-%s-%s", artifact, downloads.GetSnapshotVersion(version), metadata.Os, metadata.Arch))
 	output, _ := i.Exec(ctx, []string{"mv", srcPath, common.GetElasticAgentWorkingPath("elastic-agent")})
 	log.WithField("output", output).Trace("Moved elastic-agent")
 	return nil


### PR DESCRIPTION
## What does this PR do?

Use the detected version 

## Why is it important?

While working on https://github.com/elastic/e2e-testing/actions/runs/3288874303/jobs/5419734016

I've found

```
Check files aren't using go's testing package........(no files to check)Skipped
golangci-lint............................................................Failed
- hook id: golangci-lint
- exit code: 1

WARN [runner] Can't process result by diff processor: can't prepare diff by revgrep: could not read git repo: error executing git diff HEAD~: exit status 128 
internal/installer/elasticagent_tar_macos.go:176:4: ineffectual assignment to version (ineffassign)
			version = v
			^
```