### PR TITLE
Consider any HTTP response code > 399 as an error

### DIFF
--- a/pkg/downloads/releases.go
+++ b/pkg/downloads/releases.go
@@ -103,7 +103,7 @@ func (r *ArtifactURLResolver) Resolve() (string, string, error) {
 			return backoff.Permanent(err)
 		}
 
-		if resp.StatusCode == http.StatusNotFound {
+		if resp.StatusCode > 399 {
 			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 
@@ -242,7 +242,7 @@ func (as *ArtifactsSnapshotVersion) GetSnapshotArtifactVersion(project string, v
 			return backoff.Permanent(err)
 		}
 
-		if resp.StatusCode == http.StatusNotFound {
+		if resp.StatusCode > 399 {
 			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 
@@ -380,7 +380,7 @@ func (asur *ArtifactsSnapshotURLResolver) Resolve() (string, string, error) {
 			return backoff.Permanent(err)
 		}
 
-		if resp.StatusCode == http.StatusNotFound {
+		if resp.StatusCode > 399 {
 			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 
@@ -497,7 +497,7 @@ func (r *ReleaseURLResolver) Resolve() (string, string, error) {
 		defer resp.Body.Close()
 		_, _ = io.Copy(io.Discard, resp.Body)
 
-		if resp.StatusCode == http.StatusNotFound {
+		if resp.StatusCode > 399 {
 			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
 		}
 

--- a/pkg/downloads/versions.go
+++ b/pkg/downloads/versions.go
@@ -193,7 +193,7 @@ func GetElasticArtifactVersion(version string) (string, error) {
 			return fmt.Errorf("error getting %s: %w", url, err)
 		}
 
-		if resp.StatusCode == http.StatusNotFound {
+		if resp.StatusCode > 399 {
 			return backoff.Permanent(fmt.Errorf("version %s not found at %s", version, url))
 		}
 


### PR DESCRIPTION
## What does this PR do?

When downloading files, consider any HTTP response codes > 399, not just 404 response codes, as errors.

## Why is it important?

To be more resilient to HTTP failures.
