### PR TITLE
fix: increase upgrades timeout

### DIFF
--- a/e2e/_suites/fleet/features/upgrade_agent.feature
+++ b/e2e/_suites/fleet/features/upgrade_agent.feature
@@ -12,7 +12,6 @@ Scenario Outline: Upgrading an installed agent from <stale-version>
 Examples: Stale versions
 | stale-version |
 | latest |
-| 8.6.0 |
 | 8.5.3 |
 | 8.4.3 |
 | 8.3.3 |

--- a/e2e/_suites/fleet/features/upgrade_agent.feature
+++ b/e2e/_suites/fleet/features/upgrade_agent.feature
@@ -12,6 +12,7 @@ Scenario Outline: Upgrading an installed agent from <stale-version>
 Examples: Stale versions
 | stale-version |
 | latest |
+| 8.6.0 |
 | 8.5.3 |
 | 8.4.3 |
 | 8.3.3 |

--- a/e2e/_suites/fleet/upgrades.go
+++ b/e2e/_suites/fleet/upgrades.go
@@ -17,6 +17,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	UPGRADE_MAX_TIMEOUT = 10 * time.Minute
+)
+
 func (fts *FleetTestSuite) agentInVersion(version string) error {
 	switch version {
 	case "latest":
@@ -25,7 +29,7 @@ func (fts *FleetTestSuite) agentInVersion(version string) error {
 	log.Tracef("Checking if agent is in version %s. Current version: %s", version, fts.Version)
 
 	retryCount := 0
-	maxTimeout := time.Duration(utils.TimeoutFactor) * time.Minute
+	maxTimeout := UPGRADE_MAX_TIMEOUT
 	exp := utils.GetExponentialBackOff(maxTimeout)
 
 	agentService := deploy.NewServiceRequest(common.ElasticAgentServiceName)

--- a/e2e/_suites/fleet/upgrades.go
+++ b/e2e/_suites/fleet/upgrades.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	UPGRADE_MAX_TIMEOUT = 10 * time.Minute
+	upgradeMaxTimeout = 10 * time.Minute
 )
 
 func (fts *FleetTestSuite) agentInVersion(version string) error {
@@ -29,7 +29,7 @@ func (fts *FleetTestSuite) agentInVersion(version string) error {
 	log.Tracef("Checking if agent is in version %s. Current version: %s", version, fts.Version)
 
 	retryCount := 0
-	maxTimeout := UPGRADE_MAX_TIMEOUT
+	maxTimeout := upgradeMaxTimeout
 	exp := utils.GetExponentialBackOff(maxTimeout)
 
 	agentService := deploy.NewServiceRequest(common.ElasticAgentServiceName)


### PR DESCRIPTION
The timeout for the upgrades is too tight. Increasing the global TimeoutFactor does not seem appropriate, so I have added a new constant in the upgrades.go file to manage the updates timeout. 