### PR TITLE
updatecli: ensure one branch per release branch

### DIFF
--- a/.ci/bump-elastic-stack-snapshot.yml
+++ b/.ci/bump-elastic-stack-snapshot.yml
@@ -1,5 +1,6 @@
 ---
 name: Bump elastic-stack to latest snapshot version
+pipelineid: 'bump-elastic-stack-snapshot-{{ requiredEnv "BRANCH" }}'
 
 actions:
   default:


### PR DESCRIPTION
## What does this PR do?

Use one unique branch per PR targeting the release branches

## Why is it important?

Otherwise, it reused the same branch for different target releases and the automation will produce PRs with reused commits, such as https://github.com/elastic/beats/pull/34570

https://github.com/updatecli/updatecli/issues/1159 contains a bit more of context and the solution to solve this particular corner case, thanks @olblak 🙇 