### PR TITLE
fix: typo in the ansible playbook

### DIFF
--- a/.ci/ansible/tasks/setup_test_script_windows.yml
+++ b/.ci/ansible/tasks/setup_test_script_windows.yml
@@ -47,7 +47,7 @@
 
 - name: Extend environment for Remote provider (Windows)
   no_log: true
-  community.windows.win_lineinfile::
+  community.windows.win_lineinfile:
     state: present
     line: "{{ item }}"
     insertafter: EOF


### PR DESCRIPTION
there is an extra `:`