### PR TITLE
Fix: PR 3256 Set up nodes error is encountered while provisioning aws VMs using CI jobs.

### DIFF
--- a/e2e/TROUBLESHOOTING.md
+++ b/e2e/TROUBLESHOOTING.md
@@ -117,3 +117,15 @@ To change it, please use Docker UI, go to `Preferences > Resources > Advanced`, 
 It's important to configure `Docker for Mac` to allow it accessing the `/var/folders` directory, as this framework uses Mac's default temporary directory for storing temporary files.
 
 To change it, please use Docker UI, go to `Preferences > Resources > File Sharing`, and add there `/var/folders` to the list of paths that can be mounted into Docker containers. For more information, please read https://docs.docker.com/docker-for-mac/#file-sharing.
+
+### Unable to create AWS VMS
+- Ensure you have exported the `AWS_SECRET_ACCESS_KEY`and `AWS_ACCESS_KEY_ID` values.
+- Check permissions on id_rsa key files.
+- In case, you get errors like `couldn't resolve module/action 'ec2'`, its may be due to ansible version that is no more compatible.
+   - Here, you need to degrade ansible version to support already defined profiles. Ansible version 6.6.0 can be used here to resolve above issue.
+
+   ##Steps to be followed:
+   - Go to '.venv/bin' folder and activate the python virtual environment.
+   - Specify the ansible version in requirement.txt file under `.ci/ansible` folder.
+   - Rerun requirements.txt file manually using `pip install -r requirements.txt' command.
+


### PR DESCRIPTION
Fixes https://github.com/elastic/e2e-testing/issues/3256

## What does this PR do?
Shares some troubleshooting guide to resolve the errors encountered while provisioning aws VMs using CI jobs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [ ] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)
