### PR TITLE
CI: separate JJBB definitions for pull requests, PR merge and external e2e calls

### DIFF
--- a/.ci/jobs/e2e-testing-helm-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-helm-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|8\.\d|7\.17|feature-.*)'
+          head-filter-regex: '(main|PR-.*|8\.\d|7\.17|feature-.*)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-helm-daily-mbp.yml
+++ b/.ci/jobs/e2e-testing-helm-daily-mbp.yml
@@ -9,7 +9,7 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|PR-.*|8\.\d|7\.17|feature-.*)'
+          head-filter-regex: '(main|8\.\d|7\.17|feature-.*)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-mbp-tmp.yml
+++ b/.ci/jobs/e2e-testing-mbp-tmp.yml
@@ -1,8 +1,8 @@
 ---
 - job:
-    name: e2e-tests/e2e-testing-mbp
-    display-name: End-2-End Tests Pipeline
-    description: Jenkins pipeline for the e2e-testing project
+    name: e2e-tests/e2e-testing-mbp-tmp
+    display-name: Temporary End-2-End Tests Pipeline
+    description: Temporary Jenkins pipeline for the e2e-testing project
     view: E2E
     project-type: multibranch
     logrotate:
@@ -10,11 +10,11 @@
       numToKeep: 100
     number-to-keep: 100
     days-to-keep: 30
-    script-path: .ci/Jenkinsfile
+    script-path: .ci/Jenkinsfile-tmp
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|PR-.*|8\.\d+|7\.17|feature-.*)'
+          head-filter-regex: '(PR-3169)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -47,3 +47,4 @@
           timeout: '15'
           use-author: true
           wipe-workspace: 'True'
+          

--- a/.ci/jobs/e2e-testing-mbp.yml
+++ b/.ci/jobs/e2e-testing-mbp.yml
@@ -47,4 +47,3 @@
           timeout: '15'
           use-author: true
           wipe-workspace: 'True'
-          

--- a/.ci/jobs/e2e-testing-pr-mbp.yml
+++ b/.ci/jobs/e2e-testing-pr-mbp.yml
@@ -14,7 +14,8 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(PR-.*)'
+          # head-filter-regex: '(PR-.*)'
+          head-filter-regex: '(PR-3169)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-pr-mbp.yml
+++ b/.ci/jobs/e2e-testing-pr-mbp.yml
@@ -13,7 +13,7 @@
     script-path: .ci/pull-request.groovy
     scm:
       - github:
-          branch-discovery: no-pr
+          branch-discovery: only-pr
           # head-filter-regex: '(PR-.*)'
           head-filter-regex: '(PR-3169)'
           discover-pr-forks-strategy: merge-current

--- a/.ci/jobs/e2e-testing-pr-mbp.yml
+++ b/.ci/jobs/e2e-testing-pr-mbp.yml
@@ -1,8 +1,8 @@
 ---
 - job:
-    name: e2e-tests/e2e-testing-mbp
-    display-name: End-2-End Tests Pipeline for external calls
-    description: This pipeline can be only called from other repositories
+    name: e2e-tests/e2e-testing-pr-mbp
+    display-name: End-2-End Tests Pull Request
+    description: Jenkins pipeline for the e2e-testing project pull requests
     view: E2E
     project-type: multibranch
     logrotate:
@@ -10,29 +10,22 @@
       numToKeep: 100
     number-to-keep: 100
     days-to-keep: 30
-    script-path: .ci/Jenkinsfile
+    script-path: .ci/pull-request.groovy
     scm:
       - github:
-          property-strategies:
-            all-branches:
-              - suppress-scm-triggering: true
           branch-discovery: no-pr
-          head-filter-regex: '(main|8\.\d+|7\.17|feature-.*)'
+          head-filter-regex: '(PR-.*)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
-          notification-context: 'beats-ci/e2e-testing'
+          notification-context: 'beats-ci/e2e-testing-pr'
           repo: e2e-testing
           repo-owner: elastic
           credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:
-            - tags:
-                ignore-tags-older-than: -1
-                ignore-tags-newer-than: -1
-            - regular-branches: true
             - change-request:
                 ignore-target-only-changes: true
           clean:

--- a/.ci/jobs/e2e-testing-pr-mbp.yml
+++ b/.ci/jobs/e2e-testing-pr-mbp.yml
@@ -2,7 +2,7 @@
 - job:
     name: e2e-tests/e2e-testing-pr-mbp
     display-name: End-2-End Tests Pull Request
-    description: Jenkins pipeline for the e2e-testing project pull requests
+    description: e2e-testing pull requests builds
     view: E2E
     project-type: multibranch
     logrotate:

--- a/.ci/jobs/e2e-testing-pr-mbp.yml
+++ b/.ci/jobs/e2e-testing-pr-mbp.yml
@@ -18,7 +18,7 @@
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
-          discover-tags: true
+          discover-tags: false
           notification-context: 'beats-ci/e2e-testing-pr'
           repo: e2e-testing
           repo-owner: elastic

--- a/.ci/jobs/e2e-testing-pr-merge-mbp.yml
+++ b/.ci/jobs/e2e-testing-pr-merge-mbp.yml
@@ -19,7 +19,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
-          notification-context: 'beats-ci/e2e-testing-pr'
+          notification-context: 'beats-ci/e2e-testing-pr-merge'
           repo: e2e-testing
           repo-owner: elastic
           credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken

--- a/.ci/jobs/e2e-testing-pr-merge-mbp.yml
+++ b/.ci/jobs/e2e-testing-pr-merge-mbp.yml
@@ -14,7 +14,8 @@
     scm:
       - github:
           branch-discovery: no-pr
-          head-filter-regex: '(main|8\.\d+|7\.17)'
+          # head-filter-regex: '(main|8\.\d+|7\.17)'
+          head-filter-regex: '(PR-3169)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current

--- a/.ci/jobs/e2e-testing-pr-merge-mbp.yml
+++ b/.ci/jobs/e2e-testing-pr-merge-mbp.yml
@@ -1,8 +1,8 @@
 ---
 - job:
     name: e2e-tests/e2e-testing-pr-mbp
-    display-name: End-2-End Tests Pull Request
-    description: Jenkins pipeline for the e2e-testing project pull requests
+    display-name: End-2-End Tests Pull Request Merge
+    description: Triggered when we merge a PR to main branches 
     view: E2E
     project-type: multibranch
     logrotate:

--- a/.ci/jobs/e2e-testing-pr-merge-mbp.yml
+++ b/.ci/jobs/e2e-testing-pr-merge-mbp.yml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: e2e-tests/e2e-testing-pr-mbp
+    name: e2e-tests/e2e-testing-pr-merge-mbp
     display-name: End-2-End Tests Pull Request Merge
     description: Triggered when we merge a PR to main branches 
     view: E2E

--- a/.ci/jobs/e2e-testing-pr-merge-mbp.yml
+++ b/.ci/jobs/e2e-testing-pr-merge-mbp.yml
@@ -10,7 +10,7 @@
       numToKeep: 100
     number-to-keep: 100
     days-to-keep: 30
-    script-path: .ci/pull-request.groovy
+    script-path: .ci/pr-merge.groovy
     scm:
       - github:
           branch-discovery: no-pr

--- a/.ci/jobs/e2e-testing-pr-merge-mbp.yml
+++ b/.ci/jobs/e2e-testing-pr-merge-mbp.yml
@@ -1,8 +1,8 @@
 ---
 - job:
-    name: e2e-tests/e2e-testing-mbp
-    display-name: End-2-End Tests Pipeline for external calls
-    description: This pipeline can be only called from other repositories
+    name: e2e-tests/e2e-testing-pr-mbp
+    display-name: End-2-End Tests Pull Request
+    description: Jenkins pipeline for the e2e-testing project pull requests
     view: E2E
     project-type: multibranch
     logrotate:
@@ -10,29 +10,22 @@
       numToKeep: 100
     number-to-keep: 100
     days-to-keep: 30
-    script-path: .ci/Jenkinsfile
+    script-path: .ci/pull-request.groovy
     scm:
       - github:
-          property-strategies:
-            all-branches:
-              - suppress-scm-triggering: true
           branch-discovery: no-pr
-          head-filter-regex: '(main|8\.\d+|7\.17|feature-.*)'
+          head-filter-regex: '(main|8\.\d+|7\.17)'
           discover-pr-forks-strategy: merge-current
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
-          notification-context: 'beats-ci/e2e-testing'
+          notification-context: 'beats-ci/e2e-testing-pr'
           repo: e2e-testing
           repo-owner: elastic
           credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
           ssh-checkout:
             credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
           build-strategies:
-            - tags:
-                ignore-tags-older-than: -1
-                ignore-tags-newer-than: -1
-            - regular-branches: true
             - change-request:
                 ignore-target-only-changes: true
           clean:


### PR DESCRIPTION
## What does this PR do?

Creates 3 separate JJBB workflows:
1. `e2e-testing-mbp.yml` - For external e2e tests executions ONLY. When another pipeline triggers the tests
2. `e2e-testing-pr-mbp.yml` - For pull requests to this repo ONLY
3. `e2e-testing-pr-merge-mbp.yml` - For PR merges to `main` ,`8.x` or `7.17`

## Why is it important?
Single Jenkinsfile for all operations is overcomplicated

## Related issues

- Relates https://github.com/elastic/e2e-testing/pull/3169
