### PR TITLE
Report unexpected status codes as errors

### DIFF
--- a/pkg/downloads/releases.go
+++ b/pkg/downloads/releases.go
@@ -103,8 +103,8 @@ func (r *ArtifactURLResolver) Resolve() (string, string, error) {
 			return backoff.Permanent(err)
 		}
 
-		if resp.StatusCode > 399 {
-			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
+		if resp.StatusCode != http.StatusOK {
+			return backoff.Permanent(fmt.Errorf("unexpected status code %d from url %s", resp.StatusCode, url))
 		}
 
 		return nil
@@ -242,8 +242,8 @@ func (as *ArtifactsSnapshotVersion) GetSnapshotArtifactVersion(project string, v
 			return backoff.Permanent(err)
 		}
 
-		if resp.StatusCode > 399 {
-			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
+		if resp.StatusCode != http.StatusOK {
+			return backoff.Permanent(fmt.Errorf("unexpected status code %d from url %s", resp.StatusCode, url))
 		}
 
 		return nil
@@ -380,8 +380,8 @@ func (asur *ArtifactsSnapshotURLResolver) Resolve() (string, string, error) {
 			return backoff.Permanent(err)
 		}
 
-		if resp.StatusCode > 399 {
-			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
+		if resp.StatusCode != http.StatusOK {
+			return backoff.Permanent(fmt.Errorf("unexpected status code %d from url %s", resp.StatusCode, url))
 		}
 
 		return nil
@@ -497,8 +497,8 @@ func (r *ReleaseURLResolver) Resolve() (string, string, error) {
 		defer resp.Body.Close()
 		_, _ = io.Copy(io.Discard, resp.Body)
 
-		if resp.StatusCode > 399 {
-			return backoff.Permanent(fmt.Errorf("not found for url %s", url))
+		if resp.StatusCode != http.StatusOK {
+			return backoff.Permanent(fmt.Errorf("unexpected status code %d from url %s", resp.StatusCode, url))
 		}
 
 		found = true

--- a/pkg/downloads/versions.go
+++ b/pkg/downloads/versions.go
@@ -193,8 +193,8 @@ func GetElasticArtifactVersion(version string) (string, error) {
 			return fmt.Errorf("error getting %s: %w", url, err)
 		}
 
-		if resp.StatusCode > 399 {
-			return backoff.Permanent(fmt.Errorf("version %s not found at %s", version, url))
+		if resp.StatusCode != http.StatusOK {
+			return backoff.Permanent(fmt.Errorf("unexpected status code %d from url %s when fetching version %s", resp.StatusCode, url, version))
 		}
 
 		defer resp.Body.Close()


### PR DESCRIPTION
The only expected code is 200, the rest should fail and the error message should contain the status code itself.

This is a follow up to https://github.com/elastic/e2e-testing/pull/3834
