### PR TITLE
Set fail-fast to false for k8s-autodiscovery-test

### DIFF
--- a/.github/workflows/k8s-autodiscovery-test.yml
+++ b/.github/workflows/k8s-autodiscovery-test.yml
@@ -22,6 +22,7 @@ jobs:
     needs: elastic-stack-snapshot-branches
     strategy:
       matrix: ${{ fromJson(needs.elastic-stack-snapshot-branches.outputs.matrix) }}
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Sets the matrix strategy `fail-fast` to `false`, so that the workflow still continues in case of an error.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
