### PR TITLE
Allow downloading artifacts from project specific locations

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -5,6 +5,7 @@
 package utils
 
 import (
+	"fmt"
 	"io"
 	"math/rand"
 	"net/http"
@@ -92,12 +93,6 @@ func DownloadFile(downloadRequest *DownloadRequest) error {
 			}).Warn("Could not download the file")
 
 			retryCount++
-
-			// Not found errors are not retryable.
-			if resp != nil && resp.StatusCode == http.StatusNotFound {
-				return backoff.Permanent(err)
-			}
-
 			return err
 		}
 
@@ -107,6 +102,10 @@ func DownloadFile(downloadRequest *DownloadRequest) error {
 			"path":        downloadRequest.UnsanitizedFilePath,
 			"url":         downloadRequest.URL,
 		}).Trace("File downloaded")
+
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return backoff.Permanent(fmt.Errorf("not found for %s", url))
+		}
 
 		fileReader = resp.Body
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -93,6 +93,11 @@ func DownloadFile(downloadRequest *DownloadRequest) error {
 
 			retryCount++
 
+			// Not found errors are not retryable.
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
+				return backoff.Permanent(err)
+			}
+
 			return err
 		}
 

--- a/pkg/downloads/releases.go
+++ b/pkg/downloads/releases.go
@@ -35,6 +35,10 @@ func NewArtifactURLResolver(fullName string, name string, version string) Downlo
 	// resolve version alias
 	resolvedVersion, err := GetElasticArtifactVersion(version)
 	if err != nil {
+		log.WithFields(log.Fields{
+			"error":   err,
+			"version": version,
+		}).Error("Failed to get version")
 		return nil
 	}
 

--- a/pkg/downloads/releases.go
+++ b/pkg/downloads/releases.go
@@ -71,7 +71,6 @@ func (r *ArtifactURLResolver) Resolve() (string, string, error) {
 		tmpVersion = GetCommitVersion(version)
 	}
 
-	// client := http.Client{Timeout: }
 	apiStatus := func() error {
 		url := fmt.Sprintf("https://artifacts-api.elastic.co/v1/search/%s/%s?x-elastic-no-kpi=true", tmpVersion, artifact)
 		resp, err := http.Get(url)
@@ -97,7 +96,7 @@ func (r *ArtifactURLResolver) Resolve() (string, string, error) {
 		}
 
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return backoff.Permanent(err)
+			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 
 		log.WithFields(log.Fields{
@@ -229,7 +228,7 @@ func (as *ArtifactsSnapshotVersion) GetSnapshotArtifactVersion(project string, v
 		}
 
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return backoff.Permanent(err)
+			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 
 		log.WithFields(log.Fields{
@@ -365,7 +364,7 @@ func (asur *ArtifactsSnapshotURLResolver) Resolve() (string, string, error) {
 		}
 
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return backoff.Permanent(err)
+			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 
 		log.WithFields(log.Fields{
@@ -489,7 +488,7 @@ func (r *ReleaseURLResolver) Resolve() (string, string, error) {
 				"statusEndpoint": url,
 				"elapsedTime":    exp.GetElapsedTime(),
 			}).Info("Download could not be found at the Elastic downloads API")
-			return backoff.Permanent(err)
+			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 
 		found = true

--- a/pkg/downloads/releases.go
+++ b/pkg/downloads/releases.go
@@ -103,7 +103,7 @@ func (r *ArtifactURLResolver) Resolve() (string, string, error) {
 			return backoff.Permanent(err)
 		}
 
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
+		if resp.StatusCode == http.StatusNotFound {
 			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 
@@ -242,7 +242,7 @@ func (as *ArtifactsSnapshotVersion) GetSnapshotArtifactVersion(project string, v
 			return backoff.Permanent(err)
 		}
 
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
+		if resp.StatusCode == http.StatusNotFound {
 			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 
@@ -380,7 +380,7 @@ func (asur *ArtifactsSnapshotURLResolver) Resolve() (string, string, error) {
 			return backoff.Permanent(err)
 		}
 
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
+		if resp.StatusCode == http.StatusNotFound {
 			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 
@@ -495,9 +495,9 @@ func (r *ReleaseURLResolver) Resolve() (string, string, error) {
 		}
 
 		defer resp.Body.Close()
-		io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
+		if resp.StatusCode == http.StatusNotFound {
 			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 

--- a/pkg/downloads/releases_test.go
+++ b/pkg/downloads/releases_test.go
@@ -33,7 +33,7 @@ func TestGetSnapshotArtifactVersion(t *testing.T) {
 
 		mockURL := mockServer.URL + "/beats/latest/8.8.3-SNAPSHOT.json"
 		artifactsSnapshot := newArtifactsSnapshotCustom(mockURL)
-		version, err := artifactsSnapshot.GetSnapshotArtifactVersion("8.8.3-SNAPSHOT")
+		version, err := artifactsSnapshot.GetSnapshotArtifactVersion("beats", "8.8.3-SNAPSHOT")
 		assert.NoError(t, err, "Expected no error")
 		assert.Equal(t, "8.8.3-b1d8691a-SNAPSHOT", version, "Expected version to match")
 	})
@@ -54,7 +54,7 @@ func TestGetSnapshotArtifactVersion(t *testing.T) {
 
 		mockURL := mockServer.URL + "/beats/latest/8.8.3-SNAPSHOT.json"
 		artifactsSnapshot := newArtifactsSnapshotCustom(mockURL)
-		version, err := artifactsSnapshot.GetSnapshotArtifactVersion("8.8.3-SNAPSHOT")
+		version, err := artifactsSnapshot.GetSnapshotArtifactVersion("beats", "8.8.3-SNAPSHOT")
 		assert.ErrorContains(t, err, "could not parse the response body")
 		assert.Empty(t, version)
 	})
@@ -75,7 +75,7 @@ func TestGetSnapshotArtifactVersion(t *testing.T) {
 
 		mockURL := mockServer.URL + "/beats/latest/8.8.3-SNAPSHOT.json"
 		artifactsSnapshot := newArtifactsSnapshotCustom(mockURL)
-		version, err := artifactsSnapshot.GetSnapshotArtifactVersion("8.8.3-SNAPSHOT")
+		version, err := artifactsSnapshot.GetSnapshotArtifactVersion("beats", "8.8.3-SNAPSHOT")
 		assert.ErrorContains(t, err, "could not parse the build_id")
 		assert.ErrorContains(t, err, "bd8691a")
 		assert.Empty(t, version)
@@ -121,7 +121,7 @@ func TestArtifactsSnapshotResolver(t *testing.T) {
 		server := httptest.NewServer(mockHandler)
 		defer server.Close()
 
-		urlResolver := newCustomSnapshotURLResolver("auditbeat-8.9.0-SNAPSHOT-amd64.deb", "auditbeat", "8.9.0-SNAPSHOT", server.URL)
+		urlResolver := newCustomSnapshotURLResolver("auditbeat-8.9.0-SNAPSHOT-amd64.deb", "auditbeat", "beats", "8.9.0-SNAPSHOT", server.URL)
 		url, shaUrl, err := urlResolver.Resolve()
 		assert.Equal(t, "https://artifacts-snapshot.elastic.co/auditbeat-8.9.0-SNAPSHOT-amd64.deb", url)
 		assert.Equal(t, "https://artifacts-snapshot.elastic.co/auditbeat-8.9.0-SNAPSHOT-amd64.deb.sha512", shaUrl)

--- a/pkg/downloads/versions.go
+++ b/pkg/downloads/versions.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Jeffail/gabs/v2"
@@ -36,11 +37,13 @@ var BeatsLocalPath = ""
 // the URL of the artifact. If another installer is trying to download the same URL, it will return the location of the
 // already downloaded artifact.
 var binariesCache = map[string]string{}
+var binariesMutex sync.RWMutex
 
 // to avoid fetching the same Elastic artifacts version, we are adding this map to cache the version of the Elastic artifacts,
 // using as key the URL of the version. If another request is trying to fetch the same URL, it will return the string version
 // of the already requested one.
 var elasticVersionsCache = map[string]string{}
+var elasticVersionsMutex sync.RWMutex
 
 // GithubCommitSha1 represents the value of the "GITHUB_CHECK_SHA1" environment variable
 var GithubCommitSha1 string
@@ -161,7 +164,10 @@ func GetElasticArtifactURL(artifactName string, artifact string, version string)
 func GetElasticArtifactVersion(version string) (string, error) {
 	cacheKey := fmt.Sprintf("https://artifacts-api.elastic.co/v1/versions/%s/?x-elastic-no-kpi=true", version)
 
-	if val, ok := elasticVersionsCache[cacheKey]; ok {
+	elasticVersionsMutex.RLock()
+	val, ok := elasticVersionsCache[cacheKey]
+	elasticVersionsMutex.RUnlock()
+	if ok {
 		log.WithFields(log.Fields{
 			"URL":     cacheKey,
 			"version": val,
@@ -170,13 +176,13 @@ func GetElasticArtifactVersion(version string) (string, error) {
 	}
 
 	if SnapshotHasCommit(version) {
+		elasticVersionsMutex.Lock()
 		elasticVersionsCache[cacheKey] = version
+		elasticVersionsMutex.Unlock()
 		return version, nil
 	}
 
 	exp := utils.GetExponentialBackOff(time.Minute)
-
-	retryCount := 1
 
 	body := []byte{}
 
@@ -184,21 +190,11 @@ func GetElasticArtifactVersion(version string) (string, error) {
 		url := cacheKey
 		resp, err := http.Get(url)
 		if err != nil {
-			log.WithFields(log.Fields{
-				"version":        version,
-				"error":          err,
-				"retry":          retryCount,
-				"resp":           resp,
-				"statusEndpoint": url,
-				"elapsedTime":    exp.GetElapsedTime(),
-			}).Warn("The Elastic artifacts API is not available yet")
-			retryCount++
-
-			return err
+			return fmt.Errorf("Error getting %s: %w", err)
 		}
 
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return backoff.Permanent(fmt.Errorf("not found for version %s", version))
+			return backoff.Permanent(fmt.Errorf("version %s not found at %s", version, url))
 		}
 
 		defer resp.Body.Close()
@@ -206,14 +202,6 @@ func GetElasticArtifactVersion(version string) (string, error) {
 		if err != nil {
 			return backoff.Permanent(err)
 		}
-
-		log.WithFields(log.Fields{
-			"retries":        retryCount,
-			"statusEndpoint": url,
-			"elapsedTime":    exp.GetElapsedTime(),
-			"resp":           resp,
-		}).Debug("The Elastic artifacts API is available for version")
-
 		return nil
 	}
 
@@ -224,11 +212,7 @@ func GetElasticArtifactVersion(version string) (string, error) {
 
 	jsonParsed, err := gabs.ParseJSON(body)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"error":   err,
-			"version": version,
-		}).Error("Could not parse the response body to retrieve the version")
-		return "", err
+		return "", fmt.Errorf("parsing JSON body %s: %w", body, err)
 	}
 
 	builds := jsonParsed.Path("version.builds")
@@ -241,7 +225,9 @@ func GetElasticArtifactVersion(version string) (string, error) {
 		"version": latestVersion,
 	}).Debug("Latest version for current version obtained")
 
+	elasticVersionsMutex.Lock()
 	elasticVersionsCache[cacheKey] = latestVersion
+	elasticVersionsMutex.Unlock()
 
 	return latestVersion, nil
 }
@@ -392,7 +378,10 @@ func FetchProjectBinaryForSnapshots(ctx context.Context, useCISnapshots bool, pr
 		span.Context.SetLabel("project", project)
 		defer span.End()
 
-		if val, ok := binariesCache[URL]; ok {
+		binariesMutex.RLock()
+		val, ok := binariesCache[URL]
+		binariesMutex.RUnlock()
+		if ok {
 			log.WithFields(log.Fields{
 				"URL":  URL,
 				"path": val,
@@ -419,7 +408,9 @@ func FetchProjectBinaryForSnapshots(ctx context.Context, useCISnapshots bool, pr
 			sanitizedFilePath = downloadRequest.UnsanitizedFilePath
 		}
 
+		binariesMutex.Lock()
 		binariesCache[URL] = sanitizedFilePath
+		binariesMutex.Unlock()
 
 		return sanitizedFilePath, nil
 	}

--- a/pkg/downloads/versions.go
+++ b/pkg/downloads/versions.go
@@ -190,7 +190,7 @@ func GetElasticArtifactVersion(version string) (string, error) {
 		url := cacheKey
 		resp, err := http.Get(url)
 		if err != nil {
-			return fmt.Errorf("Error getting %s: %w", err)
+			return fmt.Errorf("Error getting %s: %w", url, err)
 		}
 
 		if resp != nil && resp.StatusCode == http.StatusNotFound {

--- a/pkg/downloads/versions.go
+++ b/pkg/downloads/versions.go
@@ -198,7 +198,7 @@ func GetElasticArtifactVersion(version string) (string, error) {
 		}
 
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return backoff.Permanent(err)
+			return backoff.Permanent(fmt.Errorf("not found for version %s", version))
 		}
 
 		defer resp.Body.Close()
@@ -212,7 +212,7 @@ func GetElasticArtifactVersion(version string) (string, error) {
 			"statusEndpoint": url,
 			"elapsedTime":    exp.GetElapsedTime(),
 			"resp":           resp,
-		}).Debug("The Elastic artifacts API is available")
+		}).Debug("The Elastic artifacts API is available for version")
 
 		return nil
 	}

--- a/pkg/downloads/versions.go
+++ b/pkg/downloads/versions.go
@@ -190,10 +190,10 @@ func GetElasticArtifactVersion(version string) (string, error) {
 		url := cacheKey
 		resp, err := http.Get(url)
 		if err != nil {
-			return fmt.Errorf("Error getting %s: %w", url, err)
+			return fmt.Errorf("error getting %s: %w", url, err)
 		}
 
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
+		if resp.StatusCode == http.StatusNotFound {
 			return backoff.Permanent(fmt.Errorf("version %s not found at %s", version, url))
 		}
 

--- a/pkg/downloads/versions.go
+++ b/pkg/downloads/versions.go
@@ -514,15 +514,14 @@ func getDownloadURLFromResolvers(resolvers []DownloadURLResolver) (string, strin
 			continue
 		}
 
+		log.WithFields(log.Fields{"kind": resolver.Kind()}).Info("Trying resolver.")
 		url, shaURL, err := resolver.Resolve()
 		if err != nil {
 			if i < len(resolvers)-1 {
-				log.WithFields(log.Fields{
-					"resolver": resolver,
-				}).Warn("Object not found. Trying with another download resolver")
+				log.WithFields(log.Fields{"kind": resolver.Kind()}).Warn("Object not found.")
 				continue
 			} else {
-				log.Error("Object not found. There is no other download resolver")
+				log.WithFields(log.Fields{"kind": resolver.Kind()}).Error("Object not found. All resolvers failed")
 				return "", "", err
 			}
 		}


### PR DESCRIPTION
This PR fixes several bugs and makes it possible to download artifacts from the project specific staging areas that feed into the unified release process. This is necessary in the time between a feature freeze and the first snapshot being produced, which historically has been several days.

Examples of project specific URLs are:
* https://artifacts-snapshot.elastic.co/beats/latest/8.11.0-SNAPSHOT.json
* https://artifacts-snapshot.elastic.co/endpoint-dev/latest/8.11.0-SNAPSHOT.json
* https://artifacts-snapshot.elastic.co/fleet-server/latest/8.11.0-SNAPSHOT.json
* https://artifacts-snapshot.elastic.co/prodfiler/latest/8.11.0-SNAPSHOT.json
  
This also makes the following changes:
* Adds mutexes to shared caches to allow downloads to happen in parallel safely.
* Remove use of the curl package in favor of the stdlib
* Improve logging, both by using less of it and including the name of the resolver that generated the log.

To test this PR, check out https://github.com/cmacknz/elastic-agent/tree/fix-artifacts-api-usage and replace the e2e-testing dependency with this version. The build will succeed, where as it fails on main. The draft PR for this change without the dependency update is https://github.com/elastic/elastic-agent/pull/3273.

To see what the new logging looks like, change to `InfoLevel` logging instead of `FatalLevel` in https://github.com/cmacknz/elastic-agent/blob/5c28f4e975748c0f63af9c653124ca4bd4e2a74b/magefile.go#L953

- Relates https://github.com/elastic/elastic-agent/issues/1273