### PR TITLE
k8s-autodiscovery: notify in slack

### DIFF
--- a/.github/workflows/k8s-autodiscovery-test.yml
+++ b/.github/workflows/k8s-autodiscovery-test.yml
@@ -58,4 +58,4 @@ jobs:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          slackChannel: "#observablt-bots"
+          slackChannel: "#obs-cloud-monitoring"


### PR DESCRIPTION
## What does this PR do?

Notify a different slack channel when the k8s-autodiscovery failed

## Why is it important?

Help with notifying the team who owns those tests.


Part of https://github.com/elastic/e2e-testing/issues/3642