### PR TITLE
github-actions: bump versions, remove obsoleted tools and remove support for Windows linting

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,16 +10,14 @@ jobs:
   golangci:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest ]
     name: lint
     runs-on: ${{  matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Fetch Go version from .go-version
-        run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.4.0
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,8 +17,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
       with:
         go-version-file: .go-version
     - uses: actions/setup-python@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,12 +18,10 @@ jobs:
     name: Run Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Fetch Go version from .go-version
-        run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: .go-version
           cache: true
           cache-dependency-path: go.sum
       - name: build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ repos:
     rev: v0.5.0
     hooks:
     -   id: go-fmt
-    -   id: go-lint
     -   id: no-go-testing
     -   id: golangci-lint
         args: ["--fix", "--fast", "--new"]


### PR DESCRIPTION

## What does this PR do?

Remove support for golint -> it's frozen since 2021
Bump github action dependencies
Use .go-version
Remove support for golanglint on Windows -> there are some failures

## Why is it important?

Fix the build system