### PR TITLE
mergify: support for updatecli automation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,43 +18,6 @@ pull_request_rules:
             git merge upstream/{{base}}
             git push upstream {{head}}
             ```
-  - name: backport patches to 8.4 branch
-    conditions:
-      - merged
-      - label=backport-v8.4.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.4"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 8.3 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-v8.3.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.3"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 7.17 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-v7.17.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "7.17"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: delete head branch after merge
     conditions:
       - merged
@@ -64,10 +27,9 @@ pull_request_rules:
     conditions:
       - -merged
       - -closed
-      - check-success=beats-ci/e2e-testing/pr-merge
       - label=automation
       - author=apmmachine
-      - head~=^update-.*-version.*
+      - head~=^updatecli.*
     actions:
       queue:
         method: squash
@@ -79,7 +41,7 @@ pull_request_rules:
         - closed
       - and:
         - label=automation
-        - head~=^update-.*-version.*
+        - head~=^updatecli.*
     actions:
       delete_head_branch:
   - name: remove-backport label
@@ -123,12 +85,49 @@ pull_request_rules:
       - author=apmmachine
       - schedule=Mon-Fri 06:00-10:00[Europe/Paris]
       - created-at<3 days ago
-      - head~=^update-.*-version.*
+      - head~=^updatecli.*
     actions:
       close:
         message: |
           This pull request has been automatically closed by Mergify.
           There are likely new up-to-date and open pull requests.
+  - name: backport patches to 7.17 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-v7.17.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.17"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.3 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-v8.3.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.3"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.4 branch
+    conditions:
+      - merged
+      - label=backport-v8.4.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.4"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.5 branch
     conditions:
       - merged


### PR DESCRIPTION
## What does this PR do?

auto-merge bump automations using updatecli

## Why

Branch changed when enabled `updatecli`.
