### PR TITLE
Updating beats Clusteroles to allow job,daemonset discovery

### DIFF
--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/elastic-agent.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/elastic-agent.yml.tmpl
@@ -286,10 +286,12 @@ rules:
       - statefulsets
       - deployments
       - replicasets
+      - daemonsets
     verbs: ["get", "list", "watch"]
   - apiGroups: ["batch"]
     resources:
       - jobs
+      - cronjobs
     verbs: ["get", "list", "watch"]
   - apiGroups:
       - ""

--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/filebeat.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/filebeat.yml.tmpl
@@ -158,6 +158,10 @@ rules:
   resources:
     - replicasets
   verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+    - jobs
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/heartbeat.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/heartbeat.yml.tmpl
@@ -140,6 +140,10 @@ rules:
   resources:
     - replicasets
   verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+    - jobs
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/metricbeat.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/metricbeat.yml.tmpl
@@ -139,6 +139,8 @@ rules:
   - events
   - pods
   - services
+  - persistentvolumes
+  - persistentvolumeclaims
   verbs: ["get", "list", "watch"]
 # Enable this rule only if planing to use Kubernetes keystore
 #- apiGroups: [""]
@@ -154,6 +156,16 @@ rules:
   - statefulsets
   - deployments
   - replicasets
+  - daemonsets
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  - cronjobs
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - ""


### PR DESCRIPTION
Bug fix for the failing E2E tests that was found here: https://beats-ci.elastic.co/blue/organizations/jenkins/e2e-tests%2Fe2e-testing-mbp/detail/main/3080/pipeline

## What does this PR do?

This PR updates the beats (filebeat, metricbeat, hearbeat) templates and agent templates of e2e test framework used in Autodiscovery scenarios. 

The mentioned templates did not have all the needed Clusteroles in order to allow monitoring of resources

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

It affects all the CI pipelines where we trigger the E2E tests with autodiscovery


## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)

## How to test this PR locally

1.Download the e2e framework
1.Navigate to `e2e/_suites/kubernetes-autodiscover`

Run the following
```bash
export BEAT_VERSION=8.9.0-SNAPSHOT                                                  
export GITHUB_CHECK_SHA1="22382ca036edce9827672013a0870df6f8583724"
export KIND_VERSION=“0.17.0”
export GITHUB_CHECK_REPO=beats
export KUBERNETES_VERSION="1.26.3"

OP_LOG_LEVEL=DEBUG go test -timeout 90m -v --godog.tags='@filebeat'
OP_LOG_LEVEL=DEBUG go test -timeout 90m -v --godog.tags='@metricbeat'
```


## Logs

```bash
DEBU[0168] Not processing custom binaries for pod: a failing pod. Only [elasticsearch, filebeat, heartbeat, metricbeat, elastic-agent] will be processed
..DEBU[0197] Running scenario Logs collection from short-living cronjobs in namespace: test-151d8b4a-15d6-49ac-9d1b-d5951f10583a
.DEBU[0207] Not processing custom binaries for pod: a short-living cronjob. Only [elasticsearch, filebeat, heartbeat, metricbeat, elastic-agent] will be processed
...DEBU[0304] Running scenario Logs collection from a pod with an init container in namespace: test-418c8e2c-db9a-4631-9920-2826458bf51b
.DEBU[0314] Not processing custom binaries for pod: a pod. Only [elasticsearch, filebeat, heartbeat, metricbeat, elastic-agent] will be processed
...DEBU[0375] Running scenario Logs collection from a pod with an ephemeral container in namespace: test-d466f5b7-6a3d-42fb-b58a-61b9822078fa
.DEBU[0385] Not processing custom binaries for pod: a pod. Only [elasticsearch, filebeat, heartbeat, metricbeat, elastic-agent] will be processed
....DEBU[0452] Running scenario Logs collection from running pod and metadata enrichment using add_kubernetes_metadata in namespace: test-584153c8-f249-44f0-84bf-11ec832a5abe
.DEBU[0462] Not processing custom binaries for pod: a pod. Only [elasticsearch, filebeat, heartbeat, metricbeat, elastic-agent] will be processed
..DEBU[0526] Running scenario Enrichment of normal input using add_kubernetes_metadata in namespace: test-19bba0f2-faf1-49e0-a444-258823556e42
.DEBU[0537] Not processing custom binaries for pod: a pod. Only [elasticsearch, filebeat, heartbeat, metricbeat, elastic-agent] will be processed
..INFO[0602] Kind cluster logs exported                    cluster=kind-36cfac49-3d88-4c39-8364-612b94678e64 path=/Users/andreasgkizas/elastic/e2e-testing/outputs/kubernetes-autodiscover/kind-36cfac49-3d88-4c39-8364-612b94678e64
INFO[0603] kind cluster  was deleted
 25


7 scenarios (7 passed)
25 steps (25 passed)
11m11.929302625s
testing: warning: no tests to run
PASS
ok  	github.com/elastic/e2e-testing/e2e/_suites/kubernetes-autodiscover	673.009s
```