### PR TITLE
Updating cronjon template for Elastic agent v7.17

### DIFF
--- a/e2e/_suites/kubernetes-autodiscover/testdata/templates/a-short-living-cronjob.yml.tmpl
+++ b/e2e/_suites/kubernetes-autodiscover/testdata/templates/a-short-living-cronjob.yml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: a-short-living-cronjob


### PR DESCRIPTION
-- Bug

## What does this PR do?

This PR updates the Cronjob template used for k8s autodiscovery especially in version 7.17
From https://github.com/elastic/e2e-testing/actions/runs/6138671269/job/16655778644#step:6:175 we can see that

```yaml
Run actions/checkout@v3
  with:
    ref: 7.17
    repository: elastic/e[2](https://github.com/elastic/e2e-testing/actions/runs/6138671269/job/16655778644#step:2:2)e-testing
```
So github actions refers to 7.17 e2e testing framework. The kubernetes version is 1.26 and in this version the `batch/beatv1` api is no longer available (see more info [batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+](https://github.com/linkerd/linkerd2/issues/7852)) 

## Why is it important?

Fixes https://github.com/elastic/e2e-testing/issues/3642

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the Unit tests (`make unit-test`), and they are passing locally
- [x] I have run the End-2-End tests for the suite I'm working on, and they are passing locally
- [ ] I have noticed new Go dependencies (run `make notice` in the proper directory)



## Related issues

- Closes  https://github.com/elastic/e2e-testing/issues/3642

