### PR TITLE
updatecli: fix pattern for updating the defaults.go

### DIFF
--- a/.ci/bump-elastic-stack-snapshot.yml
+++ b/.ci/bump-elastic-stack-snapshot.yml
@@ -54,7 +54,7 @@ targets:
     spec:
       file: ./internal/common/defaults.go
       matchpattern: '(BeatVersionBase =) "\d+.\d+.\d+-.*-SNAPSHOT"'
-      replacepattern: '$1 = "{{ source "latestVersion" }}-SNAPSHOT"'
+      replacepattern: '$1 "{{ source "latestVersion" }}-SNAPSHOT"'
 
   update-stack-version:
     name: "Update .stack-version"


### PR DESCRIPTION
## What does this PR do?
Fix wrong replacement in the updatecli

## Why is it important?


Otherwise it adds ` = = value`

<img width="868" alt="image" src="https://user-images.githubusercontent.com/2871786/224073045-641ee97e-a5f7-4fe9-b964-97e399fb320e.png">

